### PR TITLE
fix(ci): auto-rebase 의 GH_TOKEN 을 BOT_TOKEN (PAT) 으로 교체

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -21,7 +21,9 @@ jobs:
     steps:
       - name: Update all open PRs base=main
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # BOT_TOKEN (PAT) 사용 — GITHUB_TOKEN 으로 만든 코멘트는 GitHub 의 재귀 방지로
+          # 다른 workflow (claude.yml) 를 trigger 안 시킴. PAT 으로 만든 코멘트는 정상 trigger.
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -e


### PR DESCRIPTION
## 진단

PR #93 머지 후 Auto-Rebase 첫 trigger 검증 — #88/#83 conflict 시 @claude 멘션 코멘트 등록은 됐지만 claude.yml trigger X.

원인: `secrets.GITHUB_TOKEN` 으로 만든 issue_comment 는 *재귀 방지* 로 다른 workflow trigger 안 시킴.

## 근본

PAT (Personal Access Token) 으로 코멘트 → 정상 issue_comment event trigger → claude.yml 깨움.
- GitHub 공식 기능 (third-party 0)
- 사용자 PAT 발급 + `BOT_TOKEN` secret 등록 완료

## 변경

`auto-rebase.yml` 의 `GH_TOKEN: secrets.GITHUB_TOKEN` → `secrets.BOT_TOKEN`. 1줄.

## 자동 폐쇄 루프 (이 PR 머지 후)

```
PR opened (Default Ready) → auto-merge enable
                          → 머지 → main push
                                 → Auto-Rebase trigger
                                   ├─ 통과 PR: 자동 stale 해소
                                   └─ conflict PR: @claude 멘션 (PAT)
                                                  → Claude Code trigger
                                                  → Claude 자동 conflict 해결 + push
                                                  → 다시 Auto-Rebase 통과
```

## 검증 (머지 후)

- [ ] 다음 main push 시 Auto-Rebase 의 conflict 코멘트가 Claude Code workflow trigger
- [ ] PR #88 또는 #83 의 @claude 코멘트 → Claude 자동 conflict 해결 시도

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 풀 요청 충돌 해결 프로세스가 개선되었습니다. 자동화된 봇 코멘트가 다운스트림 충돌 해결 워크플로우를 효과적으로 트리거할 수 있으며, 플랫폼의 재귀 방지 기능에 의해 더 이상 차단되지 않습니다. 이를 통해 `main` 브랜치로의 푸시 시 열린 풀 요청이 보다 원활하게 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->