### PR TITLE
feat(UI): TASK-WM-021 StatusView UI Toolkit 전환

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/Input/InputStrategyWorld.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Input/InputStrategyWorld.cs
@@ -107,12 +107,6 @@ namespace WitchMendokusai
 							InputEventResponseType.Performed,
 							() => UIManager.Instance.ToggleTabUI(),
 							() => CanExecute(InputEventType.Tab)
-						),
-						new(
-							InputEventType.Status,
-							InputEventResponseType.Performed,
-							() => UIManager.Instance.ToggleStatus(),
-							() => CanExecute(InputEventType.Status)
 						)
 						#endregion
 					};

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/00_Base/Status/UIStatus.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/00_Base/Status/UIStatus.cs
@@ -1,93 +1,10 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
-using static WitchMendokusai.SOHelper;
-
 namespace WitchMendokusai
 {
+	// Legacy: StatusView (UI Toolkit) 로 대체됨. World 씬 [Block] Status.prefab 가 본 컴포넌트를
+	// 참조하고 있어 missing component 경고 방지용으로 stub 유지. prefab + 씬 정리 시 본 파일 제거.
 	public class UIStatus : UIBase
 	{
-		private List<UISlot> statusSlots;
-		private bool isInit = false;
-
-		private readonly List<UnitStatType> showOnStatPanelTypes = new()
-		{
-			UnitStatType.EXP_BONUS,
-			UnitStatType.MOVEMENT_SPEED,
-			UnitStatType.PICKUP_RADIUS,
-			UnitStatType.COOLTIME_BONUS,
-			UnitStatType.ATTACK_SPEED_BONUS,
-			UnitStatType.PROJECTILE_COUNT_BONUS,
-			UnitStatType.PROJECTILE_SPEED_BONUS,
-			UnitStatType.PROJECTILE_DURATION_BONUS,
-			UnitStatType.PROJECTILE_SCALE_BONUS,
-			UnitStatType.PROJECTILE_PIERCE_BONUS,
-			UnitStatType.DAMAGE_BONUS,
-			UnitStatType.CRITICAL_CHANCE,
-			UnitStatType.CRITICAL_DAMAGE,
-			UnitStatType.ARMOR,
-			UnitStatType.DODGE,
-			UnitStatType.INVINCIBLE_TIME,
-			UnitStatType.GOLD_BONUS,
-		};
-
-		public override void Init()
-		{
-			statusSlots = GetComponentsInChildren<UISlot>(true).ToList();
-			foreach (UISlot slot in statusSlots)
-			{
-				slot.Init();
-				slot.UpdateUI();
-				slot.gameObject.SetActive(false);
-			}
-
-			isInit = true;
-		}
-
-		public override void UpdateUI()
-		{
-			// List<UnitStatType> stats = Enum.GetValues(typeof(UnitStatType)).Cast<UnitStatType>().ToList();
-			List<UnitStatType> stats = showOnStatPanelTypes.ToList();
-
-			for (int i = 0; i < statusSlots.Count; i++)
-			{
-				if (i >= stats.Count)
-				{
-					statusSlots[i].gameObject.SetActive(false);
-					continue;
-				}
-
-				UnitStatData unitStatData = Get<UnitStatData>((int)stats[i]);
-				UnitStatType targetType = stats[i];
-
-				statusSlots[i].gameObject.SetActive(true);
-
-				int curValue = Player.Instance.UnitStat[targetType];
-				statusSlots[i].SetSlot(unitStatData, curValue);
-				statusSlots[i].UpdateUI();
-			}
-		}
-
-		private IEnumerator Loop()
-		{
-			while (true)
-			{
-				UpdateUI();
-				yield return new WaitForSeconds(TimeManager.TICK);
-			}
-		}
-
-		private void OnEnable()
-		{
-			if (isInit)
-				StartCoroutine(Loop());
-		}
-
-		private void OnDisable()
-		{
-			StopAllCoroutines();
-		}
+		public override void Init() { }
+		public override void UpdateUI() { }
 	}
 }

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/00_Base/Status/UIStatus.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/00_Base/Status/UIStatus.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/Common/UIManager.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/Common/UIManager.cs
@@ -13,7 +13,6 @@ namespace WitchMendokusai
 		public UITransition Transition { get; private set; }
 		public UIChat Chat { get; private set; }
 		public UISpeechBubble SpeechBubble { get; private set; }
-		public UIStatus Status { get; private set; }
 		public CutSceneModule CutSceneModule { get; private set; }
 		[field: SerializeField] public Canvas BaseCanvas { get; private set; }
 	
