### PR TITLE
feat(ci): auto-rebase trigger 4개로 보강 — bot 머지 / 정기 cron / 수동 dispatch

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -5,8 +5,19 @@ name: Auto Rebase Open PRs
 # conflict 시 PR 코멘트로 @claude 멘션 → claude.yml 의 claude job trigger → Claude 가 자동 conflict 해결.
 
 on:
+  # 1. main push event — 사용자 직접 머지 (user actor) 시 trigger.
   push:
     branches: [main]
+  # 2. workflow_run — Auto Merge 가 끝난 후 보강. bot enabledBy 머지 케이스 (push event 가 다른 workflow trigger 안 시키는 GitHub 한계) 우회.
+  workflow_run:
+    workflows: ["Auto Merge"]
+    types: [completed]
+    branches: [main]
+  # 3. schedule cron — 30분마다 안전망. 위 두 trigger 가 모두 놓친 경우 정기 stale 체크.
+  schedule:
+    - cron: '*/30 * * * *'
+  # 4. manual dispatch — 사용자가 GitHub UI 에서 직접 trigger 가능.
+  workflow_dispatch:
 
 concurrency:
   group: auto-rebase


### PR DESCRIPTION
## 진단

검증 결과 main push event 가 *bot enabledBy* auto-merge 머지 후엔 다른 workflow trigger X (GitHub 재귀 방지). PR #84 #85 머지 후 Auto-Rebase trigger 안 됨.

## 근본 보강

trigger 4개로 *어떤 머지 경로* 든 보장:
1. `push branches:[main]` — 사용자 직접 머지 시 (기존)
2. `workflow_run` Auto Merge completed — bot 머지 케이스 보강
3. `schedule '*/30 * * * *'` — 30분 안전망
4. `workflow_dispatch` — UI 수동 trigger

머지 후 *최대 30분* 내 모든 open Ready PR update-branch 보장.