### PR TITLE
feat(time): TASK-WM-054-A — WorldClock 시간 모델

### DIFF
--- a/Assets/_WitchMendokusai/Core/Resources/Singletons/WorldClock.prefab
+++ b/Assets/_WitchMendokusai/Core/Resources/Singletons/WorldClock.prefab
@@ -1,0 +1,63 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &840407556034966104
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2010681962905894300}
+  - component: {fileID: 6770155674362151715}
+  - component: {fileID: 7795926539809232741}
+  m_Layer: 0
+  m_Name: WorldClock
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2010681962905894300
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840407556034966104}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6770155674362151715
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840407556034966104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c037d9c37fc5e1344b6f2264931eb0cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::WitchMendokusai.WorldClock
+  dontDestroyOnLoad: 1
+  <Config>k__BackingField: {fileID: 11400000, guid: 8540101b38ba61f4cb71505de2da30a3, type: 2}
+--- !u!114 &7795926539809232741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840407556034966104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 706120d0e901d04469015d9a0bab265a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::WitchMendokusai.WorldClockHUD
+  show: 1
+  anchor: {x: 10, y: 10}

--- a/Assets/_WitchMendokusai/Core/Resources/Singletons/WorldClock.prefab.meta
+++ b/Assets/_WitchMendokusai/Core/Resources/Singletons/WorldClock.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 32d5f063436fc68419b2c26163c4e4b3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Core/Resources/WorldClockSO.asset
+++ b/Assets/_WitchMendokusai/Core/Resources/WorldClockSO.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4373d07b0d4f454babd175fabc2c8b4, type: 3}
+  m_Name: WorldClockSO
+  m_EditorClassIdentifier: Assembly-CSharp::WitchMendokusai.WorldClockSO
+  <MinutesPerRealSecond>k__BackingField: 2
+  <StartHour>k__BackingField: 6
+  <StartMinute>k__BackingField: 0
+  <HoursPerDay>k__BackingField: 24
+  <DaysPerSeason>k__BackingField: 28
+  <SeasonsPerYear>k__BackingField: 4

