### PR TITLE
fix(input): TASK-WM-044 — IsTyping UI Toolkit 일반화

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/GameManager.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/GameManager.cs
@@ -89,7 +89,7 @@ namespace WitchMendokusai
 		private static readonly Dictionary<GameConditionType, Func<bool>> gameConditionActions = new()
 		{
 			{ GameConditionType.IsPaused, () => TimeManager.Instance.IsPaused }, // Setting, Dungeon Card 선택, Transition, ...
-			{ GameConditionType.IsTyping, () => UIChat.IsChatting || (DevWindowController.TryGetExistingInstance(out DevWindowController dwc) && dwc.IsCommandLineFocused) },
+			{ GameConditionType.IsTyping, () => UIChat.IsChatting || (DevWindowController.TryGetExistingInstance(out DevWindowController dwc) && dwc.IsCommandLineFocused) || UIToolkitFocus.IsAnyTextFieldFocused() },
 			{ GameConditionType.IsMouseOnUI, () => InputManager.Instance.IsPointerOverUI() },
 			{ GameConditionType.IsPlayerCasting, () => Player.Instance.Object.UnitStat[UnitStatType.CASTING_SKILL] > 0 },
 			{ GameConditionType.IsDied, () => Player.Instance.Object.UnitStat[UnitStatType.HP_CUR] <= 0 },

--- a/Assets/_WitchMendokusai/Core/Scripts/Input/UIToolkitFocus.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Input/UIToolkitFocus.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace WitchMendokusai
+{
+	// UI Toolkit 모든 활성 UIDocument 를 스캔해 텍스트 입력 컨트롤 포커스 여부 검사.
+	// IsTyping GameCondition 의 일반화 — UIChat/DevWindow CommandLine 외 모든 TextField 가 자동 보호.
+	public static class UIToolkitFocus
+	{
+		public static bool IsAnyTextFieldFocused()
+		{
+			UIDocument[] documents = Object.FindObjectsByType<UIDocument>(FindObjectsInactive.Exclude);
+
+			for (int i = 0; i < documents.Length; i++)
+			{
+				UIDocument document = documents[i];
+				VisualElement root = document.rootVisualElement;
+				if (root == null)
+					continue;
+
+				IPanel panel = root.panel;
+				if (panel == null)
+					continue;
+
+				FocusController focusController = panel.focusController;
+				if (focusController == null)
+					continue;
+
+				VisualElement focused = focusController.focusedElement as VisualElement;
+				while (focused != null)
+				{
+					if (focused is TextField)
+						return true;
+					focused = focused.parent;
+				}
+			}
+
+			return false;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/Input/UIToolkitFocus.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Input/UIToolkitFocus.cs
@@ -7,9 +7,22 @@ namespace WitchMendokusai
 	// IsTyping GameCondition 의 일반화 — UIChat/DevWindow CommandLine 외 모든 TextField 가 자동 보호.
 	public static class UIToolkitFocus
 	{
+		private static int cachedFrame = -1;
+		private static bool cachedResult;
+
 		public static bool IsAnyTextFieldFocused()
 		{
-			UIDocument[] documents = Object.FindObjectsByType<UIDocument>(FindObjectsInactive.Exclude);
+			if (Time.frameCount == cachedFrame)
+				return cachedResult;
+
+			cachedFrame = Time.frameCount;
+			cachedResult = CheckAnyTextFieldFocused();
+			return cachedResult;
+		}
+
+		private static bool CheckAnyTextFieldFocused()
+		{
+			UIDocument[] documents = Object.FindObjectsByType<UIDocument>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
 
 			for (int i = 0; i < documents.Length; i++)
 			{
@@ -39,3 +52,4 @@ namespace WitchMendokusai
 		}
 	}
 }
+

--- a/Assets/_WitchMendokusai/Core/Scripts/Input/UIToolkitFocus.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/Input/UIToolkitFocus.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 36c4ba19a9f9a6642b9c427169be7972


### PR DESCRIPTION
## 📋 관련된 TASK
- Task: `memo/wm/tasks/TASK-WM-044-IsTyping-UIToolkit-General.md`
- Follow-up: PR #65 (TASK-WM-042) Copilot 리뷰 코멘트 #2

## 📝 PR 목적 및 의도

기존 `GameCondition.IsTyping` 정의가 `UIChat.IsChatting` + `DevWindowController.IsCommandLineFocused` 만 추적해, **DevWindow 의 다른 UI Toolkit `TextField` (모드 검색 박스 등) 에서 단축키가 그대로 발화**하는 누락을 *일반화* 로 fix.

근본은 단축키마다 ad-hoc 가드 추가가 아니라, *모든 활성 UIDocument 의 focus 상태* 를 검사하는 단일 helper. 새 UI Toolkit `TextField` 가 추가되어도 자동 보호 — 등록 의무 0.

`InputManager.cs:262` 가 이미 IsTyping 글로벌 게이트 (whitelist 외 차단) → IsTyping 정의 한 줄 강화로 *모든* 단축키 자동 보호.

## 🛠️ 주요 변경 사항

- `UIToolkitFocus.IsAnyTextFieldFocused()` 신규 — 모든 활성 `UIDocument` 의 `focusController.focusedElement` 가 `TextField` (또는 부모 chain 상의 `TextField`) 인지 검사
- `GameManager.cs:92` IsTyping lambda 에 `|| UIToolkitFocus.IsAnyTextFieldFocused()` OR 추가

## 🤔 리뷰어(CodeRabbit)에게 특별히 확인 받고 싶은 부분

1. `Object.FindObjectsByType<UIDocument>(FindObjectsInactive.Exclude)` — 입력 dispatch 시점만 호출 (키 누를 때만) 이라 비용 무시 가능 판단. *매 프레임* 호출이면 캐시 필요한데, 이 케이스에선 OK 인지
2. `focused is TextField` parent chain 검사 — UI Toolkit 의 TextField 내부 TextElement 가 focus 잡힌 케이스 처리. 누락된 위젯 패턴 (예: `IntegerField`/`FloatField` 같은 다른 BaseField) 있는지 — 본 PR 은 *현재 발견된 케이스* (TextField) 만 일반화. 추가 누락 발견 시 후속

## ✅ 체크리스트 — 룰 정본은 `WitchMendokusai/CLAUDE.md`
- [x] § 코딩 스타일 — `var` 금지 / Allman / `== false` / 변수명 풀네임
- [x] § 입력 처리 — IsTyping 게이트 강화 (`Keyboard.current` 직접 접근 X)
- [x] § 에러 처리 — null 체크는 panel/focusController 의 *합법적 비활성 상태* 만 (방어 코드 X)
- [x] § 사용자 작업 기록 — 에디터 추가 작업 없음 (helper 한 메서드 + lambda OR)
- [x] § 컴파일 에러 확인 — 원본 디렉토리에서 reimport 후 Editor.log `error CS` 0 / `warning CS` 0 확인
- [x] 오버스펙 지향 — 일반화로 *모든 TextField 자동 보호*