### PR TITLE
chore(ci): auto-rebase 도 Draft PR 포함 — main 신선도 유지

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -1,6 +1,8 @@
 name: Auto Rebase Open PRs
 
-# main 머지 후 모든 open PR (non-draft, base=main) 자동 update — main 의 변경을 PR 브랜치로 merge.
+# main 머지 후 모든 open PR (Draft 포함, base=main) 자동 update — main 의 변경을 PR 브랜치로 merge.
+# Draft 도 포함: 사용자 검증 시점 main 신선도 유지 가치. .coderabbit.yaml 의 auto_review.drafts=true 와 같은 정신.
+# Draft = 머지 자체는 안 됨 (auto-merge.yml 의 ready_for_review 트리거 별개). rebase 만 받음.
 # stack PR (base=다른 feature) 은 GitHub 가 자동 retarget 처리하니 본 워크플로 대상 X.
 # conflict 시 PR 코멘트로 @claude 멘션 → claude.yml 의 claude job trigger → Claude 가 자동 conflict 해결.
 
@@ -39,12 +41,13 @@ jobs:
         run: |
           set -e
 
+          # Draft 포함 — main 신선도 유지가 머지 가능성과 직교. Draft 가 머지되는 건 auto-merge.yml 의 ready_for_review 별개 흐름.
           PR_NUMBERS=$(gh pr list --base main --state open --limit 100 \
-            --json number,isDraft \
-            --jq '.[] | select(.isDraft == false) | .number')
+            --json number \
+            --jq '.[].number')
 
           if [ -z "$PR_NUMBERS" ]; then
-            echo "No open Ready PRs to update."
+            echo "No open PRs to update."
             exit 0
           fi
 


### PR DESCRIPTION
## 📋 관련된 TASK
- 없음 (메타 — CI 보강, PR #108 후속)

## 📝 PR 목적 및 의도

PR #106 (TASK-WM-013 prototype Draft) 사용자 진단 계기:
- \`mergeStateStatus: BEHIND\` 인데 auto-rebase 가 update 안 함
- 원인: \`auto-rebase.yml\` line 44 \`select(.isDraft == false)\` 명시 필터

## 🛠️ 주요 변경 사항

\`.github/workflows/auto-rebase.yml\`:
- \`isDraft\` 필터 제거 — Draft 도 자동 update 대상
- 주석 갱신 (Draft 포함 의도 명시 + auto_review.drafts 와 같은 정신)
- 로그 메시지 \"Ready PRs\" → \"PRs\"

## 정합성

- Draft = 머지 자체는 안 됨 (\`ready_for_review\` 트리거 별개)
- rebase 만 받음 → 사용자 검증 시점 신선도 유지
- conflict 시 @claude 멘션 자동 해결 흐름도 같음
- PR #108 (\`.coderabbit.yaml\` auto_review.drafts=true) 와 같은 정신

## 영향

- 본 PR 머지 후 PR #106 같은 Draft 도 다음 main 머지 / 30분 cron / Auto Merge workflow_run trigger 시 자동 update
- 즉시 fix 는 별도 — \`gh pr update-branch 106\` 수동 호출 (소급 자동화 X)

## ✅ 체크리스트
- [x] § Git Workflow — Default Ready (Draft X)
- [x] 1줄 변경 chore (코드 동작 변경 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)