### PR TITLE
fix(ci): unity-build-gate paths filter — self-trigger 방지

### DIFF
--- a/.github/workflows/unity-build-gate.yml
+++ b/.github/workflows/unity-build-gate.yml
@@ -12,7 +12,7 @@ on:
       - 'Assets/**/*.shadergraph'
       - 'Assembly-CSharp.csproj'
       - 'Packages/**'
-      - '.github/workflows/unity-build-gate.yml'
+      # workflow yml 자체는 paths filter 에서 제외 — self-trigger 방지 (사용자 셋업 전엔 self-hosted runner 미존재라 영원 pending)
 
 concurrency:
   group: unity-build-gate-${{ github.ref }}


### PR DESCRIPTION
PR #116 (Unity Build Gate) 의 paths filter 에 self path 포함 → 다음 yml 변경 PR self-trigger → self-hosted runner 미등록 시 영원 pending. self path 제거.

작은 chore (1줄) — Default Ready 자동 머지.

Related: #116 / TASK-WM-060

🤖 Generated with [Claude Code](https://claude.com/claude-code)
