### PR TITLE
feat(NodeGraph): TASK-WM-034 C — 도메인 분리 attribute

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/NodeDomain.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/NodeDomain.cs
@@ -1,0 +1,14 @@
+namespace WitchMendokusai.NodeGraph
+{
+	/// <summary>
+	/// 노드 그래프 도메인 — 어느 게임 시스템 (지형 / 마도서 / 퀘스트 ...) 의 그래프냐.
+	/// `NodeRegistry` 가 카탈로그 필터링 시 사용 — 지형 그래프 카탈로그 = Terrain 도메인 노드만.
+	/// `Generic` 은 fallback / 마이그레이션 — 도메인 미명시 NodeGraph 인스턴스 는 모든 노드 카탈로그 (호환성).
+	/// </summary>
+	public enum NodeDomain
+	{
+		Generic = 0,
+		Terrain = 1,
+		MagicBook = 2,
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/NodeDomainAttribute.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/NodeDomainAttribute.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace WitchMendokusai.NodeGraph
+{
+	/// <summary>
+	/// 노드 클래스에 붙여 도메인 마킹 — `NodeRegistry.NodeTypesForDomain` 이 카탈로그 필터링 시 사용.
+	/// `Inherited = false` — 베이스 (예: PointFilterNodeBase) 의 attribute 가 자손에 자동 전파 X. 자손마다 명시.
+	/// 미마킹 노드 = `NodeDomain.Generic` 으로 처리 — 모든 도메인 카탈로그에서 보임 (fallback).
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+	public sealed class NodeDomainAttribute : Attribute
+	{
+		public NodeDomain Domain { get; }
+
+		public NodeDomainAttribute(NodeDomain domain)
+		{
+			Domain = domain;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/NodeGraph.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/NodeGraph.cs
@@ -5,7 +5,8 @@ namespace WitchMendokusai.NodeGraph
 {
 	/// <summary>
 	/// 노드 그래프 SO — 노드 + 연결 묶음. `[SerializeReference]` 으로 다양한 도메인 노드 polymorphic 직렬화.
-	/// 도메인별 그래프는 이를 상속해서 표시 / 카탈로그 분리 (TASK-WM-034 단계 C). 1차는 generic.
+	/// 도메인별 그래프는 이를 상속해서 <see cref="Domain"/> override (예: <c>TerrainGraph</c>, <c>MagicBookGraph</c>).
+	/// 직접 `NodeGraph` 인스턴스 자산 = `Generic` 도메인 — fallback / 마이그레이션 (모든 노드 카탈로그 보임).
 	/// </summary>
 	[CreateAssetMenu(fileName = nameof(NodeGraph), menuName = "WM/NodeGraph/" + nameof(NodeGraph))]
 	public class NodeGraph : ScriptableObject
@@ -15,6 +16,12 @@ namespace WitchMendokusai.NodeGraph
 
 		public IReadOnlyList<NodeBase> Nodes => nodes;
 		public IReadOnlyList<NodeConnection> Connections => connections;
+
+		/// <summary>
+		/// 그래프 도메인 — 카탈로그 (Editor) 필터링에 사용. 서브클래스가 override.
+		/// 기본 = `Generic` 으로, 직접 NodeGraph 인스턴스 자산 (마이그레이션 전) 호환성 유지.
+		/// </summary>
+		public virtual NodeDomain Domain => NodeDomain.Generic;
 
 		public void AddNode(NodeBase node)
 		{

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/CurveFilterNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/CurveFilterNode.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using WitchMendokusai.NodeGraph;
 
 namespace WitchMendokusai
 {
@@ -14,6 +15,7 @@ namespace WitchMendokusai
 	/// H2 (2026-05-06) 신규.
 	/// </summary>
 	[Serializable]
+	[NodeDomain(NodeDomain.Terrain)]
 	public class CurveFilterNode : PointFilterNodeBase
 	{
 		[Header("Curve Parameters")]

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/FractalPerlinNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/FractalPerlinNode.cs
@@ -13,6 +13,7 @@ namespace WitchMendokusai
 	/// 1차 minimal — 파라미터는 *필드* (인스펙터에서 직접 편집). 향후 input port 화 시 `Constant` 노드 연결 가능.
 	/// </summary>
 	[Serializable]
+	[NodeDomain(NodeDomain.Terrain)]
 	public class FractalPerlinNode : NodeBase
 	{
 		[SerializeField, Range(1, 8)] private int octaves = 4;

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/HeightOutputNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/HeightOutputNode.cs
@@ -11,6 +11,7 @@ namespace WitchMendokusai
 	/// SO 인스턴스 mutation 없음 → background 다발 호출 thread-safe.
 	/// </summary>
 	[Serializable]
+	[NodeDomain(NodeDomain.Terrain)]
 	public class HeightOutputNode : NodeBase
 	{
 		private NodePort<float> inHeight;

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/HydraulicErosionNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/HydraulicErosionNode.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using WitchMendokusai.NodeGraph;
 
 namespace WitchMendokusai
 {
@@ -11,6 +12,7 @@ namespace WitchMendokusai
 	/// G3 (2026-05-06) refactor — 코드 230줄 → 50줄.
 	/// </summary>
 	[Serializable]
+	[NodeDomain(NodeDomain.Terrain)]
 	public class HydraulicErosionNode : RegionGridNodeBase
 	{
 		[Header("Hydraulic Parameters")]

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/LerpNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/LerpNode.cs
@@ -14,6 +14,7 @@ namespace WitchMendokusai
 	/// H3 (2026-05-06) 신규.
 	/// </summary>
 	[Serializable]
+	[NodeDomain(NodeDomain.Terrain)]
 	public class LerpNode : NodeBase
 	{
 		private NodePort<float> inA;

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/RidgedPerlinNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/RidgedPerlinNode.cs
@@ -12,6 +12,7 @@ namespace WitchMendokusai
 	/// 출력 0~amplitude (이미 양수 — ridge = 봉우리). 정점 ridge, 골짜기 0.
 	/// </summary>
 	[Serializable]
+	[NodeDomain(NodeDomain.Terrain)]
 	public class RidgedPerlinNode : NodeBase
 	{
 		[SerializeField, Range(1, 8)] private int octaves = 4;

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/SmoothFilterNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/SmoothFilterNode.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using WitchMendokusai.NodeGraph;
 
 namespace WitchMendokusai
 {
@@ -11,6 +12,7 @@ namespace WitchMendokusai
 	/// H1 (2026-05-06) 신규.
 	/// </summary>
 	[Serializable]
+	[NodeDomain(NodeDomain.Terrain)]
 	public class SmoothFilterNode : RegionGridNodeBase
 	{
 		[Header("Smooth Parameters")]

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/ThermalErosionNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/ThermalErosionNode.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using WitchMendokusai.NodeGraph;
 
 namespace WitchMendokusai
 {
@@ -12,6 +13,7 @@ namespace WitchMendokusai
 	/// G3 (2026-05-06) 신규.
 	/// </summary>
 	[Serializable]
+	[NodeDomain(NodeDomain.Terrain)]
 	public class ThermalErosionNode : RegionGridNodeBase
 	{
 		[Header("Thermal Parameters")]

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/ThresholdFilterNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/ThresholdFilterNode.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using WitchMendokusai.NodeGraph;
 
 namespace WitchMendokusai
 {
@@ -13,6 +14,7 @@ namespace WitchMendokusai
 	/// H3 (2026-05-06) 신규.
 	/// </summary>
 	[Serializable]
+	[NodeDomain(NodeDomain.Terrain)]
 	public class ThresholdFilterNode : PointFilterNodeBase
 	{
 		[Header("Threshold Parameters")]

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/VoronoiNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/VoronoiNode.cs
@@ -13,6 +13,7 @@ namespace WitchMendokusai
 	/// 0 (셀 중심) ~ ~1 (셀 경계) 범위 정규화 → ±amplitude.
 	/// </summary>
 	[Serializable]
+	[NodeDomain(NodeDomain.Terrain)]
 	public class VoronoiNode : NodeBase
 	{
 		[SerializeField] private float cellSize = 32f;

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/WorldPositionInputNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/Nodes/WorldPositionInputNode.cs
@@ -10,6 +10,7 @@ namespace WitchMendokusai
 	/// background chunk gen 다발 호출 thread-safe.
 	/// </summary>
 	[Serializable]
+	[NodeDomain(NodeDomain.Terrain)]
 	public class WorldPositionInputNode : NodeBase
 	{
 		public const string KEY_WORLD_X = "worldX";

--- a/Assets/_WitchMendokusai/Core/Scripts/Terrain/TerrainGraph.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Terrain/TerrainGraph.cs
@@ -12,6 +12,8 @@ namespace WitchMendokusai
 	[CreateAssetMenu(fileName = nameof(TerrainGraph), menuName = "WM/Terrain/" + nameof(TerrainGraph))]
 	public class TerrainGraph : NodeGraphAsset
 	{
+		public override NodeDomain Domain => NodeDomain.Terrain;
+
 		/// <summary>
 		/// (worldX, worldZ) 기준 그래프 평가 결과 height. terminal `HeightOutputNode` 누락 시 0.
 		/// **background thread 안전** — context per-call 인스턴스, NodeBase 데이터 read-only.

--- a/Assets/_WitchMendokusai/Editor/NodeGraph/NodeGraphView.cs
+++ b/Assets/_WitchMendokusai/Editor/NodeGraph/NodeGraphView.cs
@@ -174,7 +174,8 @@ namespace WitchMendokusai.NodeGraph
 		{
 			Vector2 mousePos = evt.localMousePosition;
 
-			foreach (Type nodeType in NodeRegistry.AllNodeTypes())
+			// 그래프 자기 도메인 노드만 카탈로그 — Generic 도메인 (마이그레이션 전 NodeGraph) 은 모든 노드 fallback.
+			foreach (Type nodeType in NodeRegistry.NodeTypesForDomain(graph.Domain))
 			{
 				Type capturedType = nodeType;
 				evt.menu.AppendAction($"Create/{NicifyTypeName(nodeType.Name)}", action =>

--- a/Assets/_WitchMendokusai/Editor/NodeGraph/NodeRegistry.cs
+++ b/Assets/_WitchMendokusai/Editor/NodeGraph/NodeRegistry.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using UnityEditor;
 
 namespace WitchMendokusai.NodeGraph
@@ -8,7 +9,7 @@ namespace WitchMendokusai.NodeGraph
 	/// <summary>
 	/// `NodeBase` 서브클래스 카탈로그 — Editor 의 Create Node 메뉴에서 사용.
 	/// `TypeCache.GetTypesDerivedFrom` 으로 reflection 1회 (Domain Reload 마다).
-	/// 도메인 분리는 단계 C 에서 attribute 기반 — 1차는 단순 type 리스트.
+	/// 도메인 분리 (TASK-WM-034 C) — `[NodeDomain(...)]` attribute 기반 필터.
 	/// </summary>
 	public static class NodeRegistry
 	{
@@ -16,6 +17,25 @@ namespace WitchMendokusai.NodeGraph
 		{
 			return TypeCache.GetTypesDerivedFrom<NodeBase>()
 				.Where(t => t.IsAbstract == false && t.IsGenericTypeDefinition == false);
+		}
+
+		/// <summary>
+		/// 특정 도메인의 카탈로그 노드 목록.
+		/// `Generic` 도메인 = fallback (모든 노드 — 마이그레이션 전 NodeGraph 자산 호환).
+		/// 다른 도메인 = `[NodeDomain]` attribute 일치만 (미마킹 노드 = Generic 으로 간주, 매칭 X).
+		/// </summary>
+		public static IEnumerable<Type> NodeTypesForDomain(NodeDomain domain)
+		{
+			if (domain == NodeDomain.Generic)
+				return AllNodeTypes();
+
+			return AllNodeTypes().Where(t => GetDomain(t) == domain);
+		}
+
+		private static NodeDomain GetDomain(Type t)
+		{
+			NodeDomainAttribute attr = t.GetCustomAttribute<NodeDomainAttribute>(inherit: false);
+			return attr == null ? NodeDomain.Generic : attr.Domain;
 		}
 	}
 }


### PR DESCRIPTION
## 📋 관련된 TASK
- TASK-WM-034 (공통 노드 그래프 시스템) C 단계 — 도메인 분리 attribute
- TASK-WM-048 (마도서 시스템) A1 단계 — foundation 강화 (마도서 진입 전제조건)

## 📝 PR 목적 및 의도

지형 (TASK-WM-032) 까지는 **첫 도메인** 이라 도메인 분리 의미 X. 마도서 (TASK-WM-048) 는 **두 번째 도메인** — 카탈로그 분리 첫 등장. 본 PR 이 그 foundation.

## 🛠️ 주요 변경 사항

### 신규 (foundation)
- `NodeDomain` enum — `Generic / Terrain / MagicBook`
- `NodeDomainAttribute` (`AttributeUsage(AttributeTargets.Class, Inherited = false)`) — 노드 클래스 마킹

### 변경 (foundation)
- `NodeGraph.Domain` virtual property — default `Generic` (마이그레이션 fallback). 서브클래스 override
- `TerrainGraph.Domain` override → `Terrain`
- `NodeRegistry.NodeTypesForDomain(domain)` — 도메인별 카탈로그 필터. `Generic` 은 모든 노드 (호환 fallback)
- `NodeGraphView.BuildContextualMenu` — 그래프 자기 도메인만 카탈로그

### 마킹 (지형 concrete 노드 11개)
`Fractal/Voronoi/Ridged/Hydraulic/Thermal/Smooth/Curve/Threshold/Lerp/HeightOutput/WorldPositionInput` 일괄 `[NodeDomain(NodeDomain.Terrain)]`. abstract base (`PointFilterNodeBase`, `RegionGridNodeBase`) 마킹 X — `Inherited = false` 로 자손 명시 강제.

## 🛡️ 데드 인터페이스 룰

본 PR 안에 첫 사용처 (TerrainGraph 도메인 + 카탈로그 필터) 함께 박음. attribute 만 박고 사용 X 회피.

## 🔄 호환성

기존 NodeGraph 인스턴스 자산 = `Domain.Generic` → 모든 노드 카탈로그 (fallback). broken X.

## ✅ 체크리스트
- [x] § 코딩 스타일 — `var` 금지 / Allman / `== false` / 풀네임
- [x] § 입력 처리 — N/A
- [x] § 에러 처리 — FastFail 유지 (attribute 미마킹 = Generic fallback, exception 없이)
- [ ] § 컴파일 에러 확인 — 사용자 검증 시 Editor.log error CS 0 확인 요청
- [x] 데드 인터페이스 룰

## 🔮 후속

- TASK-WM-048 A2 — `MagicBookGraph` SO + `IngredientNode` + `SpellNode` 첫 박기
- TASK-WM-048 A3+ — 의존성 edge / 진척 매니저 / UI 등