### PR TITLE
chore(ci): TASK-WM-045 — concurrency 그룹 추가 (병렬 실행 방지)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |


### PR DESCRIPTION
## 📋 관련된 TASK
- Task: `memo/wm/tasks/TASK-WM-045-Claude-Code-GitHub-Action.md`

## 📝 PR 목적 및 의도

PR #67 머지 후 첫 `@claude` 멘션 시연에서 Claude bot 이 제안한 개선 사항 적용.
같은 PR/이슈에 `@claude` 멘션이 연속으로 들어올 때 병렬 실행을 방지해 큐잉 처리.

> Bot 이 직접 commit 못 한 이유: `workflows` 권한이 GitHub App 토큰에 없어 `.github/workflows/` 파일 변경 push 거부됨 (`refusing to allow a GitHub App to create or update workflow without workflows permission`). 이 제약은 별도 처리 예정.

## 🛠️ 주요 변경 사항
- `.github/workflows/claude.yml` — `concurrency:` 블록 추가 (4줄)
  - `group`: `workflow명-이슈/PR번호` 조합 → 같은 PR/이슈 실행이 동일 그룹 묶임
  - `cancel-in-progress: false` → 선착순 큐잉 (취소 없음)

## 🤔 리뷰어(CodeRabbit)에게 특별히 확인 받고 싶은 부분
- `github.event.issue.number || github.event.pull_request.number` 가 4 이벤트 타입 모두를 누락 없이 커버하는지

## ✅ 체크리스트
- [ ] § 코딩 스타일 — N/A (YAML)
- [ ] § 입력 처리 — N/A
- [ ] § 에러 처리 — N/A
- [x] § 사용자 작업 기록 — N/A (수동 작업 없음)
- [ ] § 컴파일 에러 확인 — N/A
- [x] 오버스펙 지향 — bot 제안 그대로 4줄

🤖 Generated with [Claude Code](https://claude.com/claude-code)