### PR TITLE
chore(ci): Copilot 리뷰 자동 적용 job 추가 (claude-copilot)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -67,3 +67,31 @@ jobs:
             - nitpick / 주관적 스타일 의견 → 건너뜀
             - 아키텍처·설계 변경이 필요한 큰 지적 → 코드 변경 없이 코멘트로 설명만
             - WitchMendokusai CLAUDE.md 룰 (Allman, == false, var 금지, 변수명 풀네임) 준수
+
+  claude-copilot:
+    if: github.event_name == 'pull_request_review' && github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Apply Copilot suggestions
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            GitHub Copilot이 이 PR에 코드 리뷰를 남겼습니다. 리뷰의 actionable 제안을 검토해 적절한 것만 적용하세요.
+
+            적용 기준:
+            - 버그, 명백한 코딩 스타일 위반, 논리 오류 → 적용
+            - nitpick / 주관적 스타일 의견 → 건너뜀
+            - 아키텍처·설계 변경이 필요한 큰 지적 → 코드 변경 없이 코멘트로 설명만
+            - WitchMendokusai CLAUDE.md 룰 (Allman, == false, var 금지, 변수명 풀네임) 준수


### PR DESCRIPTION
## 요약

- `claude-copilot` job 추가 — `copilot-pull-request-reviewer[bot]` 가 PR 리뷰 제출 시 자동 트리거
- CodeRabbit 자동 트리거 (`claude-coderabbit`) 과 동일한 패턴, 동일한 적용 기준
- `@claude` 멘션 없이 Copilot 리뷰 직후 Claude가 actionable 제안만 자동 적용

## 검증 포인트

- [ ] Copilot이 리뷰 제출 → Actions 탭에서 `claude-copilot` job 실행 확인
- [ ] Claude가 같은 브랜치에 commit push

🤖 Generated with [Claude Code](https://claude.com/claude-code)