### PR TITLE
TASK-WM-056-E1 — .editorconfig + Directory.Build.props 시드 (var 금지 + Allman, severity=warning)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,45 @@
+root = true
+
+# WM 코드 룰 정본: WitchMendokusai/CLAUDE.md § 코딩 스타일.
+# TASK-WM-056-E1 — Roslyn analyzer + EditorConfig 게이트 시드 (var 금지 + Allman, severity=warning).
+# 후속 단계 (E2: dotnet format / E3: CI / E4: pre-commit hook / E5+: ! 금지 등 추가 룰).
+
+[*]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 4
+
+[*.{md,yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.cs]
+# ── var 금지 (CLAUDE.md 룰 — 명시적 타입) ───────────────────────────────
+# IDE0007: 'var' 대신 명시적 타입 사용
+# IDE0008: 'var' 대신 명시적 타입 (apparent / built-in / elsewhere 모든 케이스)
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = false:warning
+csharp_style_var_elsewhere = false:warning
+dotnet_diagnostic.IDE0007.severity = warning
+dotnet_diagnostic.IDE0008.severity = warning
+
+# ── Allman 중괄호 (CLAUDE.md 룰 — 중괄호 항상 새 줄) ────────────────────
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# 포맷 통합 룰 (formatting analyzer)
+dotnet_diagnostic.IDE0055.severity = warning
+
+# ── 후속 단계 자리 (E5+에서 enable) ────────────────────────────────────
+# dotnet_diagnostic.WM0001.severity = warning   # ! 부정 연산자 금지 (custom analyzer 후보)
+# dotnet_diagnostic.WM0002.severity = warning   # delegate { } 초기값 누락 (custom)
+# dotnet_diagnostic.WM0003.severity = warning   # Input.GetKey 등 레거시 InputAPI 금지 (custom)
+# dotnet_diagnostic.WM0004.severity = warning   # Keyboard.current / Mouse.current 직접 접근 (custom)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+  <!--
+    TASK-WM-056-E1 — 빌드 시 EditorConfig 코드 룰 enforce.
+
+    Unity 가 .csproj 자동 생성하는 환경에서 모든 csproj 에 공통 적용.
+    .editorconfig 의 dotnet_diagnostic.* severity 가 빌드 단계에서 검출됨.
+
+    severity = warning (현 단계). E2 dotnet format 자동 fix 후 E5+ 단계에서
+    핵심 룰 일부를 error 로 escalate 결정 슬롯 진입.
+  -->
+  <PropertyGroup>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest</AnalysisLevel>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## 📋 관련된 TASK
- Task: TASK-WM-056-E1 (parent: TASK-WM-056-E / TASK-WM-056)

## 📝 PR 목적 및 의도

시스템적 품질 게이트의 첫 자물쇠. WM CLAUDE.md 코딩 룰 (`var` 금지 + Allman) 을 *컴파일러/IDE 단계* 에서 enforce. AI review (CodeRabbit) 의 결정성 한계 보강.

부모 TASK-WM-056 진단에서 측정값으로 박힌 *룰 위반 65건 잔존* 을 *추가 침식 0* 로 자물쇠 우선. AI 의존 X 시스템적 품질 관리 사용자 발화 직답.

E1 = 인프라만 박는 단계 (코드 변경 0, severity=warning). 후속:
- E2 — `dotnet format` 자동 fix (Allman/var 일괄)
- E3 — `code-quality.yml` 에 CI 게이트 추가
- E4 — `dotfiles/git-hooks/pre-commit` 확장
- E5+ — custom analyzer (`!` 금지 / `Input.GetKey` 금지 / `Keyboard.current` 직접 접근 금지 / `delegate { }` 초기값)

## 🛠️ 주요 변경 사항

- `.editorconfig` 신규 — `*.cs` `var` 금지 (`IDE0007/IDE0008`) + Allman 중괄호 (`csharp_new_line_before_*`) + 포맷 통합 (`IDE0055`), 모두 `severity=warning`
- `Directory.Build.props` 신규 — `EnforceCodeStyleInBuild=true` + `AnalysisLevel=latest`, 외부 NuGet 의존 0 (`Microsoft.CodeAnalysis.NetAnalyzers` SDK 빌트인)
- E5+ custom analyzer 자리 주석 (`.editorconfig` 내 `WM0001`~`WM0004` placeholder)

## 🤔 리뷰어(CodeRabbit)에게 특별히 확인 받고 싶은 부분

- `.editorconfig` key 가 .NET SDK 빌트인 analyzer 와 정합한지 (Unity 6 + .NET 8 환경)
- `Directory.Build.props` 가 Unity 자동 생성 `.csproj` 와 충돌 없는지
- `severity=warning` 시 빌드 성공 + 경고만 — Unity 빌드/Play 영향 0 가정 검증

## 사용자 검증 (main pull 후 Unity 환경)

- [ ] main pull → Unity Editor focus → reimport → `.csproj` 재생성
- [ ] Rider/VS 에서 `var` 사용 부분 노란 줄 표시 확인
- [ ] 빨간 줄 0 (severity=warning, 빌드 성공)
- [ ] 기존 코드 warning 폭증 (Core `var` 14건 + Allman 위반 다수) — E2 에서 `dotnet format` 자동 fix 예정

## ✅ 체크리스트 — 룰 정본 `WitchMendokusai/CLAUDE.md`

- [x] § 코딩 스타일 — 본 PR 자체가 룰 enforce 인프라 (var 금지 + Allman, severity=warning)
- [x] § 입력 처리 — N/A (코드 변경 0)
- [x] § 에러 처리 — N/A (코드 변경 0)
- [x] § 사용자 작업 기록 — Test plan 의 사용자 검증 항목 (위)
- [x] § 컴파일 에러 확인 — 코드 변경 0, severity=warning 라 빌드 영향 0
- [x] 오버스펙 지향 — 시스템적 게이트 박는 행위 자체가 인프라 강화 (사용자 발화 직답)