### PR TITLE
docs(claude): § Git Workflow 보강 — Ready 전환 + auto-merge 게이트 + Closes #NN + Stack PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,53 @@ stale 이면:
 - `refactor/<주제>` — 동작 변화 없는 정리
 
 **첫 커밋 시 바로 Draft PR 생성** + `.github/pull_request_template.md` 의도 채움 →
-작업 진행하며 push → CodeRabbit 코멘트 대응 → 완료 시 PR 리뷰 후 머지.
+작업 진행하며 push → CodeRabbit 코멘트 대응 → **「§ Ready 전환 + auto-merge」 판단표 따라 Ready 자동 전환** (작은·격리 변경) 또는 Draft 유지 (큰·멀티 / 게이트 fail).
+
+### Ready 전환 + auto-merge
+
+`.github/workflows/auto-merge.yml` 가 `on: ready_for_review` + `if: draft == false` → `gh pr merge --auto --squash` 자동 호출. **Ready 전환만 되면 게이트 통과 후 squash 머지**. 따라서 모든 PR 을 Draft 로 두면 적체 — autopilot 룰 정본은 `karmoddrine/memo/dotfiles/claude-commands/autopilot.md` § Ready 전환 + auto-merge 게이트.
+
+판단표 (모두 충족 시 Ready 자동):
+- 변경 ≤ 150 LOC
+- 단일 sub TASK
+- 게이트 통과 (Code Quality + Unity build gate, `error CS` 0)
+- stack 의존 base 없음 (또는 base 가 main)
+- 새 인터페이스 = 첫 사용처 동봉 (데드 인터페이스 회피)
+- Test plan 의 "사용자 검증 필요" 항목 0
+
+호출:
+```bash
+gh pr ready <num>
+gh pr merge --auto --squash <num>   # idempotent — auto-merge.yml 이 중복 호출해도 OK
+```
+
+미충족 시 PR description 에 "**Draft 사유**: <한 줄>" 명시 후 Draft 유지.
+
+### Closes #NN — Issue 자동 종료
+
+PR description 에 관련 GitHub Issue 명시:
+- TASK 시드에 Issue link 가 있거나 1:1 매핑이면 PR 본문 끝에 `Closes #NN`
+- 머지 시 Issue 자동 close — wishlist 누적 방지
+- 매핑 없으면 박지 X (스팸 X)
+
+### Stack PR 자동 promote
+
+base 가 다른 feature 브랜치인 stack PR 은 base 머지 시 GitHub 가 자동으로 main 으로 retarget. retarget 된 PR 도 Ready + auto-merge enabled 면 게이트 통과 후 자동 머지 → 연쇄. **stack 깊어도 base 만 풀리면 다 풀림**.
+
+### Post-merge 정리
+
+`delete_branch_on_merge: true` (repo 설정 — 원격 자동 삭제). 로컬 잔여만 정리:
+
+```powershell
+git fetch -p
+git branch -vv | Select-String ': gone\]' | ForEach-Object { ($_ -split '\s+')[1] } | ForEach-Object { git branch -D $_ }
+```
+
+자율 모드는 자기 워크트리도 정리:
+
+```bash
+git worktree remove ../.worktrees/<name>
+```
 
 ### 예외 — `main` 직접 push 허용
 
@@ -242,7 +288,21 @@ Conventional Commits — `feat: / fix: / chore: / refactor: / docs: / style: / t
 
 룰을 *기계적으로 강제* 하려면 GitHub repo → Settings → Branches 에서 `main` 에 다음 protection rule:
 - Require a pull request before merging
-- Require status checks to pass (Code Quality CI 통과 필수)
+- Require status checks to pass:
+  - `Check Typos` (현재 등록됨, 단 `continue-on-error: true` — 사실상 게이트 0. workflow 에서 `continue-on-error` 제거 필요)
+  - `EditMode tests (compile gate)` — TASK-WM-047 (PR #89) 머지 + Unity license secrets (`UNITY_LICENSE`/`UNITY_EMAIL`/`UNITY_PASSWORD`) 등록 후 추가
 - Restrict who can push to matching branches (직접 push 차단)
 
-이 설정 안 되어있으면 본 § 룰은 *수동 약속* 만 됨.
+이 설정 안 되어있으면 본 § 룰은 *수동 약속* 만 됨. *auto-merge* 도 게이트가 약하면 위험 — Unity build gate 머지 후 protection 강화 필수.
+
+설정 명령 (사용자 실행, 게이트 등록 후):
+
+```bash
+gh api -X PUT repos/Mascari4615/Witch-Mendokusai/branches/main/protection \
+  -f required_status_checks.strict=true \
+  -F 'required_status_checks.contexts[]=Check Typos' \
+  -F 'required_status_checks.contexts[]=EditMode tests (compile gate)' \
+  -F enforce_admins=false \
+  -F required_pull_request_reviews=null \
+  -F restrictions=null
+```


### PR DESCRIPTION
## Summary

`memo/dotfiles/claude-commands/autopilot.md` § Ready 전환 + auto-merge 게이트 룰 (memo main 50fb4c9) 와 정합 보강. CodeRabbit 자동 픽업.

## 변경

- **Ready 전환 + auto-merge** 절 신설 — 판단표 6 조건 (≤ 150 LOC + 단일 sub + 게이트 통과 + base=main + 첫 사용처 + 미검증 0) + 호출 순서 (`gh pr ready` + `gh pr merge --auto --squash`) + Draft 사유 명시 룰.
- **Closes #NN** — Issue 자동 종료 (TASK ↔ Issue 매핑 있을 때만, 없으면 박지 X).
- **Stack PR 자동 promote** — base 머지 시 GitHub 가 main 으로 retarget + 연쇄 머지.
- **Post-merge 정리** — `git fetch -p` + 로컬 잔여 브랜치 일괄 삭제 powershell 1줄.
- **Branch Protection 보강** — `Check Typos` 의 `continue-on-error: true` 제거 필요 명시 + Unity build gate (PR #89) 등록 절차 + `gh api` 예시.

## Draft 사유

Branch protection 게이트가 약함 (`Check Typos` 만 + `continue-on-error: true` → 사실상 게이트 0). 자동 머지 활성화 위험. **PR #89 머지 + 사용자 protection 강화 후** Ready 전환.

## Test plan

- [ ] CodeRabbit 룰 본문 정독 (다음 PR 부터 자동 적용 여부)
- [ ] 신 룰의 첫 적용 PR (작은·격리 변경) 으로 Ready 자동 전환 → auto-merge.yml trigger 동작 검증