### PR TITLE
feat(MagicBook): TASK-WM-048 A2 — MagicBookGraph + IngredientNode + SpellNode

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/MagicBook/MagicBookCategory.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/MagicBook/MagicBookCategory.cs
@@ -1,0 +1,18 @@
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// 마도서 카테고리 — `wm/design/gameplay/research.md` 의 3개 분류.
+	/// SpellNode SerializeField 로 분류. UI 색상 / 페이지 그룹 / 진행 흐름 분기 등에 사용.
+	/// </summary>
+	public enum MagicBookCategory
+	{
+		/// <summary>인형 마법 — 알리사·링 강화 (영혼 공명, 감정 전달, 자율 판단). 인형과 연결되고 싶음.</summary>
+		Doll = 0,
+
+		/// <summary>세계 탐구 — 안개 성질, 수정 동굴 빛, 시간 멈춘 이유. 세계 = 욘 내면임을 점진적 발견.</summary>
+		World = 1,
+
+		/// <summary>욘 자신 — "귀찮음의 원인", "내가 좋아하는 것", "인형을 만든 이유". 자기 이해 시도.</summary>
+		Self = 2,
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/MagicBook/MagicBookGraph.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/MagicBook/MagicBookGraph.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using WitchMendokusai.NodeGraph;
+
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// 마도서 도메인 노드 그래프 — 한 챕터 1개 = 한 그래프 자산. 노드 = 마법(페이지),
+	/// edge = 진행 의존성 (앞 노드 완료 → 다음 언락, A3 단계). `Domain = MagicBook` 으로
+	/// `NodeGraphView` 카탈로그 필터 통과 — 마도서 노드 (`IngredientNode`, `SpellNode`) 만 보임.
+	///
+	/// 평가 모델: Pull (지형 그래프와 동일 foundation 재사용).
+	/// `IngredientNode` 가 재료 충족 비율 (0~1) 출력 → `SpellNode` 가 입력 + threshold 비교 후 진척 출력.
+	/// 진행 매니저 (`ResearchProgressManager`, A 후속) 가 SpellNode 평가 결과 polling.
+	/// </summary>
+	[CreateAssetMenu(fileName = nameof(MagicBookGraph), menuName = "WM/MagicBook/" + nameof(MagicBookGraph))]
+	public class MagicBookGraph : WitchMendokusai.NodeGraph.NodeGraph
+	{
+		public override NodeDomain Domain => NodeDomain.MagicBook;
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/MagicBook/Nodes/IngredientNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/MagicBook/Nodes/IngredientNode.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using WitchMendokusai.NodeGraph;
+
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// 마도서 재료 노드 — 한 ItemData 의 보유량 vs 요구량 비율을 출력 (0~1).
+	/// 외부 인벤토리 시스템 ref 는 진행 매니저 (`ResearchProgressManager`, A 후속) 가 평가 시점에
+	/// `NodeExecutionContext.SetGlobalInput(ITEM_KEY_PREFIX + itemId, ratio)` 로 박는다.
+	/// 본 단계 (A2) 는 인터페이스만 — context 미설정 시 fallback 0.0.
+	/// </summary>
+	[Serializable]
+	[NodeDomain(NodeDomain.MagicBook)]
+	public class IngredientNode : NodeBase
+	{
+		/// <summary>외부 매니저가 context.SetGlobalInput 시 사용할 key 접두사.</summary>
+		public const string ITEM_KEY_PREFIX = "magicbook.ingredient.";
+
+		[SerializeField, Tooltip("재료 ItemData ID (예: 'I_0_나무'). A 후속에 ItemData ref 직접 주입으로 promote.")]
+		private string itemId = string.Empty;
+
+		[SerializeField, Tooltip("이 재료를 몇 개 모아야 100% 충족되는가."), Min(1)]
+		private int requiredAmount = 1;
+
+		private NodePort<float> outRatio;
+
+		public string ItemId => itemId;
+		public int RequiredAmount => requiredAmount;
+
+		protected override IEnumerable<NodePort> CreatePorts()
+		{
+			outRatio = new NodePort<float>(this, "ratio", PortDirection.Output);
+			List<NodePort> list = new() { outRatio };
+			return list;
+		}
+
+		protected override void OnEvaluate(NodeExecutionContext context)
+		{
+			// 외부 매니저 (`ResearchProgressManager`) 가 평가 전 SetGlobalInput 으로 보유량 비율을 박는다.
+			// 미설정 = fallback 0.0 (재료 미보유). FastFail X — 그래프 평가 자체는 정상 동작 보장.
+			string key = ITEM_KEY_PREFIX + itemId;
+			float ratio = context.TryGetGlobalInput(key, out float storedRatio) ? storedRatio : 0f;
+			context.SetOutput(outRatio, Mathf.Clamp01(ratio));
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/MagicBook/Nodes/SpellNode.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/MagicBook/Nodes/SpellNode.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using WitchMendokusai.NodeGraph;
+
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// 마도서 마법 노드 — 한 페이지 = 한 SpellNode. 입력 `ingredient` (재료 충족 비율 0~1) → 출력
+	/// `readiness` (시작 가능 비율). 본 단계 (A2) 는 단일 재료 placeholder — 1:1 매핑.
+	///
+	/// 후속 단계:
+	/// - A3: prerequisites edge (앞 SpellNode 완료 → 본 노드 언락)
+	/// - A4: multi-재료 합성 노드 (MagicBookSumNode / MinNode 등)
+	/// - F: 마법 효과 시스템 (`SpellEffectSO` ref) — 완성 시 trigger
+	/// - D: 진척 내레이션 5단계 SerializeField (현 단계는 시스템 인터페이스만)
+	///
+	/// 진척 매니저 (`ResearchProgressManager`, A 후속) 가 본 노드 evaluate → readiness polling.
+	/// </summary>
+	[Serializable]
+	[NodeDomain(NodeDomain.MagicBook)]
+	public class SpellNode : NodeBase
+	{
+		[SerializeField, Tooltip("페이지 식별자 (예: 'spell.warmth'). 진척 매니저 / 저장 데이터 키.")]
+		private string spellId = string.Empty;
+
+		[SerializeField, Tooltip("3 카테고리 분류 — 인형 마법 / 세계 탐구 / 욘 자신 (research.md 정합).")]
+		private MagicBookCategory category = MagicBookCategory.Doll;
+
+		private NodePort<float> inIngredient;
+		private NodePort<float> outReadiness;
+
+		public string SpellId => spellId;
+		public MagicBookCategory Category => category;
+		public NodePort<float> ReadinessOutput
+		{
+			get
+			{
+				_ = Ports;
+				return outReadiness;
+			}
+		}
+
+		protected override IEnumerable<NodePort> CreatePorts()
+		{
+			inIngredient = new NodePort<float>(this, "ingredient", PortDirection.Input);
+			outReadiness = new NodePort<float>(this, "readiness", PortDirection.Output);
+			List<NodePort> list = new() { inIngredient, outReadiness };
+			return list;
+		}
+
+		protected override void OnEvaluate(NodeExecutionContext context)
+		{
+			float ingredient = context.GetInput(inIngredient);
+			context.SetOutput(outReadiness, Mathf.Clamp01(ingredient));
+		}
+	}
+}


### PR DESCRIPTION
## 📋 관련된 TASK
- TASK-WM-048 (마도서 시스템) A2 단계 — 도메인 첫 박기
- 의존: PR #84 (A1 NodeDomain 분리 attribute) — base chained, A1 머지 후 자동 main 위 갱신

## 📝 PR 목적 및 의도

A1 의 NodeDomain 분리 attribute 의 *두 번째 도메인 첫 사용처*. 마도서 도메인 + 첫 노드 2개 (재료/마법) 박음. 시스템 인터페이스만 — 실제 챕터 콘텐츠 (따뜻함 등) 는 사용자 후속.

## 🛠️ 주요 변경 사항

### 신규 (4 파일, `Core/Scripts/MagicBook/`)
- `MagicBookCategory` enum — Doll / World / Self (research.md 3 카테고리 정합)
- `MagicBookGraph` SO — `NodeGraph` 상속, `Domain = MagicBook`. NodeGraphView 카탈로그 = 마도서 노드만
- `IngredientNode` — 재료 보유량 비율 (0~1) 출력. 매니저가 `SetGlobalInput("magicbook.ingredient.{itemId}", ratio)` 박음. 미설정 = 0 fallback
- `SpellNode` — `inIngredient` (float) → `outReadiness` (float). 본 단계 1:1 placeholder

## 🛡️ 데드 인터페이스 룰

A1 의 두 번째 도메인 사용처 = 본 PR. MagicBookGraph 카탈로그가 IngredientNode/SpellNode 두 개 등록.

## 🔮 후속 (TASK-WM-048 doc 참고)

- A3: prerequisites edge — 앞 SpellNode 완료 → 다음 노드 언락
- A4: multi-재료 합성 노드 (MagicBookSumNode / MinNode)
- B: 카테고리 UI 색상 / 그룹
- C: ResearchProgressManager — 활성 연구 단일 + later 목록 + Save 통합
- D: 진척 내레이션 5단계 SpellNode SerializeField
- E: 알리사 +20% 도움
- F: 마법 효과 시스템 (`SpellEffectSO`)
- G: UI — 마도서 책 view (UIToolkit + NodeGraphView 임베드)
- I: 테스트 챕터 (시스템 검증)

## ✅ 체크리스트
- [x] § 코딩 스타일 — `var` 금지 / Allman / `== false` / 풀네임
- [x] § 입력 처리 — N/A
- [x] § 에러 처리 — context 미설정 시 0 fallback (FastFail X 의도, 평가 자체는 보장)
- [ ] § 컴파일 에러 확인 — Unity Editor 검증 필요 (사용자 작업: 메인 디렉토리에 worktree branch checkout 후 reimport)
- [x] 데드 인터페이스 룰 (A1 두 번째 도메인 사용처)

## 🌳 워킹트리

본 PR = `git worktree` 첫 사용처. `karmoddrine/.worktrees/wm-048-a2-magicbook-graph/` 에서 작업. 룰 정본: `memo/systems/git-worktree-wm.md`.