### PR TITLE
feat(Quest): TASK-WM-021 — QuestView UI Toolkit 전환 + Tab에서 Quest 분리

### DIFF
--- a/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestDetail.cs
+++ b/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestDetail.cs
@@ -1,0 +1,122 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace WitchMendokusai
+{
+	public class QuestDetail : VisualElement
+	{
+		public const string USS_CLASS = "wm-quest-detail";
+		public const string USS_NAME = "wm-quest-detail__name";
+		public const string USS_DESC = "wm-quest-detail__desc";
+		public const string USS_STATE = "wm-quest-detail__state";
+		public const string USS_PROGRESS = "wm-quest-detail__progress";
+		public const string USS_CRITERIA = "wm-quest-detail__criteria";
+
+		private readonly Label nameLabel;
+		private readonly Label descLabel;
+		private readonly Label stateLabel;
+		private readonly Label progressLabel;
+		private readonly VisualElement criteriaContainer;
+		private readonly Button workButton;
+		private readonly Button completeButton;
+
+		private RuntimeQuest quest;
+
+		public QuestDetail()
+		{
+			AddToClassList(USS_CLASS);
+
+			nameLabel = new Label();
+			nameLabel.AddToClassList(USS_NAME);
+			Add(nameLabel);
+
+			descLabel = new Label();
+			descLabel.AddToClassList(USS_DESC);
+			descLabel.style.whiteSpace = WhiteSpace.Normal;
+			Add(descLabel);
+
+			stateLabel = new Label();
+			stateLabel.AddToClassList(USS_STATE);
+			Add(stateLabel);
+
+			progressLabel = new Label();
+			progressLabel.AddToClassList(USS_PROGRESS);
+			Add(progressLabel);
+
+			criteriaContainer = new VisualElement();
+			criteriaContainer.AddToClassList(USS_CRITERIA);
+			Add(criteriaContainer);
+
+			workButton = new Button(OnWorkClicked) { text = "작업 시작" };
+			Add(workButton);
+
+			completeButton = new Button(OnCompleteClicked) { text = "보상 받기" };
+			Add(completeButton);
+
+			style.display = DisplayStyle.None;
+		}
+
+		public void Bind(RuntimeQuest newQuest)
+		{
+			quest = newQuest;
+			Refresh();
+		}
+
+		public void Refresh()
+		{
+			bool hasQuest = quest != null;
+			style.display = hasQuest ? DisplayStyle.Flex : DisplayStyle.None;
+
+			if (hasQuest == false)
+				return;
+
+			nameLabel.text = quest.Name ?? quest.SO?.Name ?? "?";
+			descLabel.text = quest.Description ?? quest.SO?.Description ?? string.Empty;
+			stateLabel.text = quest.State.ToString();
+			progressLabel.text = quest.GetProgressText();
+
+			criteriaContainer.Clear();
+			foreach (RuntimeCriteria criteria in quest.Criteria)
+			{
+				Label label = new(BuildCriteriaText(criteria));
+				label.style.color = criteria.IsCompleted
+					? new Color(0.3f, 0.9f, 0.3f)
+					: Color.white;
+				criteriaContainer.Add(label);
+			}
+
+			workButton.style.display = quest.State == RuntimeQuestState.CanWork
+				? DisplayStyle.Flex : DisplayStyle.None;
+			completeButton.style.display = quest.State == RuntimeQuestState.CanComplete
+				? DisplayStyle.Flex : DisplayStyle.None;
+		}
+
+		private string BuildCriteriaText(RuntimeCriteria criteria)
+		{
+			string name = criteria.Criteria is ItemCountCriteria itemCount
+				? SOHelper.GetItemData(itemCount.ItemID)?.Name ?? "?"
+				: criteria.Criteria.GetType().Name;
+
+			int target = criteria.GetTargetValue();
+			if (target > 0)
+				return $"{name}  {criteria.GetCurValue()}/{target}";
+
+			return name;
+		}
+
+		private void OnWorkClicked()
+		{
+			if (quest == null || quest.State != RuntimeQuestState.CanWork)
+				return;
+			quest.StartWork(0);
+			Refresh();
+		}
+
+		private void OnCompleteClicked()
+		{
+			if (quest == null || quest.State != RuntimeQuestState.CanComplete)
+				return;
+			quest.Complete();
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestDetail.cs.meta
+++ b/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestDetail.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c4f76f8d7f0f1e04185590a7c64b0e4a

--- a/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestEntry.cs
+++ b/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestEntry.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace WitchMendokusai
+{
+	public class QuestEntry : VisualElement
+	{
+		public const string USS_CLASS = "wm-quest-entry";
+		public const string USS_SELECTED = "wm-quest-entry--selected";
+		public const string USS_NAME = "wm-quest-entry__name";
+		public const string USS_TYPE = "wm-quest-entry__type";
+		public const string USS_STATE = "wm-quest-entry__state";
+		public const string USS_PROGRESS_BG = "wm-quest-entry__progress";
+		public const string USS_PROGRESS_FILL = "wm-quest-entry__progress-fill";
+
+		private readonly Label nameLabel;
+		private readonly Label typeLabel;
+		private readonly Label stateLabel;
+		private readonly VisualElement progressFill;
+
+		public RuntimeQuest Quest { get; private set; }
+
+		public QuestEntry()
+		{
+			AddToClassList(USS_CLASS);
+			focusable = true;
+			pickingMode = PickingMode.Position;
+
+			nameLabel = new Label();
+			nameLabel.AddToClassList(USS_NAME);
+			nameLabel.pickingMode = PickingMode.Ignore;
+			Add(nameLabel);
+
+			VisualElement footer = new();
+			footer.style.flexDirection = FlexDirection.Row;
+			footer.pickingMode = PickingMode.Ignore;
+			Add(footer);
+
+			typeLabel = new Label();
+			typeLabel.AddToClassList(USS_TYPE);
+			typeLabel.pickingMode = PickingMode.Ignore;
+			footer.Add(typeLabel);
+
+			stateLabel = new Label();
+			stateLabel.AddToClassList(USS_STATE);
+			stateLabel.pickingMode = PickingMode.Ignore;
+			footer.Add(stateLabel);
+
+			VisualElement progressBg = new();
+			progressBg.AddToClassList(USS_PROGRESS_BG);
+			progressBg.pickingMode = PickingMode.Ignore;
+			Add(progressBg);
+
+			progressFill = new VisualElement();
+			progressFill.AddToClassList(USS_PROGRESS_FILL);
+			progressFill.pickingMode = PickingMode.Ignore;
+			progressBg.Add(progressFill);
+		}
+
+		public void Bind(RuntimeQuest quest)
+		{
+			Quest = quest;
+			Refresh();
+		}
+
+		public void Refresh()
+		{
+			if (Quest == null)
+				return;
+
+			nameLabel.text = Quest.Name ?? Quest.SO?.Name ?? "?";
+			typeLabel.text = Quest.Type.ToString();
+			stateLabel.text = Quest.State.ToString();
+			progressFill.style.width = new StyleLength(new Length(Quest.GetProgress() * 100f, LengthUnit.Percent));
+		}
+
+		public void SetSelected(bool selected)
+		{
+			if (selected)
+				AddToClassList(USS_SELECTED);
+			else
+				RemoveFromClassList(USS_SELECTED);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestEntry.cs.meta
+++ b/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestEntry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1295b78c8b5fca84b940061837e4914d

--- a/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestFilterBar.cs
+++ b/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestFilterBar.cs
@@ -1,0 +1,64 @@
+using System;
+using UnityEngine.UIElements;
+
+namespace WitchMendokusai
+{
+	public class QuestFilterBar : VisualElement
+	{
+		public const string USS_CLASS = "wm-quest-filter-bar";
+		public const string BUTTON_CLASS = "wm-quest-filter-bar__button";
+		public const string BUTTON_ACTIVE_CLASS = "wm-quest-filter-bar__button--active";
+
+		public event Action<QuestType> OnFilterChanged = delegate { };
+
+		private QuestType current = QuestType.None;
+
+		public QuestFilterBar()
+		{
+			AddToClassList(USS_CLASS);
+
+			AddButton("전체", QuestType.None);
+			AddButton("일반", QuestType.Normal);
+			AddButton("마을의뢰", QuestType.VillageRequest);
+			AddButton("업적", QuestType.Achievement);
+			AddButton("연구", QuestType.Research);
+			AddButton("던전", QuestType.Dungeon);
+
+			RefreshActive();
+		}
+
+		private void AddButton(string label, QuestType type)
+		{
+			Button button = new(() => Select(type))
+			{
+				text = label,
+				userData = type
+			};
+			button.AddToClassList(BUTTON_CLASS);
+			Add(button);
+		}
+
+		private void Select(QuestType type)
+		{
+			if (current == type)
+				return;
+			current = type;
+			RefreshActive();
+			OnFilterChanged.Invoke(type);
+		}
+
+		private void RefreshActive()
+		{
+			foreach (VisualElement child in Children())
+			{
+				if (child is Button button && button.userData is QuestType type)
+				{
+					if (type == current)
+						button.AddToClassList(BUTTON_ACTIVE_CLASS);
+					else
+						button.RemoveFromClassList(BUTTON_ACTIVE_CLASS);
+				}
+			}
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestFilterBar.cs.meta
+++ b/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestFilterBar.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 18ad68b76505d1e43974f6e18ee8b5a5

--- a/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestGrid.cs
+++ b/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestGrid.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine.UIElements;
+
+namespace WitchMendokusai
+{
+	public class QuestGrid : VisualElement
+	{
+		public const string USS_CLASS = "wm-quest-grid";
+		public const string USS_LIST = "wm-quest-grid__list";
+
+		public event Action<RuntimeQuest> OnQuestSelected = delegate { };
+
+		private QuestBuffer buffer;
+		private QuestType filter = QuestType.None;
+		private QuestEntry selectedEntry;
+		private readonly List<QuestEntry> entries = new();
+		private readonly ScrollView scrollView;
+
+		public QuestGrid()
+		{
+			AddToClassList(USS_CLASS);
+
+			QuestFilterBar filterBar = new();
+			filterBar.OnFilterChanged += OnFilterChanged;
+			Add(filterBar);
+
+			scrollView = new ScrollView();
+			scrollView.AddToClassList(USS_LIST);
+			Add(scrollView);
+		}
+
+		public void Bind(QuestBuffer questBuffer)
+		{
+			if (buffer != null)
+				buffer.OnDataChanged -= Refresh;
+
+			buffer = questBuffer;
+
+			if (buffer == null)
+				return;
+
+			buffer.OnDataChanged += Refresh;
+			Refresh();
+		}
+
+		public void Unbind()
+		{
+			if (buffer != null)
+				buffer.OnDataChanged -= Refresh;
+			buffer = null;
+		}
+
+		private void OnFilterChanged(QuestType newFilter)
+		{
+			filter = newFilter;
+			Refresh();
+		}
+
+		public void Refresh()
+		{
+			if (buffer == null)
+				return;
+
+			List<RuntimeQuest> quests = buffer.Data;
+
+			while (entries.Count > quests.Count)
+			{
+				QuestEntry last = entries[^1];
+				scrollView.Remove(last);
+				entries.RemoveAt(entries.Count - 1);
+			}
+
+			while (entries.Count < quests.Count)
+			{
+				QuestEntry entry = new();
+				entry.RegisterCallback<PointerDownEvent>(_ => Select(entry));
+				scrollView.Add(entry);
+				entries.Add(entry);
+			}
+
+			for (int i = 0; i < quests.Count; i++)
+			{
+				entries[i].Bind(quests[i]);
+				bool show = filter == QuestType.None || quests[i].Type == filter;
+				entries[i].style.display = show ? DisplayStyle.Flex : DisplayStyle.None;
+			}
+
+			if (selectedEntry != null && selectedEntry.Quest != null && quests.Contains(selectedEntry.Quest) == false)
+				Select(entries.Count > 0 ? entries[0] : null);
+		}
+
+		private void Select(QuestEntry entry)
+		{
+			if (selectedEntry != null)
+				selectedEntry.SetSelected(false);
+
+			selectedEntry = entry;
+
+			if (selectedEntry != null)
+				selectedEntry.SetSelected(true);
+
+			OnQuestSelected.Invoke(entry?.Quest);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestGrid.cs.meta
+++ b/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestGrid.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 186096abcdbf3a64f9c871ab2d3a2e92

--- a/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestView.cs
+++ b/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestView.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace WitchMendokusai
+{
+	public class QuestView : MonoBehaviour
+	{
+		private const string WINDOW_ID = "Quest";
+
+		private WMWindow window;
+		private QuestGrid questGrid;
+		private QuestDetail questDetail;
+
+		private void Start()
+		{
+			window = new WMWindow
+			{
+				WindowId = WINDOW_ID,
+				Title = "퀘스트"
+			};
+			window.style.left = 200;
+			window.style.top = 100;
+			window.style.width = 600;
+			window.style.height = 400;
+			UIRoot.Instance.WindowsLayer.Add(window);
+
+			VisualElement body = new();
+			body.style.flexDirection = FlexDirection.Row;
+			body.style.flexGrow = 1;
+			window.Content.Add(body);
+
+			questGrid = new QuestGrid();
+			questGrid.style.width = 280;
+			questGrid.style.flexShrink = 0;
+			questGrid.OnQuestSelected += OnQuestSelected;
+			body.Add(questGrid);
+
+			questDetail = new QuestDetail();
+			questDetail.style.flexGrow = 1;
+			body.Add(questDetail);
+
+			questGrid.Bind(QuestManager.Instance.Quests);
+
+			InputManager.Instance.RegisterInputEvent(InputEventType.QuestToggle, InputEventResponseType.Performed, OnToggle);
+		}
+
+		private void OnDestroy()
+		{
+			questGrid?.Unbind();
+
+			if (InputManager.TryGetExistingInstance(out InputManager inputManager))
+				inputManager.UnregisterInputEvent(InputEventType.QuestToggle, InputEventResponseType.Performed, OnToggle);
+		}
+
+		private void OnQuestSelected(RuntimeQuest quest) => questDetail?.Bind(quest);
+
+		private void OnToggle() => window?.Toggle();
+	}
+}

--- a/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestView.cs.meta
+++ b/Assets/_WitchMendokusai/Content/Task/Quest/UI/Toolkit/QuestView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ebff17ca0be16664e8949a0d6987c684

--- a/Assets/_WitchMendokusai/Core/Scripts/Input/InputManager.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Input/InputManager.cs
@@ -45,6 +45,7 @@ namespace WitchMendokusai
 		Inventory,
 		DevWindowToggle,
 		CodexToggle,
+		QuestToggle,
 	}
 
 	public enum InputEventResponseType
@@ -93,6 +94,7 @@ namespace WitchMendokusai
 			{ InputEventType.Inventory, InputMapType.UI },
 			{ InputEventType.DevWindowToggle, InputMapType.UI },
 			{ InputEventType.CodexToggle, InputMapType.UI },
+			{ InputEventType.QuestToggle, InputMapType.UI },
 		};
 
 		// Strategy-owned: cleared on every strategy switch

--- a/Assets/_WitchMendokusai/Core/Scripts/Input/WMInput.inputactions
+++ b/Assets/_WitchMendokusai/Core/Scripts/Input/WMInput.inputactions
@@ -1028,6 +1028,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "QuestToggle",
+                    "type": "Button",
+                    "id": "adc4d35c-c4bb-4fed-b53c-20856dcdf571",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -1523,6 +1532,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "CodexToggle",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "aa9c217c-8ff7-41e5-8a62-dc20e8b72a4f",
+                    "path": "<Keyboard>/j",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "QuestToggle",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/02_Over/Tab/UITab.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/02_Over/Tab/UITab.cs
@@ -7,11 +7,10 @@ namespace WitchMendokusai
 		None = -1,
 
 		MagicBook = 0,
-		Quest = 1,
-		Doll = 2,
-		Map = 3,
+		Doll = 1,
+		Map = 2,
 
-		Count = 4,
+		Count = 3,
 
 		TabMenu = 100,
 	}
@@ -21,7 +20,6 @@ namespace WitchMendokusai
 		[Header("Prefabs")]
 		[SerializeField] private UITabMenu tabMenuPrefab = null;
 		[SerializeField] private UIMagicBookPanel magicBookPanelPrefab = null;
-		[SerializeField] private UIQuestPanel questPanelPrefab = null;
 		[SerializeField] private UIDollPanel dollPanelPrefab = null;
 		[SerializeField] private UIMap mapPanelPrefab = null;
 
@@ -36,7 +34,6 @@ namespace WitchMendokusai
 			Panels[TabPanelType.TabMenu] = Instantiate(tabMenuPrefab, transform);
 
 			Panels[TabPanelType.MagicBook] = Instantiate(magicBookPanelPrefab, transform);
-			Panels[TabPanelType.Quest] = Instantiate(questPanelPrefab, transform);
 			Panels[TabPanelType.Doll] = Instantiate(dollPanelPrefab, transform);
 			Panels[TabPanelType.Map] = Instantiate(mapPanelPrefab, transform);
 

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/Common/UIManager.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/Common/UIManager.cs
@@ -29,6 +29,7 @@ namespace WitchMendokusai
 		private InventoryView inventoryView;
 		private HotbarView hotbarView;
 		private BuildingBarView buildingBarView;
+		private QuestView questView;
 
 		public bool IsAnyPanelFullscreenOpen
 		{
@@ -68,6 +69,7 @@ namespace WitchMendokusai
 			inventoryView = uiRootGameObject.AddComponent<InventoryView>();
 			hotbarView = uiRootGameObject.AddComponent<HotbarView>();
 			buildingBarView = uiRootGameObject.AddComponent<BuildingBarView>();
+			questView = uiRootGameObject.AddComponent<QuestView>();
 		}
 
 		protected override void OnDestroy()
@@ -78,6 +80,8 @@ namespace WitchMendokusai
 				Destroy(hotbarView);
 			if (buildingBarView != null)
 				Destroy(buildingBarView);
+			if (questView != null)
+				Destroy(questView);
 
 			base.OnDestroy();
 		}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,11 @@ RegisterInputEvent()로 등록된 콜백들 호출
 
 ### 새 입력 이벤트 추가 절차
 
+**0. 키 중복 확인 (필수, 먼저 수행)**
+- `WMInput.inputactions`에서 `"path": "<Keyboard>/` grep으로 사용 중인 키 전체 목록 확인
+- `InputManager.cs`의 `UpdateCameraRotateInput` / `UpdateMoveInput`에서 직접 읽는 키 확인 (Q, E, W, A, S, D, 방향키)
+- 위 두 곳 모두 충돌 없는 키를 선택한 뒤 진행
+
 1. **`InputManager.cs`** — `InputEventType` 열거형에 항목 추가
    ```csharp
    public enum InputEventType { ..., MyAction }


### PR DESCRIPTION
## Summary

- `QuestView` / `QuestGrid` / `QuestEntry` / `QuestFilterBar` / `QuestDetail` — `WMWindow` 기반 UI Toolkit 신규 구현
- `UITab`에서 Quest 패널 제거, `TabPanelType` 재번호 (Doll=1, Map=2, Count=3)
- `InputManager` + `WMInput.inputactions`: `QuestToggle` 추가 (J키, UI 맵)
- `UIManager`: `questView` World 씬 한정 AddComponent/OnDestroy 패턴
- `CLAUDE.md`: 키 추가 시 중복 확인 절차 명문화

## Test plan

- [ ] World 씬 진입 → J키로 퀘스트 창 열림/닫힘
- [ ] 퀘스트 있을 때 목록 표시, 항목 클릭 → 오른쪽 상세 패널
- [ ] 필터 버튼으로 QuestType별 필터링
- [ ] Tab키로 MagicBook/Doll/Map 3탭 정상 동작 (Quest 없어진 것 확인)
- [ ] CanWork 상태 퀘스트 → 작업 시작 버튼, CanComplete → 보상 받기 버튼

🤖 Generated with [Claude Code](https://claude.com/claude-code)