### PR TITLE
fix(input): TASK-WM-042 빌드 모드 토글 키 B→G + 입력 룰 위반 fix

### DIFF
--- a/Assets/_WitchMendokusai/Content/Building/Scripts/BuildManager.cs
+++ b/Assets/_WitchMendokusai/Content/Building/Scripts/BuildManager.cs
@@ -74,10 +74,6 @@ namespace WitchMendokusai
 
 		private void Update()
 		{
-			// TODO: 임시 Build 키
-			if (Keyboard.current != null && Keyboard.current.bKey.wasPressedThisFrame)
-				GameModeManager.Instance.ToggleBuildMode();
-
 			if (GameModeManager.Instance.IsBuildMode == false)
 				return;
 

--- a/Assets/_WitchMendokusai/Core/Scripts/Input/InputManager.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Input/InputManager.cs
@@ -26,6 +26,7 @@ namespace WitchMendokusai
 		Scroll,
 		Sprint,
 		Crouch,
+		BuildModeToggle,
 		// HotbarSlot1~9는 연속 정의 유지 — UIHotbar이 (HotbarSlot1 + i) 산수에 의존
 		HotbarSlot1,
 		HotbarSlot2,
@@ -76,6 +77,7 @@ namespace WitchMendokusai
 			{ InputEventType.Scroll, InputMapType.Player },
 			{ InputEventType.Sprint, InputMapType.Player },
 			{ InputEventType.Crouch, InputMapType.Player },
+			{ InputEventType.BuildModeToggle, InputMapType.Player },
 			{ InputEventType.HotbarSlot1, InputMapType.Player },
 			{ InputEventType.HotbarSlot2, InputMapType.Player },
 			{ InputEventType.HotbarSlot3, InputMapType.Player },

--- a/Assets/_WitchMendokusai/Core/Scripts/Input/InputStrategyWorld.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Input/InputStrategyWorld.cs
@@ -75,6 +75,13 @@ namespace WitchMendokusai
 						),
 
 						new(
+							InputEventType.BuildModeToggle,
+							InputEventResponseType.Performed,
+							() => GameModeManager.Instance.ToggleBuildMode(),
+							() => CanExecute(InputEventType.BuildModeToggle)
+						),
+
+						new(
 							InputEventType.Scroll,
 							InputEventResponseType.Performed,
 							() => CameraManager.Instance.Zoom(),
@@ -152,6 +159,16 @@ namespace WitchMendokusai
 				}
 			},
 			{ InputEventType.ChangeMode, new[] { GameConditionType.IsTyping } },
+			{
+				InputEventType.BuildModeToggle,
+				new[]
+				{
+					GameConditionType.IsTyping,
+					GameConditionType.IsPaused,
+					GameConditionType.IsDied,
+					GameConditionType.IsViewingUI
+				}
+			},
 			{ InputEventType.Scroll, new[] { GameConditionType.IsTyping } },
 
 			{

--- a/Assets/_WitchMendokusai/Core/Scripts/Input/WMInput.inputactions
+++ b/Assets/_WitchMendokusai/Core/Scripts/Input/WMInput.inputactions
@@ -203,6 +203,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "BuildModeToggle",
+                    "type": "Button",
+                    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567042",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -885,6 +894,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "Crouch",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234568042",
+                    "path": "<Keyboard>/g",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "BuildModeToggle",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }


### PR DESCRIPTION
## 📋 관련된 TASK
- Task: `wm/tasks/TASK-WM-042-Build-Codex-Key-Conflict.md`
- Related: TASK-WM-041 (검증 마무리 후 사용자 발화로 발견)

## 📝 PR 목적 및 의도

빌드 모드 토글 키와 도감(`CodexToggle`) 키가 둘 다 `B` 라 동시 트리거되던 충돌을 해소.
원인은 `BuildManager.Update` 의 `Keyboard.current.bKey.wasPressedThisFrame` *직접 polling* (TODO 임시키 주석). 입력 룰 위반이라 정합 패턴 (`InputAction` + `InputManager` + `InputStrategyWorld` 경유) 으로 같이 정리.

## 🛠️ 주요 변경 사항

- **키 재배치**: 도감 `B` 유지, 빌드 모드 `B → G`. Q/E 는 `InputManager.UpdateCameraRotateInput` 에서 카메라 회전 axis 로 polling 중이라 후보 제외, G 는 grep 결과 사용처 0
- **`WMInput.inputactions`**: Player ActionMap 에 `BuildModeToggle` Action + `<Keyboard>/g` 바인딩 추가
- **`InputManager.cs`**: `InputEventType.BuildModeToggle` enum 항목 추가, `inputEventBindings` 에 `Player` 매핑
- **`InputStrategyWorld.cs`**: `BuildModeToggle` 콜백 등록 (`GameModeManager.ToggleBuildMode()`) + `EventReturnConditions` 차단 조건 (`IsTyping`/`IsPaused`/`IsDied`/`IsViewingUI`). `IsBuilding` 은 *제외* — 이미 빌드 모드일 때 해제 토글 위해 통과 필요
- **`BuildManager.cs`**: `Update` 의 `Keyboard.current.bKey` polling 줄 제거 (TODO 임시키 정리)

## 🤔 리뷰어(CodeRabbit)에게 특별히 확인 받고 싶은 부분

- `EventReturnConditions` 의 차단 조건 선정 (특히 `IsBuilding` 제외 결정) 이 다른 모드 토글 (`ChangeMode = Y`) 과 정합한지
- `GameModeManager.Instance.ToggleBuildMode()` 가 `InputStrategyWorld` 의 직접 의존성에 자연스럽게 합류했는지

## ✅ 체크리스트
- [x] § 코딩 스타일 — `var` 금지 / Allman / `== false` / 변수명 풀네임
- [x] § 입력 처리 — `InputManager.RegisterInputEvent` 경유 (`Keyboard.current` 직접 접근 *제거*)
- [x] § 에러 처리 — FastFail 유지
- [x] § 사용자 작업 기록 — 에디터 작업 없음 (코드 + JSON 만)
- [x] § 컴파일 에러 확인 — Editor focus 후 사용자 검증 OK
- [x] 오버스펙 지향 — 단순화 자체 검열 X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 개선**
  * 빌드 모드 전환 입력 시스템을 통합된 입력 관리자를 통해 처리하도록 개선했습니다. G 키로 빌드 모드를 토글할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->