### PR TITLE
feat(input): TASK-WM-021 A — UIQuestPanel Tab 분리 + QuestToggle 독립 키

### DIFF
--- a/Assets/_WitchMendokusai/Content/Task/Quest/UI/UIQuestPanel.cs
+++ b/Assets/_WitchMendokusai/Content/Task/Quest/UI/UIQuestPanel.cs
@@ -6,6 +6,25 @@ namespace WitchMendokusai
 
 		public override bool IsFullscreen => true;
 
+		private void Awake()
+		{
+			Init(null);
+			gameObject.SetActive(false);
+		}
+
+		private void Start()
+		{
+			InputManager.Instance.RegisterInputEvent(InputEventType.QuestToggle, InputEventResponseType.Performed, Toggle);
+		}
+
+		private void OnDestroy()
+		{
+			if (InputManager.TryGetExistingInstance(out InputManager inputManager))
+				inputManager.UnregisterInputEvent(InputEventType.QuestToggle, InputEventResponseType.Performed, Toggle);
+		}
+
+		private void Toggle() => SetActive(gameObject.activeSelf == false);
+
 		protected override void OnInit()
 		{
 			questGrid = GetComponentInChildren<UIQuestGrid>(true);

--- a/Assets/_WitchMendokusai/Core/Scripts/Input/InputManager.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Input/InputManager.cs
@@ -46,6 +46,7 @@ namespace WitchMendokusai
 		Inventory,
 		DevWindowToggle,
 		CodexToggle,
+		QuestToggle,
 	}
 
 	public enum InputEventResponseType
@@ -95,6 +96,7 @@ namespace WitchMendokusai
 			{ InputEventType.Inventory, InputMapType.UI },
 			{ InputEventType.DevWindowToggle, InputMapType.UI },
 			{ InputEventType.CodexToggle, InputMapType.UI },
+			{ InputEventType.QuestToggle, InputMapType.UI },
 		};
 
 		// Strategy-owned: cleared on every strategy switch

--- a/Assets/_WitchMendokusai/Core/Scripts/Input/WMInput.inputactions
+++ b/Assets/_WitchMendokusai/Core/Scripts/Input/WMInput.inputactions
@@ -1048,6 +1048,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "QuestToggle",
+                    "type": "Button",
+                    "id": "adc4d35c-c4bb-4fed-b53c-20856dcdf571",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -1543,6 +1552,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "CodexToggle",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "aa9c217c-8ff7-41e5-8a62-dc20e8b72a4f",
+                    "path": "<Keyboard>/j",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "QuestToggle",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/02_Over/Tab/UITab.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/02_Over/Tab/UITab.cs
@@ -7,11 +7,10 @@ namespace WitchMendokusai
 		None = -1,
 
 		MagicBook = 0,
-		Quest = 1,
-		Doll = 2,
-		Map = 3,
+		Doll = 1,
+		Map = 2,
 
-		Count = 4,
+		Count = 3,
 
 		TabMenu = 100,
 	}
@@ -21,7 +20,6 @@ namespace WitchMendokusai
 		[Header("Prefabs")]
 		[SerializeField] private UITabMenu tabMenuPrefab = null;
 		[SerializeField] private UIMagicBookPanel magicBookPanelPrefab = null;
-		[SerializeField] private UIQuestPanel questPanelPrefab = null;
 		[SerializeField] private UIDollPanel dollPanelPrefab = null;
 		[SerializeField] private UIMap mapPanelPrefab = null;
 
@@ -36,7 +34,6 @@ namespace WitchMendokusai
 			Panels[TabPanelType.TabMenu] = Instantiate(tabMenuPrefab, transform);
 
 			Panels[TabPanelType.MagicBook] = Instantiate(magicBookPanelPrefab, transform);
-			Panels[TabPanelType.Quest] = Instantiate(questPanelPrefab, transform);
 			Panels[TabPanelType.Doll] = Instantiate(dollPanelPrefab, transform);
 			Panels[TabPanelType.Map] = Instantiate(mapPanelPrefab, transform);
 


### PR DESCRIPTION
## 요약

- `UIQuestPanel` — `UITab` 의존 제거, `QuestToggle` InputEvent로 자체 토글
- `InputManager` — `InputEventType.QuestToggle` 추가 (`InputMapType.UI`)
- `WMInput.inputactions` — QuestToggle 액션 + 키 바인딩 추가
- `UITab` — `TabPanelType.Quest` 제거, `questPanelPrefab` SerializeField 제거 (Count 4→3)

## 에디터 검증 포인트

- [ ] Quest 패널 지정 키로 열기/닫기 동작
- [ ] Tab 메뉴에서 Quest 탭 사라짐 확인
- [ ] 기존 MagicBook / Doll / Map 탭 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)