### PR TITLE
feat(ci): Auto-Rebase workflow — main 머지 후 stale PR 자동 update + Claude conflict fix

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -1,0 +1,54 @@
+name: Auto Rebase Open PRs
+
+# main 머지 후 모든 open PR (non-draft, base=main) 자동 update — main 의 변경을 PR 브랜치로 merge.
+# stack PR (base=다른 feature) 은 GitHub 가 자동 retarget 처리하니 본 워크플로 대상 X.
+# conflict 시 PR 코멘트로 @claude 멘션 → claude.yml 의 claude job trigger → Claude 가 자동 conflict 해결.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: auto-rebase
+  cancel-in-progress: false
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Update all open PRs base=main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -e
+
+          PR_NUMBERS=$(gh pr list --base main --state open --limit 100 \
+            --json number,isDraft \
+            --jq '.[] | select(.isDraft == false) | .number')
+
+          if [ -z "$PR_NUMBERS" ]; then
+            echo "No open Ready PRs to update."
+            exit 0
+          fi
+
+          for pr in $PR_NUMBERS; do
+            echo "::group::Updating PR #$pr"
+            if gh pr update-branch "$pr" 2>&1; then
+              echo "PR #$pr updated successfully."
+            else
+              echo "PR #$pr update-branch failed (likely conflict). Adding @claude mention."
+              gh pr comment "$pr" --body "@claude main 머지 후 본 PR 업데이트 시도했지만 conflict 발생. main 의 최신 변경을 본 브랜치에 통합하고 conflict 를 해결해주세요.
+
+              **요구**:
+              - conflict marker (\`<<<<<<<\`, \`=======\`, \`>>>>>>>\`) 모두 제거
+              - 본 PR 의 의도 보존 (주제 = PR title)
+              - main 의 변경 의미도 보존 (단순 \`ours\` strategy 로 무시 X)
+              - 의미 충돌이면 main 의 변경을 우선 (PR description 에 conflict 해결 후 검토 메모 1줄 추가)
+              - 해결 후 본 브랜치에 push"
+            fi
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## Summary

main push 시 모든 open Ready PR 자동 update-branch (main → PR 머지). conflict 시 @claude 멘션 코멘트 → claude.yml 의 claude job trigger → Claude 자동 conflict 해결 + push.

## 근본

- 동시 다발 PR 환경에서 main 변동 → 다른 PR stale → conflict 누적 (어제 #88 #92 #90 #83 #78 다섯 개 CONFLICTING 발생 사례)
- 자작 workflow + GitHub native `gh pr update-branch` API + Anthropic 공식 `claude-code-action` (이미 도입)
- third-party 의존 0 (Mergify 등 안 씀)

## 설계

| 단계 | 동작 |
|---|---|
| main push trigger | 모든 open PR (base=main, non-draft) 조회 |
| update-branch 시도 | 통과 시 PR 자동 stale 해소 |
| conflict 발생 | @claude 멘션 PR 코멘트 |
| claude.yml trigger | Claude 가 conflict 해결 + push |
| 다음 main push | 다시 update-branch (자동 cascade) |

## 의존

- `auto-merge.yml` (Ready PR 자동 머지) ← 이미 main
- `claude.yml` (claude / claude-coderabbit / claude-copilot job) ← 이미 main, OAuth secret 등록됨
- `code-quality.yml` (typo 게이트) ← PR #100 머지 후 강화

## Test plan

- [ ] 본 PR 머지 → 다음 PR 머지 시 main push trigger → auto-rebase 가 모든 open PR 업데이트
- [ ] conflict 발생 PR 에 @claude 멘션 잘 들어가는지
- [ ] Claude 가 코멘트 받아 conflict 해결 + push 동작 검증