### PR TITLE
chore(ci): CodeRabbit 리뷰 자동 적용 job 추가 (claude-coderabbit)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,3 +39,31 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+  claude-coderabbit:
+    if: github.event_name == 'pull_request_review' && github.event.review.user.login == 'coderabbitai[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Apply CodeRabbit suggestions
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            CodeRabbit이 이 PR에 코드 리뷰를 남겼습니다. 리뷰의 actionable 제안을 검토해 적절한 것만 적용하세요.
+
+            적용 기준:
+            - 버그, 명백한 코딩 스타일 위반, 논리 오류 → 적용
+            - nitpick / 주관적 스타일 의견 → 건너뜀
+            - 아키텍처·설계 변경이 필요한 큰 지적 → 코드 변경 없이 코멘트로 설명만
+            - WitchMendokusai CLAUDE.md 룰 (Allman, == false, var 금지, 변수명 풀네임) 준수


### PR DESCRIPTION
## 📋 관련된 TASK
- Task: `memo/wm/tasks/TASK-WM-045-Claude-Code-GitHub-Action.md` (follow-up)

## 📝 PR 목적 및 의도

CodeRabbit 리뷰가 올라올 때마다 `@claude` 멘션 없이 자동으로 Claude가 actionable 제안을 적용하도록 한다. 지금까지는 사용자가 직접 `@claude apply review feedback` 을 댓글로 달아야 했음.

**actor 필터**: `coderabbitai[bot]` 만 반응 — 무한루프·오작동 방지.
**prompt 가드**: nitpick/설계 변경은 코드 수정 없이 코멘트로만 — 범위 폭주 방지.

## 🛠️ 주요 변경 사항
- `.github/workflows/claude.yml` — `claude-coderabbit` job 추가
  - trigger: `pull_request_review` submitted + actor == `coderabbitai[bot]`
  - `@claude` 멘션 가드 없음 (자동)
  - `prompt:` 적용 기준 명시 (버그·스타일 → apply / nitpick·설계 → comment only)
  - 기존 `concurrency:` 그룹 공유 → 동시 실행 방지

## 🤔 리뷰어(CodeRabbit)에게 특별히 확인 받고 싶은 부분
- `pull_request_review` 이벤트에서 `github.event.review.user.login` 이 `coderabbitai[bot]` 과 정확히 일치하는지 (login 문자열 확인)
- `action_required` 없이 동작하는지 — 동일 레포 PR 이라 문제없을 것으로 예상

## ✅ 체크리스트
- [ ] § 코딩 스타일 — N/A (YAML)
- [ ] § 입력 처리 — N/A
- [ ] § 에러 처리 — N/A
- [x] § 사용자 작업 기록 — N/A (수동 작업 없음)
- [ ] § 컴파일 에러 확인 — N/A
- [x] 오버스펙 지향 — prompt 가드로 범위 통제, 풀오토는 의도적

🤖 Generated with [Claude Code](https://claude.com/claude-code)