### PR TITLE
feat(Narrative): TASK-WM-052 Phase 1.2 — DialogueLine SO + 데모 .asset

### DIFF
--- a/Assets/_WitchMendokusai/Content/Narrative.meta
+++ b/Assets/_WitchMendokusai/Content/Narrative.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d011c74bef9b497fa72e5f4c2685d211
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Content/Narrative/Demo.meta
+++ b/Assets/_WitchMendokusai/Content/Narrative/Demo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aa625b9263fd44bdba52a7f9f837e81a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Content/Narrative/Demo/DialogueLine_YawnGreeting.asset
+++ b/Assets/_WitchMendokusai/Content/Narrative/Demo/DialogueLine_YawnGreeting.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0ebc576b69c4346913885306e7755d4, type: 3}
+  m_Name: DialogueLine_YawnGreeting
+  m_EditorClassIdentifier: Assembly-CSharp::WitchMendokusai.DialogueLine
+  <ID>k__BackingField: 0
+  <Name>k__BackingField: "욘 귀환 인사"
+  <Description>k__BackingField: "데모 — 욘이 던전에서 돌아온 플레이어에게 던지는 인사"
+  <Sprite>k__BackingField: {fileID: 0}
+  <Sprites>k__BackingField: []
+  <Speaker>k__BackingField: {fileID: 0}
+  <Text>k__BackingField: "오, 돌아왔어? 수고했어."
+  <Portrait>k__BackingField: {fileID: 0}
+  <Sfx>k__BackingField: {fileID: 0}
+  <Wait>k__BackingField: 1
+  <Choices>k__BackingField: []

--- a/Assets/_WitchMendokusai/Content/Narrative/Demo/DialogueLine_YawnGreeting.asset.meta
+++ b/Assets/_WitchMendokusai/Content/Narrative/Demo/DialogueLine_YawnGreeting.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 33ebc3dfb05044099481d3a5f5c3009c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Core/Scripts/Narrative.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/Narrative.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b81e2ca89f44169aa1edfc00aaa6ef7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Core/Scripts/Narrative/DialogueLine.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Narrative/DialogueLine.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// 한 라인의 대사 데이터. Speaker 가 Text 를 말하고, Portrait/Sfx 로 연출.
+	/// Wait 후 다음 라인 (DialogueRunner — Phase 1.3 예정) 또는 Choices 분기.
+	/// Choices 는 Phase 2 (DialogueGraph 노드 통합) 에서 ChoiceNode 로 대체될 placeholder.
+	/// </summary>
+	[CreateAssetMenu(fileName = "DialogueLine_", menuName = "WM/Narrative/DialogueLine")]
+	public class DialogueLine : DataSO
+	{
+		[field: Header("_" + nameof(DialogueLine))]
+		[field: SerializeField] public DataSO Speaker { get; private set; }
+		[field: SerializeField, TextArea(3, 10)] public string Text { get; private set; }
+		[field: SerializeField] public Sprite Portrait { get; private set; }
+		[field: SerializeField] public AudioClip Sfx { get; private set; }
+		[field: SerializeField] public float Wait { get; private set; } = 0f;
+		[field: SerializeField] public List<DialogueLine> Choices { get; private set; } = new();
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/Narrative/DialogueLine.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/Narrative/DialogueLine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f0ebc576b69c4346913885306e7755d4


### PR DESCRIPTION
## Summary

TASK-WM-052 (스토리·대화·다이얼로그 시스템 인프라) Phase 1.2 — 대사 데이터 단위 SO + 첫 데모 .asset.

자율 모드 (`/autopilot`) 두 번째 ★. PR #92 (Phase 1.1 UGUI legacy 폐기) 와 독립 (base=main 분기).

### 신규 파일

| 파일 | 역할 |
|---|---|
| `Core/Scripts/Narrative/DialogueLine.cs` | DataSO 상속, Speaker/Text/Portrait/Sfx/Wait/Choices |
| `Content/Narrative/Demo/DialogueLine_YawnGreeting.asset` | 첫 데모 — "오, 돌아왔어? 수고했어." |
| `Core/Scripts/Narrative.meta`, `Content/Narrative.meta`, `Content/Narrative/Demo.meta` | 폴더 .meta (자동화 우선 — Unity Editor 트리거 없이 작성) |

### 설계 결정

- **DataSO 패턴 정확 활용** — ChapterSO 와 동일한 `[CreateAssetMenu(menuName = "WM/Narrative/DialogueLine")]` + base ID/Name/Description/Sprite 자동 노출.
- **Choices 필드 = Phase 2 placeholder** — 노드 그래프 (TASK-WM-051) 위 ChoiceNode 로 대체될 예정. Phase 1.2 에서는 단순 `List<DialogueLine>` 로 정의.
- **Portrait 별도 필드** — Speaker.Sprite (default) 와 별개로 라인별 표정 override 가능.

### Dead interface 회피

`DialogueLine` 호출처는 본 PR 에서 zero — `[feedback_dead_interface_avoid]` 룰의 *follow-up TASK 시드* 조건으로 만족 (TASK-WM-052 안 Phase 1.3 DialogueRunner 가 첫 호출처).

## Test plan

- [ ] **Unity Editor focus 후 Editor.log 확인** — `error CS` grep 0건, `DialogueLine` 심볼 reimport 확인
- [ ] **Project 창에서 `DialogueLine_YawnGreeting.asset` 열기** — Inspector 에 Speaker/Text/Portrait/Sfx/Wait/Choices 필드 정상 노출, Text "오, 돌아왔어? 수고했어." 표시
- [ ] **Right-click → Create → WM → Narrative → DialogueLine** — 새 .asset 생성 가능 확인
- [ ] **AssetDatabase reimport** — Console missing GUID / unsupported field 경고 0건

## 자율 모드 다음 ★

Phase 1.3 — **DialogueRunner** (line 시퀀스 실행 + typewriter + skip/advance + UIManager.SpeechBubble 통합) — 첫 호출처 보장.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — `/autopilot` 자율 개발 모드