### PR TITLE
feat(shader-modding): TASK-WM-058 P2-A — 환경 슬롯 인프라 (Skybox/Water 스텁)

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManager.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/ShaderPackManager.cs
@@ -31,6 +31,8 @@ namespace WitchMendokusai
 		private void RegisterSlots()
 		{
 			RegisterSlot(new PostProcessSlot());
+			RegisterSlot(new SkyboxSlot());
+			RegisterSlot(new WaterSlot());
 		}
 
 		private void RegisterSlot(IShaderPackSlot slot)

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/SkyboxSlot.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/SkyboxSlot.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// P2 — Skybox slot. RenderSettings.skybox 교체 + uniform input contract.
+	// 모더 Skybox Material 이 SkyDirector 의 시간대 색 uniform 받아 합성:
+	//   _WMSkyZenith / _WMSkyHorizon / _WMSkySun / _WMSkyStarAlpha / _WMSunAltitude / _WMSunDirection / _WMNormalizedTime
+	// 자세한 contract: memo/wm/design/systems/shader-modding-architecture.md
+	public class SkyboxSlot : IShaderPackSlot
+	{
+		public const string SLOT_ID = "skybox";
+
+		public string SlotId => SLOT_ID;
+
+		public void Apply(AssetBundle bundle, ShaderPackSlotInfo slotInfo)
+		{
+			// P2-B 에서 구현 — RenderSettings.skybox 백업 + 모더 Material 적용
+		}
+
+		public void Revert()
+		{
+			// P2-B 에서 구현 — RenderSettings.skybox 복원
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/WaterSlot.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/WaterSlot.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// P2 — Water slot. 호수/바다 GameObject 의 MeshRenderer.sharedMaterial 교체.
+	public class WaterSlot : IShaderPackSlot
+	{
+		public const string SLOT_ID = "water";
+
+		public string SlotId => SLOT_ID;
+
+		public void Apply(AssetBundle bundle, ShaderPackSlotInfo slotInfo)
+		{
+			// P2-C 에서 구현 — 호수/바다 MeshRenderer 식별 + sharedMaterial 교체
+		}
+
+		public void Revert()
+		{
+			// P2-C 에서 구현 — sharedMaterial 복원
+		}
+	}
+}


### PR DESCRIPTION
## Summary

**TASK-WM-058 P2-A** — 환경 슬롯 인프라. SkyboxSlot + WaterSlot 스텁 + ShaderPackManager 등록.

P2-B (Skybox 실 구현) / P2-C (Water 실 구현) 는 SkyDirector (TASK-WM-054-C) C2/C3 안정 후 — 시간대 색 uniform 노출 합의 끝나면 모더 SubGraph 가 그걸 input 받아 합성.

## 변경

- `SkyboxSlot.cs` (신규) — `IShaderPackSlot` 구현, SLOT_ID = `"skybox"`. Apply/Revert 빈 스텁
- `WaterSlot.cs` (신규) — `IShaderPackSlot` 구현, SLOT_ID = `"water"`. Apply/Revert 빈 스텁
- `ShaderPackManager.RegisterSlots` — PostProcessSlot 외 두 슬롯 등록 추가

## 안전성

- 동작 변화 0 — Apply/Revert 빈 스텁 + 모더 셰이더팩에 `skybox` / `water` slot 안 박혀있으면 호출 0
- SkyDirector / 다른 세션과 충돌 0 — 신규 .cs 파일 + 단일 라인 추가만

## 합성 모델 (옵션 B 사용자 컨펌, design doc 참고)

Skybox 가 한 Material 만 가능 (`RenderSettings.skybox`) → **uniform input contract**:
- SkyDirector 가 `Shader.SetGlobal*` 로 시간대 색 노출 (`_WMSkyZenith` / `_WMSkyHorizon` / `_WMSkySun` / `_WMSkyStarAlpha` / `_WMSunAltitude` / `_WMSunDirection` / `_WMNormalizedTime`)
- 모더 Skybox ShaderGraph 가 그 input 받아 자기 효과 합성
- 모더 효과가 *시간대에 자동 반응*

자세한 contract: `memo/wm/design/systems/shader-modding-architecture.md` 의 「P2 — 환경 슬롯 uniform contract」 섹션

## Test plan

- [x] 컴파일 통과 가정 (단순 스텁 + 단일 라인)
- [ ] **사용자 시각 검증** — `WM > Setup > Recreate ShaderPackManager Bootstrap` 후 Play → Console log "Scanned N shader packs" 정상

## Follow-up

- P2-B: SkyboxSlot 실 구현 (RenderSettings.skybox 백업/교체/복원) — SkyDirector 안정 후
- P2-C: WaterSlot 실 구현 (호수/바다 MeshRenderer.sharedMaterial 교체) — 호수/바다 GameObject 식별 합의 후
- P2-D: 샘플 셰이더팩 (예: aurora-sky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)