### PR TITLE
fix(ci): auto-merge 의 GH_TOKEN 도 BOT_TOKEN (PAT) 으로 교체

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,5 +15,8 @@ jobs:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # BOT_TOKEN (PAT) 사용 — GITHUB_TOKEN 으로 머지된 squash commit 의 main push event 는
+          # GitHub 의 재귀 방지로 다른 workflow (Auto Rebase) 를 trigger 안 시킴.
+          # PAT 으로 머지하면 정상 push event trigger.
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## 진단

PR #102 머지 후 Auto-Rebase workflow trigger X. 다른 WF 도 main push event 못 받음.

원인: auto-merge.yml 가 GITHUB_TOKEN 으로 squash merge 호출 → bot actor 머지 → push event 가 다른 workflow trigger 안 시킴 (재귀 방지).

PR #93 만 trigger 됐던 이유 = 사용자가 직접 `gh pr merge` 호출 → user actor.

## 근본

auto-merge.yml 도 BOT_TOKEN (PAT) 사용 → user actor 머지 → push event 정상 trigger.

## 자동 폐쇄 루프 (이 PR 머지 후 완성)

```
PR opened (Default Ready)
  → auto-merge enable (BOT_TOKEN, user actor)
  → 게이트 통과 → 머지 (user actor)
  → main push event ✅
  → Auto-Rebase trigger ✅
    ├─ 통과 PR: 자동 stale 해소
    └─ conflict PR: @claude 멘션 (BOT_TOKEN, user actor)
                  → Claude Code workflow trigger ✅
                  → Claude 자동 conflict 해결 + push
```

## 검증 (이 PR 머지 직후)

이 PR 머지가 *user actor* 가 되면 자동 폐쇄 루프 완성:
- main push event → Auto-Rebase 자동 trigger
- conflict PR (#88, #83) 에 @claude 코멘트 등록 → Claude Code 자동 trigger
- Claude 가 conflict 해결 시도 → push → cascade

## Test plan

- [ ] 본 PR 자동 머지
- [ ] 다음 main push event 가 Auto-Rebase trigger
- [ ] PR #88 / #83 의 @claude 코멘트가 Claude Code workflow trigger