@@ -31,6 +30,7 @@ namespace WitchMendokusai
 		private BuildingBarView buildingBarView;
 		private QuestView questView;
 		private DollView dollView;
+		private StatusView statusView;
 
 		public bool IsAnyPanelFullscreenOpen
 		{
@@ -60,7 +60,6 @@ namespace WitchMendokusai
 
 			Transition = FindAnyObjectByType<UITransition>(FindObjectsInactive.Include);
 			stagePopup = FindAnyObjectByType<UIStagePopup>(FindObjectsInactive.Include);
-			Status = FindAnyObjectByType<UIStatus>(FindObjectsInactive.Include);
 
 			Tab = FindAnyObjectByType<UITab>(FindObjectsInactive.Include);
 			NPC = FindAnyObjectByType<UINPC>(FindObjectsInactive.Include);
@@ -72,6 +71,7 @@ namespace WitchMendokusai
 			buildingBarView = uiRootGameObject.AddComponent<BuildingBarView>();
 			questView = uiRootGameObject.AddComponent<QuestView>();
 			dollView = uiRootGameObject.AddComponent<DollView>();
+			statusView = uiRootGameObject.AddComponent<StatusView>();
 		}
 
 		protected override void OnDestroy()
@@ -86,15 +86,14 @@ namespace WitchMendokusai
 				Destroy(questView);
 			if (dollView != null)
 				Destroy(dollView);
+			if (statusView != null)
+				Destroy(statusView);
 
 			base.OnDestroy();
 		}
 
 		private void Start()
 		{
-			Status.Init();
-			Status.gameObject.SetActive(false);
-
 			RegisterOverlayUI(Tab);
 			RegisterOverlayUI(NPC);
 		}
@@ -166,12 +165,5 @@ namespace WitchMendokusai
 			settingView.Open();
 		}
 
-		public void ToggleStatus()
-		{
-			Status.gameObject.SetActive(!Status.gameObject.activeSelf);
-
-			if (Status.gameObject.activeSelf)
-				Status.UpdateUI();
-		}
 	}
 }

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Slot.uss
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Slot.uss
@@ -817,3 +817,32 @@
     width: 48px;
     height: 48px;
 }
