### PR TITLE
feat(shader-modding): TASK-WM-055 P1 — 셰이더 모딩 인프라

### DIFF
--- a/Assets/_WitchMendokusai/Core/Resources/BootstrapSettings.asset
+++ b/Assets/_WitchMendokusai/Core/Resources/BootstrapSettings.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   <DataManagerPrefab>k__BackingField: {fileID: 2233538775601197656, guid: 47a53c63ff3b524468554453dc01ae65, type: 3}
   <AudioManagerPrefab>k__BackingField: {fileID: 7806090928065181619, guid: f7c7aa6c57093b243820d9216262b329, type: 3}
   <InputManagerPrefab>k__BackingField: {fileID: 437165173486656460, guid: 9f92be055858bb54ab4f76527230e156, type: 3}
+  <ShaderPackManagerPrefab>k__BackingField: {fileID: 2924899492327680460, guid: 0bc105c6c97d23c4487b298412563aef, type: 3}
   <UseBootstrap>k__BackingField: 1

--- a/Assets/_WitchMendokusai/Core/Resources/Singletons/ShaderPackManager.prefab
+++ b/Assets/_WitchMendokusai/Core/Resources/Singletons/ShaderPackManager.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2887882364321188121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1088682193995780700}
+  - component: {fileID: 2924899492327680460}
+  m_Layer: 0
+  m_Name: ShaderPackManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1088682193995780700
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2887882364321188121}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2924899492327680460
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2887882364321188121}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5218de1a9c5c4624c8045040bd2fa1ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::WitchMendokusai.ShaderPackManager
+  dontDestroyOnLoad: 0

--- a/Assets/_WitchMendokusai/Core/Resources/Singletons/ShaderPackManager.prefab.meta
+++ b/Assets/_WitchMendokusai/Core/Resources/Singletons/ShaderPackManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0bc105c6c97d23c4487b298412563aef
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Core/Scripts/BootstrapSettings.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/BootstrapSettings.cs
@@ -12,6 +12,7 @@ namespace WitchMendokusai
 		[field: SerializeField] public DataManager DataManagerPrefab { get; private set; }
 		[field: SerializeField] public AudioManager AudioManagerPrefab { get; private set; }
 		[field: SerializeField] public InputManager InputManagerPrefab { get; private set; }
+		[field: SerializeField] public ShaderPackManager ShaderPackManagerPrefab { get; private set; }
 		[field: SerializeField] public bool UseBootstrap { get; private set; } = true;
 	}
 
@@ -33,6 +34,7 @@ namespace WitchMendokusai
 			Object.Instantiate(bootstrapStuff.DataManagerPrefab);
 			Object.Instantiate(bootstrapStuff.AudioManagerPrefab);
 			Object.Instantiate(bootstrapStuff.InputManagerPrefab);
