### PR TITLE
feat(ci): TASK-WM-047 — Unity build gate (compile 게이트)

### DIFF
--- a/.github/workflows/unity-build-gate.yml
+++ b/.github/workflows/unity-build-gate.yml
@@ -1,0 +1,42 @@
+name: Unity Build Gate
+
+# C# 컴파일 게이트 — main assembly 가 컴파일 통과해야 PR 머지 가능.
+# 직전 사고 (TASK-WM-047): 다른 세션이 working tree 에서 UIStatus.Status 제거 후 사용처 fix
+# 안 한 채 commit/머지 → main broken. typos check 만으로는 못 잡음.
+# 본 게이트가 진짜 근본 차단 — game-ci/unity-test-runner 로 EditMode test 1개 (compile smoke) 실행.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # base 제한 없음 — chained PR 도 게이트.
+
+jobs:
+  editmode-tests:
+    name: EditMode tests (compile gate)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Cache Library
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-${{ runner.os }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-${{ runner.os }}-
+
+      - name: Run EditMode tests
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          unityVersion: 6000.4.5f1
+          testMode: EditMode
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          checkName: EditMode test results

--- a/Assets/_WitchMendokusai/Tests/EditMode/CompileSmokeTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/CompileSmokeTest.cs
@@ -1,0 +1,21 @@
+using NUnit.Framework;
+
+namespace WitchMendokusai.EditMode.Tests
+{
+	/// <summary>
+	/// Compile smoke test — Unity Editor 가 본 test 까지 도달했다는 것만으로 main assembly 컴파일 통과 보장.
+	///
+	/// 컴파일 게이트 효과는 *test 자체* 의 ref 가 아니라 **Unity Editor 시작 흐름** 에서 옴.
+	/// main assembly 빌드 실패 = Editor reload 실패 = test runner 시작 못 함 = `game-ci/unity-test-runner` action fail.
+	///
+	/// 즉 본 test 가 단순 `Assert.Pass` 라도 main syntax error / 타입 mismatch / missing symbol 자동 차단.
+	/// </summary>
+	public class CompileSmokeTest
+	{
+		[Test]
+		public void EditorAssembliesLoad()
+		{
+			Assert.Pass("Unity Editor reached test runner — main assembly compiled successfully.");
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/WitchMendokusai.EditMode.asmdef
+++ b/Assets/_WitchMendokusai/Tests/EditMode/WitchMendokusai.EditMode.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "WitchMendokusai.EditMode.Tests",
+    "rootNamespace": "WitchMendokusai.EditMode.Tests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}


### PR DESCRIPTION
## 📋 관련된 TASK
- TASK-WM-047 (Unity CI compile gate) B 단계 — workflow yml + dummy EditMode test

## 📝 PR 목적

main 컴파일 게이트. main assembly 빌드 실패 시 PR 머지 차단. 직전 사고 (UIStatus.Status 제거 broken / PR #74 conflict markers) 자동 차단.

## 🛠️ 주요 변경

- `.github/workflows/unity-build-gate.yml` — `game-ci/unity-test-runner@v4`, Unity 6000.4.5f1, EditMode test, Library cache
- `Assets/_WitchMendokusai/Tests/EditMode/CompileSmokeTest.cs` — `Assert.Pass()` 단일
- `WitchMendokusai.EditMode.Tests.asmdef`

## 🔑 컴파일 게이트 효과

test 자체 ref 가 아니라 **Unity Editor 시작 흐름** 에서 옴.
main assembly 빌드 실패 = Editor reload 실패 = test runner 시작 못 함 = action fail.

## ⚙️ 사용자 작업 (머지 전 필수)

1. Unity Hub → Manage license → Manual activation → .ulf 파일 추출
2. GitHub repo Settings → Secrets:
   - `UNITY_LICENSE` (.ulf 텍스트 내용)
   - `UNITY_EMAIL`
   - `UNITY_PASSWORD`
3. Branch protection (Settings → Branches → main):
   - Require status checks to pass — `EditMode tests (compile gate)` 추가

## 🌳 워킹트리

`karmoddrine/.worktrees/wm-047-unity-ci-gate/` 에서 작업.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 자동화된 빌드 검증을 위한 Unity EditMode 테스트 게이트 추가
  * 주 어셈블리의 컴파일 성공 여부를 확인하는 테스트 추가

* **Chores**
  * CI/CD 파이프라인에 자동 빌드 테스트 인프라 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->