+
+/* === Status Window === */
+.wm-stat-row {
+    flex-direction: row;
+    align-items: center;
+    padding: 3px 6px;
+    border-bottom-width: 1px;
+    border-bottom-color: rgba(60, 60, 75, 0.4);
+}
+
+.wm-stat-row__icon {
+    width: 20px;
+    height: 20px;
+    margin-right: 8px;
+    background-color: rgba(15, 15, 18, 0.6);
+    -unity-background-scale-mode: scale-to-fit;
+    flex-shrink: 0;
+}
+
+.wm-stat-row__name {
+    flex-grow: 1;
+}
+
+.wm-stat-row__value {
+    color: rgba(255, 220, 130, 1);
+    -unity-font-style: bold;
+    -unity-text-align: middle-right;
+    min-width: 60px;
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Status.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Status.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6dbdee907b13b204cbb8a31725f7337a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Status/StatRow.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Status/StatRow.cs
@@ -1,0 +1,56 @@
+using UnityEngine.UIElements;
+
+namespace WitchMendokusai
+{
+	public class StatRow : VisualElement
+	{
+		public const string USS_CLASS = "wm-stat-row";
+		public const string USS_ICON = "wm-stat-row__icon";
+		public const string USS_NAME = "wm-stat-row__name";
+		public const string USS_VALUE = "wm-stat-row__value";
+
+		private readonly UnitStatType statType;
+		private readonly UnitStatData statData;
+		private readonly VisualElement icon;
+		private readonly Label nameLabel;
+		private readonly Label valueLabel;
+
+		public UnitStatType StatType => statType;
+
+		public StatRow(UnitStatType type)
+		{
+			statType = type;
+			statData = SOHelper.Get<UnitStatData>((int)type);
+
+			AddToClassList(USS_CLASS);
+
+			icon = new VisualElement();
+			icon.AddToClassList(USS_ICON);
+			icon.pickingMode = PickingMode.Ignore;
+			Add(icon);
+
+			if (statData != null && statData.Sprite != null)
+				icon.style.backgroundImage = new StyleBackground(statData.Sprite);
+
+			nameLabel = new Label(statData?.Name ?? type.ToString());
+			nameLabel.AddToClassList(USS_NAME);
+			nameLabel.pickingMode = PickingMode.Ignore;
+			Add(nameLabel);
+
+			valueLabel = new Label();
+			valueLabel.AddToClassList(USS_VALUE);
+			valueLabel.pickingMode = PickingMode.Ignore;
+			Add(valueLabel);
+		}
+
+		public void Refresh(UnitStat unitStat)
+		{
+			if (unitStat == null)
+			{
+				valueLabel.text = "—";
+				return;
+			}
+			valueLabel.text = unitStat[statType].ToString();
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Status/StatRow.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Status/StatRow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3876681779ee62c40ab776281dad2f82

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Status/StatusView.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Status/StatusView.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace WitchMendokusai
+{
+	public class StatusView : MonoBehaviour
+	{
+		private const string WINDOW_ID = "Status";
+
+		private static readonly UnitStatType[] DISPLAYED_STATS = new[]
+		{
+			UnitStatType.EXP_BONUS,
+			UnitStatType.MOVEMENT_SPEED,
+			UnitStatType.PICKUP_RADIUS,
+			UnitStatType.COOLTIME_BONUS,
+			UnitStatType.ATTACK_SPEED_BONUS,
+			UnitStatType.PROJECTILE_COUNT_BONUS,
+			UnitStatType.PROJECTILE_SPEED_BONUS,
+			UnitStatType.PROJECTILE_DURATION_BONUS,
+			UnitStatType.PROJECTILE_SCALE_BONUS,
+			UnitStatType.PROJECTILE_PIERCE_BONUS,
+			UnitStatType.DAMAGE_BONUS,
+			UnitStatType.CRITICAL_CHANCE,
+			UnitStatType.CRITICAL_DAMAGE,
+			UnitStatType.ARMOR,
+			UnitStatType.DODGE,
+			UnitStatType.INVINCIBLE_TIME,
+			UnitStatType.GOLD_BONUS,
+		};
+
+		private WMWindow window;
+		private readonly List<StatRow> rows = new();
+
+		private void Start()
+		{
+			window = new WMWindow
+			{
+				WindowId = WINDOW_ID,
+				Title = "스탯"
+			};
+			window.style.left = 320;
+			window.style.top = 100;
+			window.style.width = 320;
+			window.style.height = 480;
+			UIRoot.Instance.WindowsLayer.Add(window);
+
+			ScrollView scrollView = new();
+			window.Content.Add(scrollView);
+
+			foreach (UnitStatType type in DISPLAYED_STATS)
+			{
+				StatRow row = new(type);
+				scrollView.Add(row);
+				rows.Add(row);
+			}
+
+			InputManager.Instance.RegisterInputEvent(InputEventType.Status, InputEventResponseType.Performed, OnToggle);
+			TimeManager.Instance.RegisterCallback(Refresh);
+		}
+
+		private void OnDestroy()
+		{
+			if (InputManager.TryGetExistingInstance(out InputManager inputManager))
+				inputManager.UnregisterInputEvent(InputEventType.Status, InputEventResponseType.Performed, OnToggle);
+			if (TimeManager.TryGetExistingInstance(out TimeManager timeManager))
+				timeManager.RemoveCallback(Refresh);
+		}
+
+		private void Refresh()
+		{
+			if (window == null || window.IsOpen == false)
+				return;
+			if (Player.Instance == null)
+				return;
+
+			foreach (StatRow row in rows)
+				row.Refresh(Player.Instance.UnitStat);
+		}
+
+		private void OnToggle()
+		{
+			if (window == null)
+				return;
+			window.Toggle();
+			if (window.IsOpen)
+				Refresh();
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Status/StatusView.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/Status/StatusView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1391224607995ce4e85ffb8f6dbe22ac


### PR DESCRIPTION
## Summary

- **StatusView** (MonoBehaviour, WMWindow + V키) — UI Toolkit 신규
- **StatRow** (VisualElement) — 17개 stat type 자동 렌더 (icon + name + value)
- TimeManager.TICK 폴링 (원본 UIStatus 동작 답습)
- UIManager: \`Status\` 필드/\`ToggleStatus()\` 제거, \`statusView\` 추가
- InputStrategyWorld: Status InputRegisterData 제거 (StatusView 자체 등록)
- Slot.uss: \`.wm-stat-row\` 시리즈
- UIStatus.cs: 작은 stub 으로 정리 (씬 \`[Block] Status.prefab\` 의존 — prefab/씬 정리는 follow-up)

## Test plan

- [x] V키 → 스탯 창 토글
- [x] 17개 stat 모두 표시 (icon + name + value)
- [x] TimeManager.TICK 마다 값 갱신
- [ ] [Block] Status.prefab + 씬 GameObject 정리 (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)