+			Object.Instantiate(bootstrapStuff.ShaderPackManagerPrefab);
 		}
 	}
 }

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bdb7103d40fe7bf4aaa089ce65074624
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/IShaderPackSlot.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/IShaderPackSlot.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	public interface IShaderPackSlot
+	{
+		string SlotId { get; }
+		void Apply(AssetBundle bundle, ShaderPackSlotInfo slotInfo);
+		void Revert();
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/IShaderPackSlot.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/IShaderPackSlot.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 89d0dd397b99a3645b92d7978930a276

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/PostProcessSlot.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/PostProcessSlot.cs
@@ -1,20 +1,52 @@
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace WitchMendokusai
 {
 	// base+overlay 합성 — 셰이더팩이 DefaultVolumeProfile 을 수정하지 않고 별도 Runtime Volume 에 합성된다.
+	// 모더는 AssetBundle 안에 VolumeProfile.asset 박고 manifest.slots[].assetName 으로 명시.
 	public class PostProcessSlot : IShaderPackSlot
 	{
 		public const string SLOT_ID = "postprocess";
+		public const string RUNTIME_VOLUME_OBJECT_NAME = "ShaderPack.PostProcess.RuntimeVolume";
 
 		public string SlotId => SLOT_ID;
 
+		private GameObject runtimeVolumeObject;
+		private Volume runtimeVolume;
+
 		public void Apply(AssetBundle bundle, ShaderPackSlotInfo slotInfo)
 		{
+			VolumeProfile profile = bundle.LoadAsset<VolumeProfile>(slotInfo.assetName);
+			if (profile == null)
+			{
+				Debug.LogError($"[PostProcessSlot] VolumeProfile '{slotInfo.assetName}' not found in bundle.");
+				return;
+			}
+
+			Revert();
+
+			runtimeVolumeObject = new GameObject(RUNTIME_VOLUME_OBJECT_NAME);
+			Object.DontDestroyOnLoad(runtimeVolumeObject);
+
+			runtimeVolume = runtimeVolumeObject.AddComponent<Volume>();
+			runtimeVolume.isGlobal = true;
+			runtimeVolume.priority = slotInfo.priority;
+			runtimeVolume.sharedProfile = profile;
+
+			Debug.Log($"[PostProcessSlot] Applied VolumeProfile '{slotInfo.assetName}' (priority {slotInfo.priority})");
 		}
 
 		public void Revert()
 		{
+			if (runtimeVolumeObject == null)
+				return;
+
+			Object.Destroy(runtimeVolumeObject);
+			runtimeVolumeObject = null;
+			runtimeVolume = null;
+
+			Debug.Log($"[PostProcessSlot] Reverted runtime volume.");
 		}
 	}
 }

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/PostProcessSlot.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/PostProcessSlot.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// base+overlay 합성 — 셰이더팩이 DefaultVolumeProfile 을 수정하지 않고 별도 Runtime Volume 에 합성된다.
+	public class PostProcessSlot : IShaderPackSlot
+	{
+		public const string SLOT_ID = "postprocess";
+
+		public string SlotId => SLOT_ID;
+
+		public void Apply(AssetBundle bundle, ShaderPackSlotInfo slotInfo)
+		{
+		}
+
+		public void Revert()
+		{
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/PostProcessSlot.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/PostProcessSlot.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 769f0ebd8d68b33429c75d0dfc83c24a

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManager.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManager.cs
@@ -8,6 +8,7 @@ namespace WitchMendokusai
 	{
 		public const string SHADERPACKS_FOLDER_NAME = "shaderpacks";
 		public const string MANIFEST_FILE_NAME = "manifest.json";
+		public const string PREF_KEY_ACTIVE_PACK = "shadermod.active_pack_id";
 
 		private readonly Dictionary<string, IShaderPackSlot> registeredSlots = new();
 		private readonly List<ShaderPackEntry> availablePacks = new();
@@ -24,6 +25,7 @@ namespace WitchMendokusai
 			base.Awake();
 			RegisterSlots();
 			ScanShaderPacks();
+			RestoreActivePack();
 		}
 
 		private void RegisterSlots()
@@ -114,6 +116,8 @@ namespace WitchMendokusai
 			}
 
 			activePack = target;
+			PlayerPrefs.SetString(PREF_KEY_ACTIVE_PACK, packId);
+			PlayerPrefs.Save();
 			Debug.Log($"[ShaderPackManager] Applied pack: {target.Manifest.name} ({packId})");
 		}
 
@@ -136,6 +140,27 @@ namespace WitchMendokusai
 
 			Debug.Log($"[ShaderPackManager] Reverted pack: {activePack.Manifest.name}");
 			activePack = null;
+			PlayerPrefs.DeleteKey(PREF_KEY_ACTIVE_PACK);
+			PlayerPrefs.Save();
+		}
+
+		private void RestoreActivePack()
+		{
+			if (PlayerPrefs.HasKey(PREF_KEY_ACTIVE_PACK) == false)
+				return;
+
+			string savedId = PlayerPrefs.GetString(PREF_KEY_ACTIVE_PACK);
+			if (string.IsNullOrEmpty(savedId))
+				return;
+
+			Apply(savedId);
+
+			if (activePack == null)
+			{
+				Debug.LogWarning($"[ShaderPackManager] Saved active pack '{savedId}' not found, clearing preference.");
+				PlayerPrefs.DeleteKey(PREF_KEY_ACTIVE_PACK);
+				PlayerPrefs.Save();
+			}
 		}
 	}
 

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManager.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManager.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	public class ShaderPackManager : Singleton<ShaderPackManager>
+	{
+		public const string SHADERPACKS_FOLDER_NAME = "shaderpacks";
+		public const string MANIFEST_FILE_NAME = "manifest.json";
+
+		private readonly Dictionary<string, IShaderPackSlot> registeredSlots = new();
+		private readonly List<ShaderPackEntry> availablePacks = new();
+		private ShaderPackEntry activePack;
+		private AssetBundle activeBundle;
+
+		public IReadOnlyList<ShaderPackEntry> AvailablePacks => availablePacks;
+		public ShaderPackEntry ActivePack => activePack;
+
+		public string ShaderPacksDirectory => Path.Combine(Application.persistentDataPath, SHADERPACKS_FOLDER_NAME);
+
+		protected override void Awake()
+		{
+			base.Awake();
+			RegisterSlots();
+			ScanShaderPacks();
+		}
+
+		private void RegisterSlots()
+		{
+			RegisterSlot(new PostProcessSlot());
+		}
+
+		private void RegisterSlot(IShaderPackSlot slot)
+		{
+			registeredSlots[slot.SlotId] = slot;
+		}
+
+		public void ScanShaderPacks()
+		{
+			availablePacks.Clear();
+
+			string root = ShaderPacksDirectory;
+			if (Directory.Exists(root) == false)
+			{
+				Directory.CreateDirectory(root);
+				Debug.Log($"[ShaderPackManager] Created shaderpacks folder: {root}");
+				return;
+			}
+
+			foreach (string packDirectory in Directory.GetDirectories(root))
+			{
+				string manifestPath = Path.Combine(packDirectory, MANIFEST_FILE_NAME);
+				if (File.Exists(manifestPath) == false)
+				{
+					Debug.LogWarning($"[ShaderPackManager] No {MANIFEST_FILE_NAME} in {packDirectory}, skipping.");
+					continue;
+				}
+
+				string manifestText = File.ReadAllText(manifestPath);
+				ShaderPackManifest manifest = JsonUtility.FromJson<ShaderPackManifest>(manifestText);
+				if (manifest == null)
+				{
+					Debug.LogWarning($"[ShaderPackManager] Failed to parse {manifestPath}, skipping.");
+					continue;
+				}
+
+				ShaderPackEntry entry = new ShaderPackEntry
+				{
+					Id = Path.GetFileName(packDirectory),
+					Path = packDirectory,
+					Manifest = manifest
+				};
+				availablePacks.Add(entry);
+			}
+
+			Debug.Log($"[ShaderPackManager] Scanned {availablePacks.Count} shader packs from {root}");
+		}
+
+		public void Apply(string packId)
+		{
+			ShaderPackEntry target = availablePacks.Find(entry => entry.Id == packId);
+			if (target == null)
+			{
+				Debug.LogWarning($"[ShaderPackManager] Pack '{packId}' not found.");
+				return;
+			}
+
+			Revert();
+
+			string bundleFile = target.Manifest.bundleFile;
+			if (string.IsNullOrEmpty(bundleFile))
+			{
+				Debug.LogError($"[ShaderPackManager] Pack '{packId}' has no bundleFile in manifest.");
+				return;
+			}
+
+			string bundlePath = Path.Combine(target.Path, bundleFile);
+			activeBundle = AssetBundle.LoadFromFile(bundlePath);
+			if (activeBundle == null)
+			{
+				Debug.LogError($"[ShaderPackManager] Failed to load AssetBundle: {bundlePath}");
+				return;
+			}
+
+			foreach (ShaderPackSlotInfo slotInfo in target.Manifest.slots)
+			{
+				if (registeredSlots.TryGetValue(slotInfo.id, out IShaderPackSlot slot) == false)
+				{
+					Debug.LogWarning($"[ShaderPackManager] No slot registered for id '{slotInfo.id}' (manifest of '{packId}'). Skipping.");
+					continue;
+				}
+				slot.Apply(activeBundle, slotInfo);
+			}
+
+			activePack = target;
+			Debug.Log($"[ShaderPackManager] Applied pack: {target.Manifest.name} ({packId})");
+		}
+
+		public void Revert()
+		{
+			if (activePack == null)
+				return;
+
+			foreach (ShaderPackSlotInfo slotInfo in activePack.Manifest.slots)
+			{
+				if (registeredSlots.TryGetValue(slotInfo.id, out IShaderPackSlot slot))
+					slot.Revert();
+			}
+
+			if (activeBundle != null)
+			{
+				activeBundle.Unload(true);
+				activeBundle = null;
+			}
+
+			Debug.Log($"[ShaderPackManager] Reverted pack: {activePack.Manifest.name}");
+			activePack = null;
+		}
+	}
+
+	public class ShaderPackEntry
+	{
+		public string Id;
+		public string Path;
+		public ShaderPackManifest Manifest;
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManager.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5218de1a9c5c4624c8045040bd2fa1ac

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManifest.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManifest.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace WitchMendokusai
+{
+	[Serializable]
+	public class ShaderPackManifest
+	{
+		public int schemaVersion;
+		public string name;
+		public string author;
+		public string version;
+		public string description;
+		public ShaderPackSlotInfo[] slots;
+	}
+
+	[Serializable]
+	public class ShaderPackSlotInfo
+	{
+		public string id;
+		public string assetName;
+		public string blendMode;
+		public int priority;
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManifest.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManifest.cs
@@ -10,6 +10,7 @@ namespace WitchMendokusai
 		public string author;
 		public string version;
 		public string description;
+		public string bundleFile;
 		public ShaderPackSlotInfo[] slots;
 	}
 

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManifest.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManifest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 135aa3e97638ead4294e288ced58e336

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/SettingView.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/SettingView.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -6,14 +8,21 @@ namespace WitchMendokusai
 	/// <summary>
 	/// 전체화면 환경설정 UI (엔드필드/오버워치 스타일).
 	/// UIRoot.ScreenLayer에 직접 VisualElement를 추가함.
-	/// InventoryView와 동일한 MonoBehaviour 패턴 사용.
+	/// 좌측 사이드바의 탭 버튼 클릭 → 우측 컨텐츠 swap (data-driven, RegisterTab).
 	/// </summary>
 	public class SettingView : MonoBehaviour
 	{
 		private const string USS_CLASS = "wm-setting-view";
 		private const string ACTIVE_CLASS = "wm-setting-view--active";
+		private const string TAB_KEY_GENERAL = "general";
 
 		private VisualElement container;
+		private VisualElement sidebar;
+		private VisualElement contentArea;
+
+		private readonly Dictionary<string, VisualElement> tabContents = new();
+		private readonly Dictionary<string, Button> tabButtons = new();
+		private string currentTabKey;
 
 		private Button btnDungeonExit;
 
@@ -46,22 +55,57 @@ namespace WitchMendokusai
 
 		private void BuildUI()
 		{
-			// 좌측 사이드바
-			VisualElement sidebar = new VisualElement();
+			sidebar = new VisualElement();
 			sidebar.AddToClassList("wm-setting-sidebar");
 
 			Label titleLabel = new Label("환경설정");
 			titleLabel.AddToClassList("wm-setting-title");
 			sidebar.Add(titleLabel);
 
-			Button tabSystem = new Button { text = "시스템 설정" };
-			tabSystem.AddToClassList("wm-setting-tab");
-			tabSystem.AddToClassList("wm-setting-tab--active");
-			sidebar.Add(tabSystem);
+			contentArea = new VisualElement();
+			contentArea.AddToClassList("wm-setting-content-area");
 
-			// 우측 컨텐츠
-			VisualElement content = new VisualElement();
+			RegisterTab(TAB_KEY_GENERAL, "환경설정", BuildGeneralContent);
+
+			SwitchTab(TAB_KEY_GENERAL);
+
+			container.Add(sidebar);
+			container.Add(contentArea);
+		}
+
+		protected void RegisterTab(string tabKey, string title, Func<VisualElement> contentBuilder)
+		{
+			Button tabButton = new Button(() => SwitchTab(tabKey)) { text = title };
+			tabButton.AddToClassList("wm-setting-tab");
+			sidebar.Add(tabButton);
+			tabButtons[tabKey] = tabButton;
+
+			VisualElement content = contentBuilder();
 			content.AddToClassList("wm-setting-content");
+			content.style.display = DisplayStyle.None;
+			contentArea.Add(content);
+			tabContents[tabKey] = content;
+		}
+
+		private void SwitchTab(string tabKey)
+		{
+			if (currentTabKey == tabKey)
+				return;
+
+			if (currentTabKey != null)
+			{
+				tabContents[currentTabKey].style.display = DisplayStyle.None;
+				tabButtons[currentTabKey].RemoveFromClassList("wm-setting-tab--active");
+			}
+
+			tabContents[tabKey].style.display = DisplayStyle.Flex;
+			tabButtons[tabKey].AddToClassList("wm-setting-tab--active");
+			currentTabKey = tabKey;
+		}
+
+		private VisualElement BuildGeneralContent()
+		{
+			VisualElement content = new VisualElement();
 
 			// Audio
 			Label audioHeader = new Label("오디오");
@@ -115,8 +159,7 @@ namespace WitchMendokusai
 			btnClose.AddToClassList("wm-setting-close");
 			content.Add(btnClose);
 
-			container.Add(sidebar);
-			container.Add(content);
+			return content;
 		}
 
 		private static Slider CreateSlider(string label, float min, float max, float value)

--- a/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/SettingView.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/UI/Toolkit/SettingView.cs
@@ -15,6 +15,7 @@ namespace WitchMendokusai
 		private const string USS_CLASS = "wm-setting-view";
 		private const string ACTIVE_CLASS = "wm-setting-view--active";
 		private const string TAB_KEY_GENERAL = "general";
+		private const string TAB_KEY_SHADERPACKS = "shaderpacks";
 
 		private VisualElement container;
 		private VisualElement sidebar;
@@ -33,6 +34,11 @@ namespace WitchMendokusai
 
 		// System
 		private Toggle framerateToggle;
+
+		// Shaderpacks
+		private VisualElement shaderPackListContainer;
+		private VisualElement shaderPackDetailContainer;
+		private ShaderPackEntry selectedShaderPack;
 
 		public bool IsOpen { get; private set; }
 
@@ -66,6 +72,7 @@ namespace WitchMendokusai
 			contentArea.AddToClassList("wm-setting-content-area");
 
 			RegisterTab(TAB_KEY_GENERAL, "환경설정", BuildGeneralContent);
+			RegisterTab(TAB_KEY_SHADERPACKS, "쉐이더팩", BuildShaderPackContent);
 
 			SwitchTab(TAB_KEY_GENERAL);
 
@@ -162,6 +169,168 @@ namespace WitchMendokusai
 			return content;
 		}
 
+		private VisualElement BuildShaderPackContent()
+		{
+			VisualElement root = new VisualElement();
+
+			// 헤더 + 액션 버튼 (폴더 열기 / 재스캔)
+			VisualElement header = new VisualElement();
+			header.AddToClassList("wm-setting-shaderpack-header");
+
+			Label title = new Label("쉐이더팩");
+			title.AddToClassList("wm-setting-header");
+			header.Add(title);
+
+			Button btnOpenFolder = new Button(OnOpenShaderPacksFolder) { text = "폴더 열기" };
+			btnOpenFolder.AddToClassList("wm-setting-btn");
+			header.Add(btnOpenFolder);
+
+			Button btnRescan = new Button(OnRescanShaderPacks) { text = "재스캔" };
+			btnRescan.AddToClassList("wm-setting-btn");
+			header.Add(btnRescan);
+
+			root.Add(header);
+
+			// Split: 좌측 list / 우측 detail
+			VisualElement split = new VisualElement();
+			split.AddToClassList("wm-setting-shaderpack-split");
+
+			shaderPackListContainer = new VisualElement();
+			shaderPackListContainer.AddToClassList("wm-setting-shaderpack-list");
+			split.Add(shaderPackListContainer);
+
+			shaderPackDetailContainer = new VisualElement();
+			shaderPackDetailContainer.AddToClassList("wm-setting-shaderpack-detail");
+			split.Add(shaderPackDetailContainer);
+
+			root.Add(split);
+
+			RebuildShaderPackList();
+			RebuildShaderPackDetail();
+
+			return root;
+		}
+
+		private void RebuildShaderPackList()
+		{
+			if (shaderPackListContainer == null)
+				return;
+
+			shaderPackListContainer.Clear();
+
+			IReadOnlyList<ShaderPackEntry> packs = ShaderPackManager.Instance.AvailablePacks;
+
+			if (packs.Count == 0)
+			{
+				Label emptyLabel = new Label("(셰이더팩 없음 — '폴더 열기' 로 셰이더팩 추가)");
+				emptyLabel.AddToClassList("wm-setting-shaderpack-empty");
+				shaderPackListContainer.Add(emptyLabel);
+				return;
+			}
+
+			ShaderPackEntry activePack = ShaderPackManager.Instance.ActivePack;
+
+			foreach (ShaderPackEntry pack in packs)
+			{
+				ShaderPackEntry capturedPack = pack;
+				Button packButton = new Button(() => SelectShaderPack(capturedPack)) { text = pack.Manifest.name };
+				packButton.AddToClassList("wm-setting-shaderpack-item");
+				if (activePack == pack)
+					packButton.AddToClassList("wm-setting-shaderpack-item--active");
+				if (selectedShaderPack == pack)
+					packButton.AddToClassList("wm-setting-shaderpack-item--selected");
+				shaderPackListContainer.Add(packButton);
+			}
+		}
+
+		private void SelectShaderPack(ShaderPackEntry pack)
+		{
+			selectedShaderPack = pack;
+			RebuildShaderPackList();
+			RebuildShaderPackDetail();
+		}
+
+		private void RebuildShaderPackDetail()
+		{
+			if (shaderPackDetailContainer == null)
+				return;
+
+			shaderPackDetailContainer.Clear();
+
+			if (selectedShaderPack == null)
+			{
+				Label hint = new Label("좌측에서 셰이더팩을 선택하세요");
+				hint.AddToClassList("wm-setting-shaderpack-hint");
+				shaderPackDetailContainer.Add(hint);
+				return;
+			}
+
+			ShaderPackManifest manifest = selectedShaderPack.Manifest;
+
+			Label nameLabel = new Label(manifest.name);
+			nameLabel.AddToClassList("wm-setting-shaderpack-detail-name");
+			shaderPackDetailContainer.Add(nameLabel);
+
+			Label authorLabel = new Label($"by {manifest.author}");
+			authorLabel.AddToClassList("wm-setting-shaderpack-detail-author");
+			shaderPackDetailContainer.Add(authorLabel);
+
+			Label versionLabel = new Label($"v{manifest.version}");
+			versionLabel.AddToClassList("wm-setting-shaderpack-detail-version");
+			shaderPackDetailContainer.Add(versionLabel);
+
+			if (string.IsNullOrEmpty(manifest.description) == false)
+			{
+				Label descLabel = new Label(manifest.description);
+				descLabel.AddToClassList("wm-setting-shaderpack-detail-desc");
+				shaderPackDetailContainer.Add(descLabel);
+			}
+
+			bool isActive = ShaderPackManager.Instance.ActivePack == selectedShaderPack;
+
+			if (isActive)
+			{
+				Button btnRevert = new Button(OnRevertShaderPack) { text = "언로드" };
+				btnRevert.AddToClassList("wm-setting-btn");
+				shaderPackDetailContainer.Add(btnRevert);
+			}
+			else
+			{
+				Button btnApply = new Button(OnApplyShaderPack) { text = "적용" };
+				btnApply.AddToClassList("wm-setting-btn");
+				shaderPackDetailContainer.Add(btnApply);
+			}
+		}
+
+		private void OnOpenShaderPacksFolder()
+		{
+			string folder = ShaderPackManager.Instance.ShaderPacksDirectory;
+			if (System.IO.Directory.Exists(folder) == false)
+				System.IO.Directory.CreateDirectory(folder);
+			Application.OpenURL("file://" + folder);
+		}
+
+		private void OnRescanShaderPacks()
+		{
+			ShaderPackManager.Instance.ScanShaderPacks();
+			RebuildShaderPackList();
+			RebuildShaderPackDetail();
+		}
+
+		private void OnApplyShaderPack()
+		{
+			ShaderPackManager.Instance.Apply(selectedShaderPack.Id);
+			RebuildShaderPackList();
+			RebuildShaderPackDetail();
+		}
+
+		private void OnRevertShaderPack()
+		{
+			ShaderPackManager.Instance.Revert();
+			RebuildShaderPackList();
+			RebuildShaderPackDetail();
+		}
+
 		private static Slider CreateSlider(string label, float min, float max, float value)
 		{
 			Slider slider = new Slider(label, min, max)
@@ -193,6 +362,10 @@ namespace WitchMendokusai
 			bool isWorld = UnityEngine.SceneManagement.SceneManager.GetActiveScene().name == "World";
 			bool isDungeon = DungeonManager.TryGetExistingInstance(out DungeonManager dm) && dm.IsDungeon;
 			btnDungeonExit.style.display = (isWorld && isDungeon) ? DisplayStyle.Flex : DisplayStyle.None;
+
+			// 쉐이더팩 탭 진입 시 최신 상태 반영 (다른 곳에서 ShaderPackManager 변경했을 수 있음)
+			RebuildShaderPackList();
+			RebuildShaderPackDetail();
 
 			TimeManager.Instance.Pause(gameObject);
 		}

--- a/Assets/_WitchMendokusai/Editor/ShaderModding.meta
+++ b/Assets/_WitchMendokusai/Editor/ShaderModding.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3302a31a8ca5ed4fac371d0f3b37612
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Editor/ShaderModding/ShaderPackManagerBootstrapMenu.cs
+++ b/Assets/_WitchMendokusai/Editor/ShaderModding/ShaderPackManagerBootstrapMenu.cs
@@ -1,0 +1,58 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// ShaderPackManager.prefab 자동 생성 + BootstrapSettings.asset 에 자동 wire. (TASK-WM-055)
+	public static class ShaderPackManagerBootstrapMenu
+	{
+		private const string PREFAB_PATH = "Assets/_WitchMendokusai/Core/Resources/Singletons/ShaderPackManager.prefab";
+		private const string BOOTSTRAP_SETTINGS_PATH = "Assets/_WitchMendokusai/Core/Resources/BootstrapSettings.asset";
+		private const string SHADER_PACK_MANAGER_PROPERTY = "<ShaderPackManagerPrefab>k__BackingField";
+
+		[InitializeOnLoadMethod]
+		private static void AutoBootstrapIfMissing()
+		{
+			GameObject existingPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(PREFAB_PATH);
+			BootstrapSettings settings = AssetDatabase.LoadAssetAtPath<BootstrapSettings>(BOOTSTRAP_SETTINGS_PATH);
+
+			if (existingPrefab != null && settings != null && settings.ShaderPackManagerPrefab != null)
+				return;
+
+			CreateBootstrap();
+		}
+
+		[MenuItem("WM/Setup/Recreate ShaderPackManager Bootstrap")]
+		private static void RecreateMenuItem() => CreateBootstrap();
+
+		private static void CreateBootstrap()
+		{
+			GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(PREFAB_PATH);
+			if (prefab == null)
+			{
+				GameObject root = new GameObject(nameof(ShaderPackManager));
+				root.AddComponent<ShaderPackManager>();
+				prefab = PrefabUtility.SaveAsPrefabAsset(root, PREFAB_PATH);
+				Object.DestroyImmediate(root);
+				Debug.Log($"[ShaderPackManagerBootstrap] Created {PREFAB_PATH}");
+			}
+
+			BootstrapSettings settings = AssetDatabase.LoadAssetAtPath<BootstrapSettings>(BOOTSTRAP_SETTINGS_PATH);
+			if (settings != null && prefab != null)
+			{
+				ShaderPackManager managerComponent = prefab.GetComponent<ShaderPackManager>();
+				SerializedObject serialized = new SerializedObject(settings);
+				SerializedProperty property = serialized.FindProperty(SHADER_PACK_MANAGER_PROPERTY);
+				if (property != null && property.objectReferenceValue != managerComponent)
+				{
+					property.objectReferenceValue = managerComponent;
+					serialized.ApplyModifiedProperties();
+					Debug.Log($"[ShaderPackManagerBootstrap] Wired into {BOOTSTRAP_SETTINGS_PATH}");
+				}
+			}
+
+			AssetDatabase.SaveAssets();
+			AssetDatabase.Refresh();
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Editor/ShaderModding/ShaderPackManagerBootstrapMenu.cs.meta
+++ b/Assets/_WitchMendokusai/Editor/ShaderModding/ShaderPackManagerBootstrapMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d946b71a50e1f7a4e97a164d990efe10


### PR DESCRIPTION
## Summary

- **TASK-WM-055 P1-A~E** — 마인크래프트/OptiFine 풍 외부 셰이더팩 모딩 인프라 누적 (5 commit, ~600 LOC)
  - **P1-A** (`694be5c6`): `ShaderPackManifest` 스키마 + `IShaderPackSlot` 추상화 + `PostProcessSlot` 스텁
  - **P1-B** (`89593e1a`): `ShaderPackManager` (Singleton, `persistentDataPath/shaderpacks/` 자동 스캔, AssetBundle load/unload, `BootstrapSettings` 자동 wire via `[InitializeOnLoadMethod]`)
  - **P1-C** (`794db60c` + `830ae703`): `SettingView` 데이터 driven 탭 전환 + 쉐이더팩 탭 (split layout — 좌 list / 우 detail + 폴더 열기/재스캔)
  - **P1-D** (`f2d3ad3c`): `PlayerPrefs` 영속화 (`shadermod.active_pack_id`) + stale 자동 정리
  - **P1-E** (`0a43c47d`): `PostProcessSlot` 실 구현 — **별도 Runtime Volume** + `VolumeProfile` 주입. **base+overlay 합성 모델** (`DefaultVolumeProfile` 직접 수정 X — 시간 시스템과 분리)

## 안전성

- **동작 변화 0**: 모더 `.shaderbundle` 없으면 빈 폴더 자동 생성 + 효과 0. 기존 게임 흐름 영향 없음.
- **시간 시스템 (TASK-WM-054) 충돌 0**: 별도 Runtime Volume 격리 = 같은 `DefaultVolumeProfile.asset` 안 만짐.
- `BootstrapSettings.cs` 에 `ShaderPackManagerPrefab` field 추가 — `[InitializeOnLoadMethod]` 가 `BootstrapSettings.asset` 자동 wire (사용자 클릭 0).

## Test plan

- [x] 컴파일 통과 (`error CS` 0)
- [x] Play mode — `Bootstrap.OnBooting` → `ShaderPackManager.Awake` → `ScanShaderPacks` 폴더 자동 생성 log 확인
- [x] `SettingView` — 환경설정/쉐이더팩 두 탭 + 폴더 열기/재스캔 정상 (사용자 시각 검증)
- [ ] **통합 동작 검증** — P1-F (Editor SDK + 샘플 `cozy-night.shaderbundle`) 시점에 통합

## Follow-up

- **P1-F**: Editor SDK 별도 GitHub 리포 (`witch-mendokusai-shaderpack-sdk`) + 샘플 셰이더팩 (`cozy-night.shaderbundle`)
- **P1-G**: design doc (`wm/concepts/shader-modding-architecture.md`) — base+overlay 합성 모델 + 슬롯 contract
- **USS 톤**: `wm-setting-shaderpack-*` class 들 USS 파일 정의 (현재 raw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)