### PR TITLE
chore(ci): TASK-WM-045 — Claude Code GitHub Action 워크플로 추가

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,4 +34,4 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## 📋 관련된 TASK
- Task: `memo/wm/tasks/TASK-WM-045-Claude-Code-GitHub-Action.md`

## 📝 PR 목적 및 의도

`anthropics/claude-code-action@v1` 을 WM 레포에 설치한다. PR 코멘트·리뷰·이슈에서 `@claude` 멘션이 감지되면 GitHub Action 이 트리거되어 Claude 가 같은 PR 브랜치에 직접 commit 한다.

**왜:** 지금까지 CodeRabbit/Copilot review 코멘트는 사용자가 *로컬 Claude Code 띄워서 → 수동으로 fix 지시 → 사용자 PC commit/push* 흐름이었다. PC OFF 상태에선 PR 묵힘. GitHub Action 으로 옮기면 PR 댓글 1줄로 끝나고 PC 의존성 사라진다.

**옵션 A 채택 사유 (TASK 문서 참고):** 멘션이 명시 단계로 남아 비용 통제 + 오작동 가드. 자동 트리거 (옵션 B) 는 무한루프·오해 fix 리스크 있어 신뢰 쌓인 후 검토.

**시연 타겟:** PR #65 가 아닌 TASK-WM-043/044 의 후속 PR. #65 는 키 재배치 단일 주제로 그대로 머지 (한 commit 한 주제 룰).

**인증:** 사용자 Claude Pro/Max 구독 OAuth 토큰 (`CLAUDE_CODE_OAUTH_TOKEN`) 사용. 사용량은 구독 한도에서 차감, 별도 API 결제 없음. (초안 commit 은 `ANTHROPIC_API_KEY` 박았다가 swap.)

## 🛠️ 주요 변경 사항
- `.github/workflows/claude.yml` 신규
  - 트리거: `issue_comment` / `pull_request_review_comment` / `pull_request_review` / `issues` (4 이벤트)
  - 가드: `if: contains(<event>.body, '@claude')` — 멘션 없으면 job skip (한도 차감 0)
  - permissions: `contents/pull-requests/issues/id-token: write`, `actions: read`
  - 액션 버전: `anthropics/claude-code-action@v1` (2025-08-26 GA, 안정 태그)
  - 인증 input: `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`

## 🔧 사용자 수동 작업 (머지 전후)

1. **OAuth 토큰 발급 + 시크릿 등록** — 로컬 터미널에서 `claude setup-token` → 브라우저 OAuth 흐름 → 출력 토큰을 `Settings → Secrets and variables → Actions → New repository secret` 에 `CLAUDE_CODE_OAUTH_TOKEN` 으로 등록
2. **Claude GitHub App 설치** — <https://github.com/apps/claude> → Witch-Mendokusai 선택
3. **시연** — TASK-WM-043 또는 044 PR 에 `@claude` 멘션 → Action 결과 확인

## 🤔 리뷰어(CodeRabbit)에게 특별히 확인 받고 싶은 부분

- **트리거 가드 정합성**: `if` 조건이 4 이벤트 각각의 멘션 위치 (`comment.body` / `review.body` / `issue.body` / `issue.title`) 를 누락 없이 커버하는지
- **permissions 최소화**: `contents: write` 가 가장 광범위. Claude 가 정말 같은 브랜치에 commit 하려면 필요함이 맞는지
- **버전 핀 vs 태그**: `@v1` (major tag) — minor 업데이트 자동 따라감. `@v1.x.y` 처럼 핀 박는 게 안전한지

## ✅ 체크리스트
- [ ] § 코딩 스타일 — N/A (YAML)
- [ ] § 입력 처리 — N/A (인프라)
- [ ] § 에러 처리 — N/A (인프라)
- [x] § 사용자 작업 기록 — TASK 문서 명시
- [ ] § 컴파일 에러 확인 — N/A
- [x] 오버스펙 지향 — 표준 example 그대로

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * GitHub Actions 자동화 워크플로우를 추가하여 코드 검토 및 작업 처리 프로세스를 개선했습니다. 이슈, 풀 리퀘스트 리뷰 등 여러 이벤트 유형에 자동으로 트리거되도록 구성되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->