--- a/Assets/_WitchMendokusai/Core/Resources/WorldClockSO.asset.meta
+++ b/Assets/_WitchMendokusai/Core/Resources/WorldClockSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8540101b38ba61f4cb71505de2da30a3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Core/Scripts/Time/Debug.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/Time/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f94d5aefd7244ca45ae08c84de5f1139
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Core/Scripts/Time/Debug/WorldClockHUD.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Time/Debug/WorldClockHUD.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// WorldClock 디버그 HUD (IMGUI). 시각 표시 + 속도 슬라이더 (런타임 tweak) + Skip 버튼.
+	// WorldClock.OnHourChanged 첫 사용처 — 데드 인터페이스 방지. (TASK-WM-054-A)
+	public class WorldClockHUD : MonoBehaviour
+	{
+		[SerializeField] private bool show = true;
+		[SerializeField] private Vector2 anchor = new Vector2(10, 10);
+
+		private string lastHourEvent = "(none)";
+		private GUIStyle labelStyle;
+
+		private void OnEnable()
+		{
+			if (WorldClock.TryGetExistingInstance(out WorldClock worldClock) == false)
+				return;
+
+			worldClock.OnHourChanged += HandleHourChanged;
+		}
+
+		private void OnDisable()
+		{
+			if (WorldClock.TryGetExistingInstance(out WorldClock worldClock) == false)
+				return;
+
+			worldClock.OnHourChanged -= HandleHourChanged;
+		}
+
+		private void HandleHourChanged(int hour) => lastHourEvent = $"hour → {hour}";
+
+		private void OnGUI()
+		{
+			if (show == false)
+				return;
+
+			if (WorldClock.TryGetExistingInstance(out WorldClock worldClock) == false)
+				return;
+
+			if (worldClock.Config == null)
+				return;
+
+			EnsureStyles();
+
+			float width = 340f;
+			float height = 130f;
+			Rect rect = new Rect(anchor.x, anchor.y, width, height);
+			GUI.Box(rect, GUIContent.none);
+
+			GUILayout.BeginArea(new Rect(anchor.x + 10, anchor.y + 8, width - 20, height - 16));
+
+			GUILayout.Label($"<b>WorldClock</b>  {worldClock.ToDebugString()}", labelStyle);
+			GUILayout.Label($"paused: {worldClock.IsClockPaused}  /  last: {lastHourEvent}", labelStyle);
+
+			GUILayout.BeginHorizontal();
+			GUILayout.Label($"speed: {worldClock.Config.MinutesPerRealSecond:F1} min/sec", labelStyle, GUILayout.Width(170));
+			float newSpeed = GUILayout.HorizontalSlider(worldClock.Config.MinutesPerRealSecond, 0.1f, 600f);
+			if (Mathf.Approximately(newSpeed, worldClock.Config.MinutesPerRealSecond) == false)
+				worldClock.Config.MinutesPerRealSecond = newSpeed;
+			GUILayout.EndHorizontal();
+
+			if (GUILayout.Button("Skip to next day"))
+				worldClock.SkipToNextDay();
+
+			GUILayout.EndArea();
+		}
+
+		private void EnsureStyles()
+		{
+			if (labelStyle != null)
+				return;
+
+			labelStyle = new GUIStyle(GUI.skin.label) { richText = true, fontSize = 12 };
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/Time/Debug/WorldClockHUD.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/Time/Debug/WorldClockHUD.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 706120d0e901d04469015d9a0bab265a

--- a/Assets/_WitchMendokusai/Core/Scripts/Time/SeasonSO.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Time/SeasonSO.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	[CreateAssetMenu(fileName = nameof(SeasonSO), menuName = "WM/SeasonSO")]
+	public class SeasonSO : ScriptableObject
+	{
+		[field: Header("_" + nameof(SeasonSO))]
+		[field: SerializeField] public string DisplayName { get; private set; } = "";
+		[field: SerializeField] public Color Tint { get; private set; } = Color.white;
+
+		// sub-D (WeatherSystem) 진입 시 weather weight table / BGM clip 등 추가
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/Time/SeasonSO.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/Time/SeasonSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef7c27fafb1b23341855fba00757d9c9

--- a/Assets/_WitchMendokusai/Core/Scripts/Time/WorldClock.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Time/WorldClock.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// 게임 내부 시각 (시·분·일·계절·년) 모델. TimeManager.OnTick 에 hook 해서 advance.
+	// SO 값 캐싱 X — 인스펙터 런타임 변경 즉시 반영. (TASK-WM-054-A)
+	public class WorldClock : Singleton<WorldClock>
+	{
+		[field: SerializeField] public WorldClockSO Config { get; private set; }
+
+		public int Year { get; private set; }
+		public int Season { get; private set; }
+		public int Day { get; private set; }
+		public int Hour { get; private set; }
+		public int Minute { get; private set; }
+
+		// payload 채널 — 변경된 새 값 직접 전달
+		public event Action<int> OnHourChanged = delegate { };
+		public event Action<int> OnDayChanged = delegate { };
+		public event Action<int> OnSeasonChanged = delegate { };
+
+		// 시계 정지 (게임 전체 정지 X — TimeManager.Pause 와 분리, 시계만 멈춤)
+		private readonly List<GameObject> pausers = new();
+		public bool IsClockPaused => pausers.Count > 0;
+
+		// TICK 단위 누적 sub-minute (실수 분량의 게임 분)
+		private float minuteAccumulator;
+
+		protected override void Awake()
+		{
+			base.Awake();
+			ResetToConfigStart();
+		}
+
+		private void Start()
+		{
+			TimeManager.Instance.RegisterCallback(AdvanceTick);
+		}
+
+		protected override void OnDestroy()
+		{
+			if (TimeManager.TryGetExistingInstance(out TimeManager timeManager) == true)
+				timeManager.RemoveCallback(AdvanceTick);
+
+			base.OnDestroy();
+		}
+
+		private void ResetToConfigStart()
+		{
+			Year = 1;
+			Season = 0;
+			Day = 1;
+			Hour = Config.StartHour;
+			Minute = Config.StartMinute;
+			minuteAccumulator = 0f;
+		}
+
+		private void AdvanceTick()
+		{
+			if (IsClockPaused == true)
+				return;
+
+			// SO 값 매 tick 다시 읽음 — 런타임 tweak 즉시 반영
+			float deltaMinutes = Config.MinutesPerRealSecond * TimeManager.TICK;
+			minuteAccumulator += deltaMinutes;
+
+			int wholeMinutes = (int)minuteAccumulator;
+			if (wholeMinutes <= 0)
+				return;
+
+			minuteAccumulator -= wholeMinutes;
+			ApplyMinutes(wholeMinutes);
+		}
+
+		private void ApplyMinutes(int minutesToAdd)
+		{
+			int newMinute = Minute + minutesToAdd;
+			int hourCarry = newMinute / 60;
+			Minute = newMinute % 60;
+
+			if (hourCarry <= 0)
+				return;
+
+			ApplyHours(hourCarry);
+		}
+
+		private void ApplyHours(int hoursToAdd)
+		{
+			int newHour = Hour + hoursToAdd;
+			int dayCarry = newHour / Config.HoursPerDay;
+			Hour = newHour % Config.HoursPerDay;
+
+			OnHourChanged.Invoke(Hour);
+
+			if (dayCarry <= 0)
+				return;
+
+			ApplyDays(dayCarry);
+		}
+
+		private void ApplyDays(int daysToAdd)
+		{
+			int newDay = Day + daysToAdd;
+			int seasonCarry = (newDay - 1) / Config.DaysPerSeason;
+			Day = ((newDay - 1) % Config.DaysPerSeason) + 1;
+
+			OnDayChanged.Invoke(Day);
+
+			if (seasonCarry <= 0)
+				return;
+
+			ApplySeasons(seasonCarry);
+		}
+
+		private void ApplySeasons(int seasonsToAdd)
+		{
+			int newSeason = Season + seasonsToAdd;
+			int yearCarry = newSeason / Config.SeasonsPerYear;
+			Season = newSeason % Config.SeasonsPerYear;
+
+			OnSeasonChanged.Invoke(Season);
+
+			if (yearCarry <= 0)
+				return;
+
+			Year += yearCarry;
+		}
+
+		public void PauseClock(GameObject pauser)
+		{
+			if (pauser == null)
+				return;
+
+			if (pausers.Contains(pauser) == true)
+				return;
+
+			pausers.Add(pauser);
+		}
+
+		public void ResumeClock(GameObject pauser)
+		{
+			if (pauser == null)
+				return;
+
+			pausers.Remove(pauser);
+		}
+
+		public void SkipTo(int targetHour)
+		{
+			if (targetHour < 0 || targetHour >= Config.HoursPerDay)
+			{
+				Debug.LogWarning($"[{nameof(WorldClock)}] SkipTo: invalid hour {targetHour}");
+				return;
+			}
+
+			int hoursToAdd;
+			if (targetHour > Hour)
+				hoursToAdd = targetHour - Hour;
+			else
+				hoursToAdd = (Config.HoursPerDay - Hour) + targetHour;
+
+			Minute = 0;
+			ApplyHours(hoursToAdd);
+		}
+
+		public void SkipDays(int days)
+		{
+			if (days <= 0)
+				return;
+
+			ApplyDays(days);
+		}
+
+		// Play Mode 시작 + 씬 로드 후 Singleton 자동 ensure (lazy load 트리거).
+		// 없으면 prefab 안의 WorldClockHUD 가 활성화 안 돼 시계가 흐르지 않는다.
+		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+		private static void EnsureSingletonOnPlay()
+		{
+			_ = Instance;
+		}
+
+		[ContextMenu(nameof(SkipToNextDay))]
+		public void SkipToNextDay() => SkipTo(Config.StartHour);
+
+		[ContextMenu("Debug/Skip 1 Hour")]
+		private void DebugSkipOneHour() => ApplyHours(1);
+
+		public string ToDebugString() => $"Y{Year} S{Season + 1} D{Day} {Hour:D2}:{Minute:D2}";
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/Time/WorldClock.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/Time/WorldClock.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c037d9c37fc5e1344b6f2264931eb0cd

--- a/Assets/_WitchMendokusai/Core/Scripts/Time/WorldClockSO.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Time/WorldClockSO.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	[CreateAssetMenu(fileName = nameof(WorldClockSO), menuName = "WM/WorldClockSO")]
+	public class WorldClockSO : ScriptableObject
+	{
+		[field: Header("_" + nameof(WorldClockSO))]
+		[field: Tooltip("1초 (실시간) 당 진행되는 게임 분. 디폴트 2 → 1게임일 = 12실분")]
+		[field: SerializeField, Range(0.1f, 600f)]
+		public float MinutesPerRealSecond { get; set; } = 2f;
+
+		[field: Header("시작 시각")]
+		[field: SerializeField, Range(0, 23)] public int StartHour { get; set; } = 6;
+		[field: SerializeField, Range(0, 59)] public int StartMinute { get; set; } = 0;
+
+		[field: Header("길이")]
+		[field: SerializeField, Range(1, 48)] public int HoursPerDay { get; set; } = 24;
+		[field: SerializeField, Range(1, 100)] public int DaysPerSeason { get; set; } = 28;
+		[field: SerializeField, Range(1, 12)] public int SeasonsPerYear { get; set; } = 4;
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/Time/WorldClockSO.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/Time/WorldClockSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f4373d07b0d4f454babd175fabc2c8b4

--- a/Assets/_WitchMendokusai/Editor/Time.meta
+++ b/Assets/_WitchMendokusai/Editor/Time.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f229b8b26bb69340823a6a074b45ddc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Editor/Time/WorldClockBootstrapMenu.cs
+++ b/Assets/_WitchMendokusai/Editor/Time/WorldClockBootstrapMenu.cs
@@ -1,0 +1,89 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// WorldClockSO.asset + WorldClock.prefab (with WorldClockHUD) 자동 생성.
+	// Domain Reload 시 missing 검사 + 누락이면 자동 생성. (TASK-WM-054-A)
+	public static class WorldClockBootstrapMenu
+	{
+		private const string SO_PATH = "Assets/_WitchMendokusai/Core/Resources/WorldClockSO.asset";
+		private const string PREFAB_PATH = "Assets/_WitchMendokusai/Core/Resources/Singletons/WorldClock.prefab";
+
+		[InitializeOnLoadMethod]
+		private static void AutoBootstrapIfMissing()
+		{
+			if (AssetDatabase.LoadAssetAtPath<GameObject>(PREFAB_PATH) == null)
+			{
+				CreateBootstrap();
+				return;
+			}
+
+			EnsurePrefabFlags();
+		}
+
+		[MenuItem("WM/Setup/Recreate WorldClock Bootstrap")]
+		private static void RecreateMenuItem() => CreateBootstrap();
+
+		private static void CreateBootstrap()
+		{
+			WorldClockSO worldClockSO = AssetDatabase.LoadAssetAtPath<WorldClockSO>(SO_PATH);
+			if (worldClockSO == null)
+			{
+				worldClockSO = ScriptableObject.CreateInstance<WorldClockSO>();
+				AssetDatabase.CreateAsset(worldClockSO, SO_PATH);
+				Debug.Log($"[WorldClockBootstrap] Created {SO_PATH}");
+			}
+
+			GameObject root = new GameObject(nameof(WorldClock));
+			WorldClock worldClock = root.AddComponent<WorldClock>();
+			root.AddComponent<WorldClockHUD>();
+
+			SerializedObject serializedObject = new SerializedObject(worldClock);
+
+			SerializedProperty configProperty = serializedObject.FindProperty("<Config>k__BackingField");
+			if (configProperty != null)
+				configProperty.objectReferenceValue = worldClockSO;
+
+			SerializedProperty dontDestroyProp = serializedObject.FindProperty("dontDestroyOnLoad");
+			if (dontDestroyProp != null)
+				dontDestroyProp.boolValue = true;
+
+			serializedObject.ApplyModifiedProperties();
+
+			PrefabUtility.SaveAsPrefabAsset(root, PREFAB_PATH);
+			Object.DestroyImmediate(root);
+
+			AssetDatabase.SaveAssets();
+			AssetDatabase.Refresh();
+
+			Debug.Log($"[WorldClockBootstrap] Created {PREFAB_PATH}");
+		}
+
+		// 기존 prefab 의 SerializedField 보정 (dontDestroyOnLoad 등). idempotent.
+		private static void EnsurePrefabFlags()
+		{
+			GameObject prefabRoot = PrefabUtility.LoadPrefabContents(PREFAB_PATH);
+			try
+			{
+				WorldClock worldClock = prefabRoot.GetComponent<WorldClock>();
+				if (worldClock == null)
+					return;
+
+				SerializedObject serializedObject = new SerializedObject(worldClock);
+				SerializedProperty dontDestroyProp = serializedObject.FindProperty("dontDestroyOnLoad");
+				if (dontDestroyProp == null || dontDestroyProp.boolValue == true)
+					return;
+
+				dontDestroyProp.boolValue = true;
+				serializedObject.ApplyModifiedProperties();
+				PrefabUtility.SaveAsPrefabAsset(prefabRoot, PREFAB_PATH);
+				Debug.Log($"[WorldClockBootstrap] Updated {PREFAB_PATH} (dontDestroyOnLoad=true)");
+			}
+			finally
+			{
+				PrefabUtility.UnloadPrefabContents(prefabRoot);
+			}
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Editor/Time/WorldClockBootstrapMenu.cs.meta
+++ b/Assets/_WitchMendokusai/Editor/Time/WorldClockBootstrapMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5723de59009bc584daa077db06a9d846

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,17 @@ TASK 시드의 단계 분할 표(A1/A2/A3...)는 *합의된 작업 단위*다. �
 
 새 시스템이 *우리 패턴과 다른 모양*이라면 *이유*를 TASK 시드에 명시한다.
 
+## 수치 노출 / 런타임 tweak
+
+게임 시스템의 모든 *수치·시간·길이·가중치·확률* 은 하드코딩 금지. SO / `[SerializeField]` / `Variable<T>` 로 노출하고, **인스펙터에서 런타임 변경 → 즉시 반영** 되는 구조로 작성한다.
+
+- 매니저는 SO 값 캐싱 X — 매 사용 시 다시 읽거나, 캐싱하면 변경 감지 후 갱신
+- 자주 tweak 하는 값은 디버그 HUD 슬라이더 노출 (인스펙터 안 열어도 in-play tweak 가능해야)
+- 같은 수치 두 곳에 박기 X — SO 가 정본, 매니저는 참조만
+- 예외: 컴파일 타임 상수 (`const`) — frame 0, GameObject 키 문자열 등
+
+이유: 런타임에 수치 못 바꾸면 디자인 iteration 비용 폭증. tweak 가능성은 *시스템 가치의 일부*. WM 의 "다른 게임 좋은 시스템 다 흡수" 비전과 직결.
+
 ## 에러 처리 — FastFail 유지
 
 에러를 삼키는 방어 코드(TryGet, null 체크, 기본값 반환)로 증상을 덮지 말고,
@@ -188,10 +199,15 @@ Unity Editor 가 **foreground (focus)** 상태가 아니면 .cs 변경 reimport 
 - `Reloading assemblies after forced synchronous recompile.` 로그의 *시점* — 내 변경 후인지 확인
 - `Refresh completed in ...` 으로 import 세션 끝 시점 확인
 
-stale 이면:
-- 사용자에게 **Unity Editor focus 명시 요청** — "Editor 창 클릭해서 자동 reimport 시켜주세요"
-- 또는 `Ctrl+R` (Refresh) 안내
-- reimport 후 다시 grep "error CS" 로 본인 검증
+stale 이면 — **자동화 우선**:
+1. **`pwsh memo/dotfiles/scripts/unity-refresh.ps1`** 호출 — Unity 창 `SetForegroundWindow` → Auto Refresh 트리거. 사용자에게 "Editor 창 클릭" 요청 X
+2. **sleep ~25초** — 컴파일 + Domain Reload + `[InitializeOnLoadMethod]` 까지 충분 (4~5 신규 .cs 기준; 더 많으면 30초 이상)
+3. **Editor.log grep** — `error CS` 0 + `Reloading assemblies after forced synchronous recompile` 새 매치 (이전 max line 보다 큰 line) 으로 컴파일 완료 검증
+
+자동화 한계 (이때만 사용자 손 요청):
+- Unity 창이 *이미 foreground* 면 `SetForegroundWindow` no-op (focus 이벤트 X) — 우회: PowerShell `SendKeys ^r` 또는 사용자가 다른 창 잠시 클릭 후 재호출
+- Auto Refresh OFF 면 무용 — `Edit > Preferences > Asset Pipeline > Auto Refresh` 설정 사용자 컨펌 1회
+- 신규 폴더의 파일은 fsnotify 가 가끔 누락 → Project 패널에서 폴더 한 번 클릭 또는 Editor 재시작
 
 ### 새 .cs 파일 만들었을 때
 
@@ -208,6 +224,22 @@ stale 이면:
 이전 사례: TASK-WM-034 B (NodeGraph GraphView UI) — `Func<GraphViewChange, GraphViewChange>` vs `GraphView.GraphViewChanged` delegate 타입 mismatch 컴파일 에러를 사용자가 먼저 발견. 본인이 Editor.log 안 보고 검증 요청해버림. 룰 추가 계기.
 
 이전 사례 2: TASK-WM-039 Knockback A+B+C — `PlayerKnockbackCameraGlue` 신규 .cs 만든 후 Editor.log 봤는데 Unity foreground 안 와서 import 안 됨. 다른 (`HitstopFeedback`, `KnockbackFeedback`) 은 import 됐고 새로 만든 것만 안 됨 = stale 일 가능성 인지. 사용자에게 reimport 요청 → 통과 확인 후 검증 진행.
+
+### Play Mode 진입 자동 lazy load — `RuntimeInitializeOnLoadMethod` 한계
+
+새 매니저 prefab + `[RuntimeInitializeOnLoadMethod(AfterSceneLoad)]` 로 Play Mode 시 자동 ensure 시:
+
+- **컴파일 끝나기 *전* Play 진입하면 옛 .dll 사용** → 새 코드 적용 X. Play Mode 시작 후 *forced sync recompile* 발생 (Editor.log 의 `Reloading assemblies after forced synchronous recompile`) = 옛 .dll 시점에 RuntimeInitializeOnLoadMethod 이미 호출됨
+- Unity well-known 한계: **assembly reload 시 RuntimeInitializeOnLoadMethod 재호출 X**
+
+해결 흐름:
+1. `unity-refresh.ps1` 호출 + sleep ~25초 + Editor.log grep (`error CS` 0 + `Reloading assemblies` 새 매치) 으로 *컴파일 완료 검증*
+2. 검증 OK 면 사용자에게 Play 요청
+3. Play 들어갔는데 새 코드 반영 안 되면 → Stop → 다시 Play (이번엔 새 .dll 로딩됨)
+
+**`Singleton<T>` 매니저의 `dontDestroyOnLoad`** — prefab 의 `[SerializeField] dontDestroyOnLoad` 노브를 *true* 로 박는다. 씬 전환 시 destroy 되면 RuntimeInitializeOnLoadMethod(AfterSceneLoad) 1회만 호출이라 재인스턴스화 트리거 0. **코드로 `DontDestroyOnLoad()` 강제 호출은 X** — Singleton 베이스 SerializedField 가 정본 (수치 노출 / 런타임 tweak 룰 정합). 자동 부트스트랩 메뉴가 prefab 생성 시 SerializedField 박는 패턴.
+
+이전 사례: TASK-WM-054-A WorldClock (2026-05-08) — Awake 에서 `DontDestroyOnLoad` 코드 강제 호출했다가 사용자가 "Singleton 베이스에 노브 있는데 왜 코드 강제냐" 지적. `WorldClockBootstrapMenu` 가 prefab 생성 시 SerializedField = true 박는 + idempotent `EnsurePrefabFlags` 패턴으로 정정.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

TASK-WM-054 (parent, 밤낮·날씨 시스템) 의 **sub-A — WorldClock 시간 모델**.
시·분·일·계절·년 advance + skip/pause API + delegate event 3채널 + 디버그 HUD.
**SO 값 캐싱 X** (런타임 tweak 즉시 반영). Editor 자동 부트스트랩
(`[InitializeOnLoadMethod]` + `EnsurePrefabFlags` idempotent).

## Commits

- `b6a4c06a docs(rules)` — CLAUDE.md 룰 3건:
  - 「수치 노출 / 런타임 tweak」 (정본 § 추가)
  - 「Unity 자동화 흐름」 (§ 컴파일 에러 확인 갱신 — unity-refresh.ps1)
  - 「Play Mode 진입 한계」 (RuntimeInitializeOnLoadMethod + Singleton dontDestroyOnLoad SerializeField)
- `e5d277e6 feat(time)` — WorldClock 시간 모델 코드 (16 파일 +518)

## 코드 변경

- `Core/Scripts/Time/WorldClock.cs` — `Singleton<WorldClock>`, TimeManager.OnTick hook, `event Action<int>` 3채널, skip/pause API, `RuntimeInitializeOnLoadMethod(AfterSceneLoad)` ensure
- `Core/Scripts/Time/WorldClockSO.cs` — `ScriptableObject` 직접, 모든 수치 `[field: SerializeField, Range]` (런타임 tweak)
- `Core/Scripts/Time/SeasonSO.cs` — 골격 (DisplayName/Tint), sub-D 에서 weight 채움
- `Core/Scripts/Time/Debug/WorldClockHUD.cs` — IMGUI 디버그 (시각 + speed 슬라이더 + Skip + `OnHourChanged` 첫 사용처)
- `Editor/Time/WorldClockBootstrapMenu.cs` — `[InitializeOnLoadMethod]` 자동 부트스트랩 + `EnsurePrefabFlags` idempotent + `WM/Setup/Recreate` 메뉴

## 자동 생성 자산

- `Core/Resources/WorldClockSO.asset` (디폴트)
- `Core/Resources/Singletons/WorldClock.prefab` (WorldClock + WorldClockHUD, `dontDestroyOnLoad=true`)

## Test plan

- [x] 컴파일 에러 0 (Editor.log grep `error CS` 0)
- [x] HUD 시각 흐름 (Play Mode 진입 → `Y1 S1 D1 06:00` 부터 `06:01` → ...)
- [x] speed 슬라이더 즉시 반영 (런타임 tweak)
- [x] Skip to next day 버튼 → 다음날 `06:00` 점프
- [x] SO 인스펙터 *플레이 중* 값 변경 → 즉시 반영
- [x] last hour 메시지 carry 시 갱신 (`OnHourChanged` delegate 사용처)
- [x] ContextMenu `Debug/Skip 1 Hour` 동작

전체 6항목 사용자 Play Mode 검증 통과.

## 후속

- sub-B (TimePhase enum + OnPhaseChanged + 디버그 큐브)
- sub-C (SkyDirector — Skybox/DirLight/Fog 시간대 lerp)
- sub-D~ (WeatherSystem)
- `GameEventType` enum 추가는 sub-C/D 첫 사용처와 묶음 (`feedback_dead_interface_avoid` 룰)

## Related

- parent TASK: `memo/wm/tasks/TASK-WM-054-밤낮-날씨-시스템.md`
- sub-A TASK: `memo/wm/tasks/TASK-WM-054-A-WorldClock.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게임 내 시간 시스템 추가 - 연도, 계절, 일, 시간, 분 추적
  * 디버그 HUD로 게임 시간 제어 및 속도 조절 가능
  * 시간 진행 속도, 시작 시간, 계절 구성 등 설정 가능한 옵션 추가
  * 시간 변화 이벤트 시스템으로 다른 게임 요소와 연동 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->