### PR TITLE
feat(sky): TASK-WM-054-C C1 — SkyDirector + 모동숲 Skybox

### DIFF
--- a/Assets/_WitchMendokusai/Core/Resources/Singletons/SkyDirector.prefab
+++ b/Assets/_WitchMendokusai/Core/Resources/Singletons/SkyDirector.prefab
@@ -1,0 +1,51 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4630170308774170701
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7634735365751001997}
+  - component: {fileID: 1793841287083357068}
+  m_Layer: 0
+  m_Name: SkyDirector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7634735365751001997
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4630170308774170701}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1793841287083357068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4630170308774170701}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c66cd845649c1ce4193110cf9816c327, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::WitchMendokusai.SkyDirector
+  dontDestroyOnLoad: 1
+  <ActivePreset>k__BackingField: {fileID: 11400000, guid: 7dfb6657b0a0df944b421b00a3a88c09, type: 2}
+  <SkyboxMaterial>k__BackingField: {fileID: 2100000, guid: 282b50081561f8f4289b7d1b999c03de, type: 2}
+  applyDirectionalLight: 0
+  applyEnvironment: 0

--- a/Assets/_WitchMendokusai/Core/Resources/Singletons/SkyDirector.prefab.meta
+++ b/Assets/_WitchMendokusai/Core/Resources/Singletons/SkyDirector.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a1fc49c8acb05844a9b8832ff9c8f018
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Core/Resources/SkyPreset_AnimalCrossing.asset
+++ b/Assets/_WitchMendokusai/Core/Resources/SkyPreset_AnimalCrossing.asset
@@ -1,0 +1,390 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8066ad0830248a94e8849559d47406e3, type: 3}
+  m_Name: SkyPreset_AnimalCrossing
+  m_EditorClassIdentifier: Assembly-CSharp::WitchMendokusai.SkyPresetSO
+  <DisplayName>k__BackingField: Animal Crossing
+  <ZenithColor>k__BackingField:
+    serializedVersion: 2
+    key0: {r: 0.1, g: 0.08, b: 0.25, a: 1}
+    key1: {r: 0.55, g: 0.45, b: 0.65, a: 1}
+    key2: {r: 0.5, g: 0.75, b: 0.9, a: 1}
+    key3: {r: 0.4, g: 0.7, b: 0.95, a: 1}
+    key4: {r: 0.55, g: 0.55, b: 0.85, a: 1}
+    key5: {r: 0.95, g: 0.55, b: 0.55, a: 1}
+    key6: {r: 0.3, g: 0.2, b: 0.55, a: 1}
+    key7: {r: 0.1, g: 0.08, b: 0.25, a: 1}
+    ctime0: 0
+    ctime1: 13107
+    ctime2: 19661
+    ctime3: 32768
+    ctime4: 45875
+    ctime5: 51117
+    ctime6: 55705
+    ctime7: 65535
+    atime0: 0
+    atime1: 13107
+    atime2: 19661
+    atime3: 32768
+    atime4: 45875
+    atime5: 51117
+    atime6: 55705
+    atime7: 65535
+    m_Mode: 0
+    m_ColorSpace: -1
+    m_NumColorKeys: 8
+    m_NumAlphaKeys: 8
+  <HorizonColor>k__BackingField:
+    serializedVersion: 2
+    key0: {r: 0.2, g: 0.15, b: 0.3, a: 1}
+    key1: {r: 1, g: 0.7, b: 0.75, a: 1}
+    key2: {r: 1, g: 0.95, b: 0.85, a: 1}
+    key3: {r: 0.85, g: 0.9, b: 1, a: 1}
+    key4: {r: 1, g: 0.65, b: 0.4, a: 1}
+    key5: {r: 0.85, g: 0.45, b: 0.55, a: 1}
+    key6: {r: 0.25, g: 0.2, b: 0.4, a: 1}
+    key7: {r: 0.2, g: 0.15, b: 0.3, a: 1}
+    ctime0: 0
+    ctime1: 13107
+    ctime2: 19661
+    ctime3: 32768
+    ctime4: 49151
+    ctime5: 54394
+    ctime6: 58982
+    ctime7: 65535
+    atime0: 0
+    atime1: 13107
+    atime2: 19661
+    atime3: 32768
+    atime4: 49151
+    atime5: 54394
+    atime6: 58982
+    atime7: 65535
+    m_Mode: 0
+    m_ColorSpace: -1
+    m_NumColorKeys: 8
+    m_NumAlphaKeys: 8
+  <SunDiscColor>k__BackingField:
+    serializedVersion: 2
+    key0: {r: 0, g: 0, b: 0, a: 0}
+    key1: {r: 1, g: 0.8, b: 0.7, a: 1}
+    key2: {r: 1, g: 0.97, b: 0.85, a: 1}
+    key3: {r: 1, g: 0.55, b: 0.3, a: 1}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 14418
+    ctime2: 32768
+    ctime3: 51117
+    ctime4: 55705
+    ctime5: 65535
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 14418
+    atime2: 32768
+    atime3: 51117
+    atime4: 55705
+    atime5: 65535
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_ColorSpace: -1
+    m_NumColorKeys: 6
+    m_NumAlphaKeys: 6
+  <SunLightColor>k__BackingField:
+    serializedVersion: 2
+    key0: {r: 0.3, g: 0.3, b: 0.5, a: 1}
+    key1: {r: 1, g: 0.85, b: 0.75, a: 1}
+    key2: {r: 1, g: 0.95, b: 0.9, a: 1}
+    key3: {r: 1, g: 0.65, b: 0.45, a: 1}
+    key4: {r: 0.45, g: 0.35, b: 0.55, a: 1}
+    key5: {r: 0.3, g: 0.3, b: 0.5, a: 1}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 14418
+    ctime2: 32768
+    ctime3: 51117
+    ctime4: 55705
+    ctime5: 65535
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 14418
+    atime2: 32768
+    atime3: 51117
+    atime4: 55705
+    atime5: 65535
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_ColorSpace: -1
+    m_NumColorKeys: 6
+    m_NumAlphaKeys: 6
+  <FogColor>k__BackingField:
+    serializedVersion: 2
+    key0: {r: 0.15, g: 0.13, b: 0.25, a: 1}
+    key1: {r: 0.8, g: 0.85, b: 0.95, a: 1}
+    key2: {r: 0.95, g: 0.75, b: 0.65, a: 1}
+    key3: {r: 0.15, g: 0.13, b: 0.25, a: 1}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 32768
+    ctime2: 51117
+    ctime3: 65535
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 32768
+    atime2: 51117
+    atime3: 65535
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_ColorSpace: -1
+    m_NumColorKeys: 4
+    m_NumAlphaKeys: 4
+  <AmbientColor>k__BackingField:
+    serializedVersion: 2
+    key0: {r: 0.18, g: 0.18, b: 0.3, a: 1}
+    key1: {r: 0.65, g: 0.7, b: 0.8, a: 1}
+    key2: {r: 0.85, g: 0.65, b: 0.6, a: 1}
+    key3: {r: 0.18, g: 0.18, b: 0.3, a: 1}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 32768
+    ctime2: 51117
+    ctime3: 65535
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 32768
+    atime2: 51117
+    atime3: 65535
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_ColorSpace: -1
+    m_NumColorKeys: 4
+    m_NumAlphaKeys: 4
+  <SunIntensity>k__BackingField:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0.1
+      inSlope: 1.5
+      outSlope: 1.5
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.2
+      value: 0.4
+      inSlope: 2.0833335
+      outSlope: 2.0833335
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.5
+      value: 1.2
+      inSlope: 0.44047606
+      outSlope: 0.44047606
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.78
+      value: 0.7
+      inSlope: -3.6428564
+      outSlope: -3.6428564
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.88
+      value: 0.15
+      inSlope: -2.9583323
+      outSlope: -2.9583323
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0.1
+      inSlope: -0.4166667
+      outSlope: -0.4166667
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  <SunAltitude>k__BackingField:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: -0.3
+      inSlope: 1.2
+      outSlope: 1.2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.25
+      value: 0
+      inSlope: 2.6
+      outSlope: 2.6
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.5
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.75
+      value: 0
+      inSlope: -2.6
+      outSlope: -2.6
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: -0.3
+      inSlope: -1.2
+      outSlope: -1.2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  <StarAlpha>k__BackingField:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: -4
+      outSlope: -4
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.2
+      value: 0.2
+      inSlope: -3
+      outSlope: -3
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.3
+      value: 0
+      inSlope: -0.99999994
+      outSlope: -0.99999994
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.78
+      value: 0
+      inSlope: 2.4999995
+      outSlope: 2.4999995
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.88
+      value: 0.5
+      inSlope: 4.583333
+      outSlope: 4.583333
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 4.1666665
+      outSlope: 4.1666665
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  <PostSaturation>k__BackingField:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/_WitchMendokusai/Core/Resources/SkyPreset_AnimalCrossing.asset.meta
+++ b/Assets/_WitchMendokusai/Core/Resources/SkyPreset_AnimalCrossing.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7dfb6657b0a0df944b421b00a3a88c09
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Core/Resources/SkyboxGradient.mat
+++ b/Assets/_WitchMendokusai/Core/Resources/SkyboxGradient.mat
@@ -1,0 +1,38 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkyboxGradient
+  m_Shader: {fileID: 4800000, guid: b3b5357776ca6b149a480e7df1aa4d00, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Ints: []
+    m_Floats:
+    - _HorizonExponent: 2.5
+    - _StarAlpha: -0.20859763
+    - _SunSize: 0.04
+    - _SunSoftness: 0.05
+    m_Colors:
+    - _HorizonColor: {r: 0.9291657, g: 0.76805717, b: 0.6833372, a: 1}
+    - _SunDirection: {r: 0, g: 0.75412303, b: 0.65673316, a: 0}
+    - _SunDiscColor: {r: 1, g: 0.7720862, b: 0.5908272, a: 1}
+    - _ZenithColor: {r: 0.4989526, g: 0.6010474, b: 0.88403165, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Assets/_WitchMendokusai/Core/Resources/SkyboxGradient.mat.meta
+++ b/Assets/_WitchMendokusai/Core/Resources/SkyboxGradient.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 282b50081561f8f4289b7d1b999c03de
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Core/Scripts/Sky.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/Sky.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f36051ed6a7eeae4eb50bfb47542ee4f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyDirector.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyDirector.cs
@@ -1,0 +1,226 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace WitchMendokusai
+{
+	// 시간대별 하늘·라이팅 lerp. WorldClock 의 시간 → SkyPresetSO 의 Gradient 평가
+	// → Skybox material property + DirLight + Fog/Ambient 적용.
+	// SO 값 캐싱 X — 인스펙터 런타임 변경 즉시 반영.
+	// (TASK-WM-054-C C1: Skybox 만 / C2: DirLight / C3a: Fog/Ambient)
+	public class SkyDirector : Singleton<SkyDirector>
+	{
+		[field: SerializeField] public SkyPresetSO ActivePreset { get; set; }
+		[field: SerializeField] public Material SkyboxMaterial { get; private set; }
+
+		[Header("C2 / C3a — 단계별 활성")]
+		[SerializeField] private bool applyDirectionalLight = false;
+		[SerializeField] private bool applyEnvironment = false;
+
+		[Header("Debug")]
+		[SerializeField] private bool debugLogStartup = false;
+		[SerializeField] private bool debugLogSkyboxRestore = false;
+
+		private Light directionalLight;
+		private float cachedNormalizedTime = -1f;
+
+		private static readonly int ZenithColorId = Shader.PropertyToID("_ZenithColor");
+		private static readonly int HorizonColorId = Shader.PropertyToID("_HorizonColor");
+		private static readonly int SunDiscColorId = Shader.PropertyToID("_SunDiscColor");
+		private static readonly int SunDirectionId = Shader.PropertyToID("_SunDirection");
+		private static readonly int StarAlphaId = Shader.PropertyToID("_StarAlpha");
+
+		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+		private static void EnsureSingletonOnPlay()
+		{
+			_ = Instance;
+		}
+
+		protected override void Awake()
+		{
+			base.Awake();
+			ApplySkyboxMaterial();
+		}
+
+		private void Start()
+		{
+			FindDirectionalLight();
+			ApplyPreset(force: true);
+
+			if (debugLogStartup == true)
+			{
+				Camera[] allCameras = FindObjectsByType<Camera>(FindObjectsInactive.Include);
+				Debug.Log($"[SkyDirector] Camera scan: {allCameras.Length} cameras");
+				foreach (Camera cam in allCameras)
+				{
+					Skybox sb = cam.GetComponent<Skybox>();
+					string skyboxInfo = sb != null ? (sb.material != null ? sb.material.name : "null mat") : "no Skybox component";
+					Debug.Log($"[SkyDirector]   '{cam.name}' depth={cam.depth} clearFlags={cam.clearFlags} | Skybox comp: {skyboxInfo}");
+				}
+			}
+		}
+
+		// 씬 전환 시 Unity 가 RenderSettings.skybox 를 그 씬의 Lighting Settings Skybox Material 로 자동 reset.
+		// 매 프레임 guard 로 SkyboxGradient 복구. (근본 fix = 모든 씬의 Lighting Settings 의 Skybox Material 변경 — follow-up)
+		private void Update()
+		{
+			if (RenderSettings.skybox != SkyboxMaterial && SkyboxMaterial != null)
+			{
+				if (debugLogSkyboxRestore == true)
+					Debug.Log($"[SkyDirector] RenderSettings.skybox 가 '{(RenderSettings.skybox != null ? RenderSettings.skybox.name : "null")}' 로 변경 → SkyboxGradient 복구");
+				RenderSettings.skybox = SkyboxMaterial;
+			}
+			ApplyPreset(force: false);
+		}
+
+		private void ApplySkyboxMaterial()
+		{
+			if (SkyboxMaterial == null)
+				return;
+
+			RenderSettings.skybox = SkyboxMaterial;
+
+			// Camera 에 Skybox component 가 attach 돼 있으면 RenderSettings.skybox 보다 우선됨 → 동기화 강제.
+			Camera[] cameras = FindObjectsByType<Camera>(FindObjectsInactive.Include);
+			foreach (Camera camera in cameras)
+			{
+				Skybox cameraSkybox = camera.GetComponent<Skybox>();
+				if (cameraSkybox != null)
+				{
+					Debug.Log($"[SkyDirector] Camera '{camera.name}' has Skybox component (was: {(cameraSkybox.material != null ? cameraSkybox.material.name : "null")}) → override with {SkyboxMaterial.name}");
+					cameraSkybox.material = SkyboxMaterial;
+				}
+			}
+
+			DynamicGI.UpdateEnvironment();
+		}
+
+		private void FindDirectionalLight()
+		{
+			Light[] lights = FindObjectsByType<Light>(FindObjectsInactive.Include);
+			foreach (Light light in lights)
+			{
+				if (light.type == LightType.Directional)
+				{
+					directionalLight = light;
+					return;
+				}
+			}
+		}
+
+		private void ApplyPreset(bool force)
+		{
+			if (ActivePreset == null)
+				return;
+
+			if (WorldClock.TryGetExistingInstance(out WorldClock worldClock) == false)
+				return;
+
+			if (worldClock.Config == null)
+				return;
+
+			float normalizedTime = ComputeNormalizedTime(worldClock);
+
+			if (force == false && Mathf.Approximately(normalizedTime, cachedNormalizedTime) == true)
+				return;
+
+			cachedNormalizedTime = normalizedTime;
+
+			ApplySky(normalizedTime);
+
+			if (applyDirectionalLight == true)
+				ApplyDirectionalLight(normalizedTime);
+
+			if (applyEnvironment == true)
+				ApplyEnvironment(normalizedTime);
+		}
+
+		private static float ComputeNormalizedTime(WorldClock worldClock)
+		{
+			float minutesPerDay = worldClock.Config.HoursPerDay * 60f;
+			float currentMinutes = worldClock.Hour * 60f + worldClock.Minute;
+			return currentMinutes / minutesPerDay;
+		}
+
+		private void ApplySky(float t)
+		{
+			if (SkyboxMaterial == null)
+				return;
+
+			SkyboxMaterial.SetColor(ZenithColorId, ActivePreset.ZenithColor.Evaluate(t));
+			SkyboxMaterial.SetColor(HorizonColorId, ActivePreset.HorizonColor.Evaluate(t));
+			SkyboxMaterial.SetColor(SunDiscColorId, ActivePreset.SunDiscColor.Evaluate(t));
+
+			float altitude = ActivePreset.SunAltitude.Evaluate(t);
+			Vector3 sunDirection = ComputeSunDirection(altitude);
+			SkyboxMaterial.SetVector(SunDirectionId, sunDirection);
+
+			SkyboxMaterial.SetFloat(StarAlphaId, ActivePreset.StarAlpha.Evaluate(t));
+		}
+
+		private static Vector3 ComputeSunDirection(float altitude)
+		{
+			// altitude: -1=수평선 아래 / 0=수평선 / 1=천정
+			float pitch = altitude * 90f * Mathf.Deg2Rad;
+			return new Vector3(0f, Mathf.Sin(pitch), Mathf.Cos(pitch));
+		}
+
+		private void ApplyDirectionalLight(float t)
+		{
+			if (directionalLight == null)
+			{
+				FindDirectionalLight();
+				if (directionalLight == null)
+					return;
+			}
+
+			directionalLight.color = ActivePreset.SunLightColor.Evaluate(t);
+			directionalLight.intensity = ActivePreset.SunIntensity.Evaluate(t);
+
+			float altitude = ActivePreset.SunAltitude.Evaluate(t);
+			float pitchDegrees = altitude * 90f;
+			directionalLight.transform.rotation = Quaternion.Euler(pitchDegrees, 30f, 0f);
+		}
+
+		private void ApplyEnvironment(float t)
+		{
+			RenderSettings.ambientMode = AmbientMode.Flat;
+			RenderSettings.ambientLight = ActivePreset.AmbientColor.Evaluate(t);
+			RenderSettings.fogColor = ActivePreset.FogColor.Evaluate(t);
+		}
+
+		[ContextMenu("Debug/Reapply Now")]
+		private void DebugReapplyNow()
+		{
+			cachedNormalizedTime = -1f;
+			Camera mainCamera = Camera.main;
+			Color zenith = ActivePreset != null ? ActivePreset.ZenithColor.Evaluate(0.78f) : Color.magenta;
+			Debug.Log($"[SkyDirector] DebugReapplyNow — RenderSettings.skybox: {(RenderSettings.skybox != null ? RenderSettings.skybox.name : "null")} | SkyboxMaterial: {(SkyboxMaterial != null ? SkyboxMaterial.name : "null")} | Camera.main.clearFlags: {(mainCamera != null ? mainCamera.clearFlags.ToString() : "n/a")} | Sunset zenith RGB: ({zenith.r:F2}, {zenith.g:F2}, {zenith.b:F2})");
+			ApplyPreset(force: true);
+		}
+
+		[ContextMenu("Debug/Force time 0.00 (Midnight)")]
+		private void DebugSetMidnight() => DebugApplyAtTime(0.00f);
+
+		[ContextMenu("Debug/Force time 0.25 (Dawn)")]
+		private void DebugSetDawn() => DebugApplyAtTime(0.25f);
+
+		[ContextMenu("Debug/Force time 0.50 (Noon)")]
+		private void DebugSetNoon() => DebugApplyAtTime(0.50f);
+
+		[ContextMenu("Debug/Force time 0.78 (Sunset)")]
+		private void DebugSetSunset() => DebugApplyAtTime(0.78f);
+
+		[ContextMenu("Debug/Force time 0.90 (Night)")]
+		private void DebugSetNight() => DebugApplyAtTime(0.90f);
+
+		private void DebugApplyAtTime(float t)
+		{
+			cachedNormalizedTime = -1f;
+			ApplySky(t);
+			if (applyDirectionalLight == true)
+				ApplyDirectionalLight(t);
+			if (applyEnvironment == true)
+				ApplyEnvironment(t);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyDirector.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyDirector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c66cd845649c1ce4193110cf9816c327

--- a/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyPresetSO.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyPresetSO.cs
@@ -1,0 +1,162 @@
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// 시간대별 하늘 색·곡선 Preset. 모든 색 = Gradient (0~1 = 00:00~24:00).
+	// 사용자가 인스펙터에서 Play 중 점 끌어 색 변경 → SkyDirector 가 매 tick 다시 평가 → 즉시 반영.
+	// preset swap = SkyDirector.ActivePreset 인스펙터에서 다른 SO 로 교체.
+	// (TASK-WM-054-C C1)
+	[CreateAssetMenu(fileName = nameof(SkyPresetSO), menuName = "WM/Sky/SkyPresetSO")]
+	public class SkyPresetSO : ScriptableObject
+	{
+		[field: Header("_" + nameof(SkyPresetSO))]
+		[field: Tooltip("preset 이름 (모동숲 / 스타듀 / WM 오리지널 등)")]
+		[field: SerializeField] public string DisplayName { get; private set; } = "Animal Crossing";
+
+		[field: Header("Sky Colors (0=00:00, 0.5=12:00, 1=24:00)")]
+		[field: SerializeField] public Gradient ZenithColor { get; private set; } = DefaultZenith();
+		[field: SerializeField] public Gradient HorizonColor { get; private set; } = DefaultHorizon();
+		[field: SerializeField] public Gradient SunDiscColor { get; private set; } = DefaultSunDisc();
+
+		[field: Header("Light / Fog / Ambient")]
+		[field: SerializeField] public Gradient SunLightColor { get; private set; } = DefaultSunLight();
+		[field: SerializeField] public Gradient FogColor { get; private set; } = DefaultFog();
+		[field: SerializeField] public Gradient AmbientColor { get; private set; } = DefaultAmbient();
+
+		[field: Header("Curves (0~1 → scalar)")]
+		[field: Tooltip("DirLight intensity (0=꺼짐, 1=정오 강함)")]
+		[field: SerializeField] public AnimationCurve SunIntensity { get; private set; } = DefaultSunIntensity();
+
+		[field: Tooltip("해 높이 (0=수평선 / 1=천정 / 다시 0=수평선). 0~1 = 00:00~24:00")]
+		[field: SerializeField] public AnimationCurve SunAltitude { get; private set; } = DefaultSunAltitude();
+
+		[field: Tooltip("별 layer alpha (밤만 1)")]
+		[field: SerializeField] public AnimationCurve StarAlpha { get; private set; } = DefaultStarAlpha();
+
+		[field: Tooltip("PostFX saturation (-100~100). C3b 에서 사용 (sub-C 후속)")]
+		[field: SerializeField] public AnimationCurve PostSaturation { get; private set; } = AnimationCurve.Constant(0f, 1f, 0f);
+
+		// ─── 모동숲 디폴트 색 (사용자 인스펙터 조정 전제) ───
+
+		private static Gradient DefaultZenith()
+		{
+			return MakeGradient(
+				(0.00f, new Color(0.10f, 0.08f, 0.25f)), // 깊은 남보라 (한밤)
+				(0.20f, new Color(0.55f, 0.45f, 0.65f)), // dawn 보라
+				(0.30f, new Color(0.50f, 0.75f, 0.90f)), // morning cyan
+				(0.50f, new Color(0.40f, 0.70f, 0.95f)), // 정오 맑은 파랑
+				(0.70f, new Color(0.55f, 0.55f, 0.85f)), // afternoon 톤
+				(0.78f, new Color(0.95f, 0.55f, 0.55f)), // sunset 분홍
+				(0.85f, new Color(0.30f, 0.20f, 0.55f)), // twilight 보라
+				(1.00f, new Color(0.10f, 0.08f, 0.25f))  // 깊은 남보라
+			);
+		}
+
+		private static Gradient DefaultHorizon()
+		{
+			return MakeGradient(
+				(0.00f, new Color(0.20f, 0.15f, 0.30f)),
+				(0.20f, new Color(1.00f, 0.70f, 0.75f)), // dawn 분홍
+				(0.30f, new Color(1.00f, 0.95f, 0.85f)), // morning 흰빛
+				(0.50f, new Color(0.85f, 0.90f, 1.00f)),
+				(0.75f, new Color(1.00f, 0.65f, 0.40f)), // sunset 주황
+				(0.83f, new Color(0.85f, 0.45f, 0.55f)),
+				(0.90f, new Color(0.25f, 0.20f, 0.40f)),
+				(1.00f, new Color(0.20f, 0.15f, 0.30f))
+			);
+		}
+
+		private static Gradient DefaultSunDisc()
+		{
+			return MakeGradient(
+				(0.00f, new Color(0f, 0f, 0f, 0f)),
+				(0.22f, new Color(1.00f, 0.80f, 0.70f, 1f)), // dawn
+				(0.50f, new Color(1.00f, 0.97f, 0.85f, 1f)), // 정오
+				(0.78f, new Color(1.00f, 0.55f, 0.30f, 1f)), // sunset
+				(0.85f, new Color(0f, 0f, 0f, 0f)),
+				(1.00f, new Color(0f, 0f, 0f, 0f))
+			);
+		}
+
+		private static Gradient DefaultSunLight()
+		{
+			return MakeGradient(
+				(0.00f, new Color(0.30f, 0.30f, 0.50f)), // 달빛
+				(0.22f, new Color(1.00f, 0.85f, 0.75f)),
+				(0.50f, new Color(1.00f, 0.95f, 0.90f)), // 정오 흰
+				(0.78f, new Color(1.00f, 0.65f, 0.45f)), // sunset 따뜻
+				(0.85f, new Color(0.45f, 0.35f, 0.55f)),
+				(1.00f, new Color(0.30f, 0.30f, 0.50f))
+			);
+		}
+
+		private static Gradient DefaultFog()
+		{
+			return MakeGradient(
+				(0.00f, new Color(0.15f, 0.13f, 0.25f)),
+				(0.50f, new Color(0.80f, 0.85f, 0.95f)),
+				(0.78f, new Color(0.95f, 0.75f, 0.65f)),
+				(1.00f, new Color(0.15f, 0.13f, 0.25f))
+			);
+		}
+
+		private static Gradient DefaultAmbient()
+		{
+			return MakeGradient(
+				(0.00f, new Color(0.18f, 0.18f, 0.30f)),
+				(0.50f, new Color(0.65f, 0.70f, 0.80f)),
+				(0.78f, new Color(0.85f, 0.65f, 0.60f)),
+				(1.00f, new Color(0.18f, 0.18f, 0.30f))
+			);
+		}
+
+		private static AnimationCurve DefaultSunIntensity()
+		{
+			AnimationCurve curve = new AnimationCurve();
+			curve.AddKey(0.00f, 0.10f); // 한밤 약한 달빛
+			curve.AddKey(0.20f, 0.40f);
+			curve.AddKey(0.50f, 1.20f); // 정오 강함
+			curve.AddKey(0.78f, 0.70f);
+			curve.AddKey(0.88f, 0.15f);
+			curve.AddKey(1.00f, 0.10f);
+			return curve;
+		}
+
+		private static AnimationCurve DefaultSunAltitude()
+		{
+			AnimationCurve curve = new AnimationCurve();
+			curve.AddKey(0.00f, -0.30f); // 한밤 수평선 아래
+			curve.AddKey(0.25f, 0.00f);  // dawn 수평선
+			curve.AddKey(0.50f, 1.00f);  // 정오 천정
+			curve.AddKey(0.75f, 0.00f);  // sunset 수평선
+			curve.AddKey(1.00f, -0.30f);
+			return curve;
+		}
+
+		private static AnimationCurve DefaultStarAlpha()
+		{
+			AnimationCurve curve = new AnimationCurve();
+			curve.AddKey(0.00f, 1.00f); // 한밤 별 뚜렷
+			curve.AddKey(0.20f, 0.20f);
+			curve.AddKey(0.30f, 0.00f); // morning 별 사라짐
+			curve.AddKey(0.78f, 0.00f);
+			curve.AddKey(0.88f, 0.50f); // 밤 별 등장
+			curve.AddKey(1.00f, 1.00f);
+			return curve;
+		}
+
+		private static Gradient MakeGradient(params (float time, Color color)[] keys)
+		{
+			Gradient gradient = new Gradient();
+			GradientColorKey[] colorKeys = new GradientColorKey[keys.Length];
+			GradientAlphaKey[] alphaKeys = new GradientAlphaKey[keys.Length];
+			for (int i = 0; i < keys.Length; i++)
+			{
+				colorKeys[i] = new GradientColorKey(keys[i].color, keys[i].time);
+				alphaKeys[i] = new GradientAlphaKey(keys[i].color.a, keys[i].time);
+			}
+			gradient.SetKeys(colorKeys, alphaKeys);
+			return gradient;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyPresetSO.cs.meta
+++ b/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyPresetSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8066ad0830248a94e8849559d47406e3

--- a/Assets/_WitchMendokusai/Editor/Sky.meta
+++ b/Assets/_WitchMendokusai/Editor/Sky.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d79731f54a7d86c45bddd2c13aff416c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Editor/Sky/SkyDirectorBootstrapMenu.cs
+++ b/Assets/_WitchMendokusai/Editor/Sky/SkyDirectorBootstrapMenu.cs
@@ -1,0 +1,108 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// SkyPresetSO + SkyboxGradient material + SkyDirector prefab 자동 생성.
+	// Domain Reload 시 missing 검사 → 자동 부트스트랩. (TASK-WM-054-C C1)
+	public static class SkyDirectorBootstrapMenu
+	{
+		private const string PRESET_PATH = "Assets/_WitchMendokusai/Core/Resources/SkyPreset_AnimalCrossing.asset";
+		private const string MATERIAL_PATH = "Assets/_WitchMendokusai/Core/Resources/SkyboxGradient.mat";
+		private const string PREFAB_PATH = "Assets/_WitchMendokusai/Core/Resources/Singletons/SkyDirector.prefab";
+		private const string SHADER_NAME = "WM/SkyboxGradient";
+
+		[InitializeOnLoadMethod]
+		private static void AutoBootstrapIfMissing()
+		{
+			if (AssetDatabase.LoadAssetAtPath<GameObject>(PREFAB_PATH) == null)
+			{
+				CreateBootstrap();
+				return;
+			}
+
+			EnsurePrefabFlags();
+		}
+
+		[MenuItem("WM/Setup/Recreate SkyDirector Bootstrap")]
+		private static void RecreateMenuItem() => CreateBootstrap();
+
+		private static void CreateBootstrap()
+		{
+			Shader shader = Shader.Find(SHADER_NAME);
+			if (shader == null)
+			{
+				Debug.LogWarning($"[SkyDirectorBootstrap] Shader '{SHADER_NAME}' 미발견. Shader 컴파일 후 재시도 (다음 Domain Reload).");
+				return;
+			}
+
+			SkyPresetSO preset = AssetDatabase.LoadAssetAtPath<SkyPresetSO>(PRESET_PATH);
+			if (preset == null)
+			{
+				preset = ScriptableObject.CreateInstance<SkyPresetSO>();
+				AssetDatabase.CreateAsset(preset, PRESET_PATH);
+				Debug.Log($"[SkyDirectorBootstrap] Created {PRESET_PATH}");
+			}
+
+			Material material = AssetDatabase.LoadAssetAtPath<Material>(MATERIAL_PATH);
+			if (material == null)
+			{
+				material = new Material(shader);
+				AssetDatabase.CreateAsset(material, MATERIAL_PATH);
+				Debug.Log($"[SkyDirectorBootstrap] Created {MATERIAL_PATH}");
+			}
+
+			GameObject root = new GameObject(nameof(SkyDirector));
+			SkyDirector skyDirector = root.AddComponent<SkyDirector>();
+
+			SerializedObject serializedObject = new SerializedObject(skyDirector);
+
+			SerializedProperty presetProp = serializedObject.FindProperty("<ActivePreset>k__BackingField");
+			if (presetProp != null)
+				presetProp.objectReferenceValue = preset;
+
+			SerializedProperty materialProp = serializedObject.FindProperty("<SkyboxMaterial>k__BackingField");
+			if (materialProp != null)
+				materialProp.objectReferenceValue = material;
+
+			SerializedProperty dontDestroyProp = serializedObject.FindProperty("dontDestroyOnLoad");
+			if (dontDestroyProp != null)
+				dontDestroyProp.boolValue = true;
+
+			serializedObject.ApplyModifiedProperties();
+
+			PrefabUtility.SaveAsPrefabAsset(root, PREFAB_PATH);
+			Object.DestroyImmediate(root);
+
+			AssetDatabase.SaveAssets();
+			AssetDatabase.Refresh();
+
+			Debug.Log($"[SkyDirectorBootstrap] Created {PREFAB_PATH}");
+		}
+
+		private static void EnsurePrefabFlags()
+		{
+			GameObject prefabRoot = PrefabUtility.LoadPrefabContents(PREFAB_PATH);
+			try
+			{
+				SkyDirector skyDirector = prefabRoot.GetComponent<SkyDirector>();
+				if (skyDirector == null)
+					return;
+
+				SerializedObject serializedObject = new SerializedObject(skyDirector);
+				SerializedProperty dontDestroyProp = serializedObject.FindProperty("dontDestroyOnLoad");
+				if (dontDestroyProp == null || dontDestroyProp.boolValue == true)
+					return;
+
+				dontDestroyProp.boolValue = true;
+				serializedObject.ApplyModifiedProperties();
+				PrefabUtility.SaveAsPrefabAsset(prefabRoot, PREFAB_PATH);
+				Debug.Log($"[SkyDirectorBootstrap] Updated {PREFAB_PATH} (dontDestroyOnLoad=true)");
+			}
+			finally
+			{
+				PrefabUtility.UnloadPrefabContents(prefabRoot);
+			}
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Editor/Sky/SkyDirectorBootstrapMenu.cs.meta
+++ b/Assets/_WitchMendokusai/Editor/Sky/SkyDirectorBootstrapMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ebdbd34f7cc663f4d89ac6bc4177bf1a

--- a/Assets/_WitchMendokusai/Shaders.meta
+++ b/Assets/_WitchMendokusai/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c64f6a515985dfd43a213f215de4d7ba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WitchMendokusai/Shaders/SkyboxGradient.shader
+++ b/Assets/_WitchMendokusai/Shaders/SkyboxGradient.shader
@@ -1,0 +1,90 @@
+// Skybox: zenith ↔ horizon gradient + sun disc.
+// 모동숲 같은 수채화 그라데이션 톤. SkyDirector 가 매 tick property mutate.
+// (TASK-WM-054-C C1; star/cloud 는 C4/C5 후속)
+Shader "WM/SkyboxGradient"
+{
+	Properties
+	{
+		_ZenithColor ("Zenith", Color) = (0.10, 0.10, 0.30, 1)
+		_HorizonColor ("Horizon", Color) = (1.00, 0.70, 0.50, 1)
+		_SunDiscColor ("Sun Disc", Color) = (1.00, 0.95, 0.85, 1)
+		_SunDirection ("Sun Direction (xyz, normalized)", Vector) = (0, 1, 0, 0)
+		_SunSize ("Sun Size", Range(0, 0.5)) = 0.04
+		_SunSoftness ("Sun Softness", Range(0, 0.5)) = 0.05
+		_HorizonExponent ("Horizon Exponent", Range(0.5, 8)) = 2.5
+		_StarAlpha ("Star Alpha (C4)", Range(0, 1)) = 0
+	}
+
+	SubShader
+	{
+		Tags
+		{
+			"Queue" = "Background"
+			"RenderType" = "Background"
+			"PreviewType" = "Skybox"
+			"RenderPipeline" = "UniversalPipeline"
+		}
+		Cull Off
+		ZWrite Off
+
+		Pass
+		{
+			HLSLPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+			struct Attributes
+			{
+				float4 positionOS : POSITION;
+			};
+
+			struct Varyings
+			{
+				float4 positionHCS : SV_POSITION;
+				float3 viewDir : TEXCOORD0;
+			};
+
+			CBUFFER_START(UnityPerMaterial)
+				float4 _ZenithColor;
+				float4 _HorizonColor;
+				float4 _SunDiscColor;
+				float4 _SunDirection;
+				float _SunSize;
+				float _SunSoftness;
+				float _HorizonExponent;
+				float _StarAlpha;
+			CBUFFER_END
+
+			Varyings vert(Attributes IN)
+			{
+				Varyings OUT;
+				OUT.positionHCS = TransformObjectToHClip(IN.positionOS.xyz);
+				OUT.viewDir = normalize(IN.positionOS.xyz);
+				return OUT;
+			}
+
+			half4 frag(Varyings IN) : SV_Target
+			{
+				float3 dir = normalize(IN.viewDir);
+
+				// 1. zenith ↔ horizon gradient
+				float horizonFactor = pow(saturate(1.0 - max(dir.y, 0.0)), _HorizonExponent);
+				float3 skyColor = lerp(_ZenithColor.rgb, _HorizonColor.rgb, horizonFactor);
+
+				// 2. sun disc
+				float3 sunDir = normalize(_SunDirection.xyz);
+				float sunDot = dot(dir, sunDir);
+				float innerEdge = 1.0 - _SunSize;
+				float outerEdge = innerEdge - _SunSoftness;
+				float sunMask = smoothstep(outerEdge, innerEdge, sunDot);
+				skyColor = lerp(skyColor, _SunDiscColor.rgb, sunMask * _SunDiscColor.a);
+
+				return half4(skyColor, 1.0);
+			}
+			ENDHLSL
+		}
+	}
+	Fallback Off
+}

--- a/Assets/_WitchMendokusai/Shaders/SkyboxGradient.shader.meta
+++ b/Assets/_WitchMendokusai/Shaders/SkyboxGradient.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b3b5357776ca6b149a480e7df1aa4d00
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,33 +181,50 @@ TASK 기반으로 시작한 작업은 `memo/wm/tasks/TASK-NNN-*.md`를 작업 �
 
 대화 말미에 별도로 안내하는 것으로 끝내지 않고, 문서에 남겨 추적 가능하게 한다.
 
-## 컴파일 에러 확인 — 사용자 검증 요청 전 본인 먼저
+## 컴파일 에러 확인 — `dotnet build` 우선
 
-코드 작성 후 사용자에게 "검증해주세요" 요청 *전*에 본인이 먼저 컴파일 에러 확인.
+코드 작성 후 사용자에게 "검증해주세요" 요청 *전*에 본인이 먼저 컴파일 검증.
 
-- Editor.log 위치: `C:\Users\masca\AppData\Local\Unity\Editor\Editor.log`
-- `grep "error CS" Editor.log` 으로 컴파일 에러 검색
+- 컴파일 검증 = **`dotnet build`** (Unity foreground / stuck state 무관, 30~40초)
+- Unity 가 필요한 건 *.meta / .prefab / .asset / 씬 / shader / Play Mode* 만 — `unity-refresh.ps1` 사용
 - 사용자가 코드 보고 검증하기 전에 *컴파일 통과* 자체가 사전 조건
 - "사용자에게 빨리 넘기기" 보다 *검증 가능한 상태로 넘기기* 가 우선
 
-### Editor.log stale 체크 — focus 안 됐으면 신뢰 X
+### 컴파일 검증 = `dotnet build` (Unity 무관)
 
-Unity Editor 가 **foreground (focus)** 상태가 아니면 .cs 변경 reimport 안 함 → Editor.log 가 *내 최근 변경을 반영 안 한 상태*. "에러 없어 보임" 이 거짓일 수 있음.
+```bash
+cd WitchMendokusai
+dotnet build Assembly-CSharp.csproj -v quiet --nologo 2>&1 | tail -20
+```
 
-확인 방법:
-- 새로 만든 *심볼* (클래스명 / 메서드명 / enum 항목) 이 Editor.log 에 잡히는지 grep — 안 잡히면 reimport 안 됨
-- `Reloading assemblies after forced synchronous recompile.` 로그의 *시점* — 내 변경 후인지 확인
-- `Refresh completed in ...` 으로 import 세션 끝 시점 확인
+- **Unity 가 stuck state 여도 작동** — Library/ScriptAssemblies / Editor.log 무관
+- WM 의 `Assembly-CSharp.csproj` 는 Unity 가 자동 생성 — 모든 패키지 references 박아둠
+- `오류 0개` / `error 0` 면 통과. warning 도 직접 출력 (deprecated API 등)
+- 모든 `.cs` (멀티 worktree / 멀티 sub) 즉시 검증
 
-stale 이면 — **자동화 우선**:
-1. **`pwsh memo/dotfiles/scripts/unity-refresh.ps1`** 호출 — Unity 창 `SetForegroundWindow` → Auto Refresh 트리거. 사용자에게 "Editor 창 클릭" 요청 X
-2. **sleep ~25초** — 컴파일 + Domain Reload + `[InitializeOnLoadMethod]` 까지 충분 (4~5 신규 .cs 기준; 더 많으면 30초 이상)
-3. **Editor.log grep** — `error CS` 0 + `Reloading assemblies after forced synchronous recompile` 새 매치 (이전 max line 보다 큰 line) 으로 컴파일 완료 검증
+### Unity 가 필요한 경우 = `unity-refresh.ps1`
 
-자동화 한계 (이때만 사용자 손 요청):
-- Unity 창이 *이미 foreground* 면 `SetForegroundWindow` no-op (focus 이벤트 X) — 우회: PowerShell `SendKeys ^r` 또는 사용자가 다른 창 잠시 클릭 후 재호출
-- Auto Refresh OFF 면 무용 — `Edit > Preferences > Asset Pipeline > Auto Refresh` 설정 사용자 컨펌 1회
-- 신규 폴더의 파일은 fsnotify 가 가끔 누락 → Project 패널에서 폴더 한 번 클릭 또는 Editor 재시작
+자산 + Play Mode 시만:
+
+```bash
+pwsh memo/dotfiles/scripts/unity-refresh.ps1
+# sleep ~25초 (Domain Reload + [InitializeOnLoadMethod])
+```
+
+용도:
+- `.meta` 자동 생성 (새 .cs / 폴더)
+- `.prefab` / `.asset` 자동 생성 (Bootstrap menu `[InitializeOnLoadMethod]`)
+- 씬 / `RenderSettings` / Volume Profile / shader 컴파일
+- Play Mode 진입 검증
+
+검증: Editor.log grep — `Reloading assemblies after forced synchronous recompile` 새 매치 + Bootstrap 로그
+
+### unity-refresh 한계 (이때만 사용자 손)
+
+- Unity 창이 *이미 foreground* 면 `SetForegroundWindow` no-op (focus 이벤트 X) — 우회: PowerShell `SendKeys ^r` 또는 사용자가 다른 창 잠시 클릭
+- Auto Refresh OFF → `Edit > Preferences > Asset Pipeline > Auto Refresh` 1회 컨펌
+- 신규 폴더 파일은 fsnotify 가 가끔 누락 → Project 패널에서 폴더 한 번 클릭
+- **Unity 컴파일 stuck state** (빈 .cs 가 일시 존재 후 컴파일 무응답) — `dotnet build` 로 코드 OK 검증 후 사용자에게 *Assets > Refresh* 메뉴 또는 Editor 재시작 1회 (unity-refresh / SendKeys 다 무효)
 
 ### 새 .cs 파일 만들었을 때
 


### PR DESCRIPTION
## Summary

TASK-WM-054 (밤낮·날씨) 의 **sub-C C1** — SkyDirector + 모동숲 Skybox.
WorldClock 시간 → `SkyPresetSO` Gradient 평가 → Skybox material property mutate.
**모동숲 (New Horizons) 디폴트** — 수채화 그라데이션 + 풍부한 채도 + 해질녘 분홍.

## Commits

- `6d57c529 docs(rules)` — `CLAUDE.md § 컴파일 에러 확인` 갱신: **`dotnet build` 우선** (Unity foreground / stuck 무관, 30~40초). Unity 자산 (.meta/.prefab/씬/shader/Play Mode) 만 `unity-refresh.ps1`. Unity 컴파일 stuck state 회복 안내 추가.
- `2d4d6289 feat(sky)` — 코드 + 자동 자산 (17 파일 +1127)

## 코드

- `Core/Scripts/Sky/SkyDirector.cs` — `Singleton<SkyDirector>` + 매 프레임 `RenderSettings.skybox` guard + 모든 색·곡선 lerp + ContextMenu 디버그 5개. SO 값 캐싱 X (런타임 tweak 즉시 반영). C2/C3a 단계는 SerializeField 토글로 후속 활성. `RuntimeInitializeOnLoadMethod(AfterSceneLoad)` Play Mode 자동 ensure.
- `Core/Scripts/Sky/SkyPresetSO.cs` — `ScriptableObject`, 6 Gradient + 4 AnimationCurve. 모동숲 디폴트.
- `Editor/Sky/SkyDirectorBootstrapMenu.cs` — `[InitializeOnLoadMethod]` 자동 부트스트랩 + idempotent `EnsurePrefabFlags` (`dontDestroyOnLoad=true`) + `WM/Setup/Recreate SkyDirector Bootstrap` 메뉴.
- `Shaders/SkyboxGradient.shader` — ShaderLab + HLSL. zenith/horizon gradient + sun disc. **`CBUFFER_START(UnityPerMaterial)`** — URP SRP Batcher 호환 (material property mutate 가 GPU 에 정상 전달).

## 자동 생성 자산

- `Core/Resources/SkyPreset_AnimalCrossing.asset`
- `Core/Resources/SkyboxGradient.mat`
- `Core/Resources/Singletons/SkyDirector.prefab`

## Test plan

- [x] `dotnet build Assembly-CSharp.csproj` error 0
- [x] Play Mode 진입 → Skybox 색 시간 따라 변화
- [x] `Debug/Force time 0.25 (Dawn)` — 진보라 → 분홍
- [x] `Debug/Force time 0.50 (Noon)` — 맑은 파랑
- [x] `Debug/Force time 0.78 (Sunset)` — 주황·분홍·보라 그라데이션 ★
- [x] `Debug/Force time 0.90 (Night)` — 짙은 남보라

사용자 모동숲 톤 검증 OK (2026-05-08).

## 학습 + 발견

- **Unity 가 씬 전환 시 `RenderSettings.skybox` 를 그 씬의 Lighting Settings Skybox Material 로 자동 reset** — 매 프레임 guard 로 SkyboxGradient 복구. WM 코드 내 `RenderSettings.skybox = ...` setter 0 — Unity 자체 동작.
- **`CBUFFER_START(UnityPerMaterial)` 누락** 시 URP SRP Batcher 가 `material.SetColor` 무시. Skybox 색 변화 0 의 1차 원인이었음.
- **Unity 컴파일 stuck state** — 빈 .cs 일시 존재 후 컴파일 무응답. `dotnet build` 로 코드 OK 검증 후 사용자 *Assets > Refresh* 또는 재시작.
- **`dotnet build` Unity 무관 검증** — 사용자 지적: "컴파일만 하는 거면 유니티 포커스 안 해도 되지 않나?" — 룰 본문에 박음.

## 후속 (sub-C 안)

- **C2** — DirLight 회전 (SunAltitude curve) + 색·intensity (`applyDirectionalLight = true`)
- **C3a** — Fog + Ambient (`applyEnvironment = true`)
- **C3b** — PostFX Volume blend (WM-055 PostProcessSlot 안정화 후 통합)
- **C4** — Star layer (SkyboxGradient shader)
- **C5** — Cloud layer (sub-D WeatherSystem 결합)

## 후속 follow-up (별도 TASK)

모든 씬 (Lobby/Loading/Intro/World/8 stage) Lighting Settings 의 Skybox Material 을 `SkyboxGradient.mat` 으로 변경 — EditorWindow 자동화 + 씬 dirty 처리. 현 시점 매 프레임 guard 로 즉시 복구라 비용 최소.

## Related

- parent TASK: `memo/wm/tasks/TASK-WM-054-밤낮-날씨-시스템.md`
- sub-C TASK: `memo/wm/tasks/TASK-WM-054-C-SkyDirector.md`
- sub-A (이미 머지): WorldClock 시간 모델 (#107)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시간대별 하늘 모양 제어 시스템 추가
  * 사용자 정의 가능한 하늘 프리셋 시스템 구현 (그래디언트, 애니메이션 곡선 포함)
  * 방향성 조명 및 환경 설정 지원 추가

* **문서**
  * 컴파일 검증 지침 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->