### PR TITLE
feat(shader-modding): TASK-WM-058 P2-C — WaterSlot 실 구현 + WaterRenderer 마커

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/WaterRenderer.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/WaterRenderer.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// 셰이더팩 Water slot 의 식별 마커. 호수/바다 GameObject 에 붙인다.
+	// WaterSlot 이 FindObjectsByType<WaterRenderer> 로 탐지 후 MeshRenderer.sharedMaterial 교체.
+	[RequireComponent(typeof(MeshRenderer))]
+	public class WaterRenderer : MonoBehaviour
+	{
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/WaterSlot.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/ShaderModding/WaterSlot.cs
@@ -1,22 +1,62 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace WitchMendokusai
 {
-	// P2 — Water slot. 호수/바다 GameObject 의 MeshRenderer.sharedMaterial 교체.
+	// P2 — Water slot. WaterRenderer 마커가 붙은 MeshRenderer 들의 sharedMaterial 을 모더 Material 로 교체.
 	public class WaterSlot : IShaderPackSlot
 	{
 		public const string SLOT_ID = "water";
 
 		public string SlotId => SLOT_ID;
 
+		private readonly Dictionary<MeshRenderer, Material> originalMaterials = new();
+
 		public void Apply(AssetBundle bundle, ShaderPackSlotInfo slotInfo)
 		{
-			// P2-C 에서 구현 — 호수/바다 MeshRenderer 식별 + sharedMaterial 교체
+			Material modderMaterial = bundle.LoadAsset<Material>(slotInfo.assetName);
+			if (modderMaterial == null)
+			{
+				Debug.LogError($"[WaterSlot] Material '{slotInfo.assetName}' not found in bundle.");
+				return;
+			}
+
+			Revert();
+
+			WaterRenderer[] waterRenderers = Object.FindObjectsByType<WaterRenderer>(FindObjectsSortMode.None);
+			if (waterRenderers.Length == 0)
+			{
+				Debug.LogWarning($"[WaterSlot] No WaterRenderer found in scene. Material '{slotInfo.assetName}' has no target.");
+				return;
+			}
+
+			foreach (WaterRenderer waterRenderer in waterRenderers)
+			{
+				MeshRenderer meshRenderer = waterRenderer.GetComponent<MeshRenderer>();
+				if (meshRenderer == null)
+					continue;
+
+				originalMaterials[meshRenderer] = meshRenderer.sharedMaterial;
+				meshRenderer.sharedMaterial = modderMaterial;
+			}
+
+			Debug.Log($"[WaterSlot] Applied Material '{slotInfo.assetName}' to {originalMaterials.Count} WaterRenderer(s).");
 		}
 
 		public void Revert()
 		{
-			// P2-C 에서 구현 — sharedMaterial 복원
+			if (originalMaterials.Count == 0)
+				return;
+
+			foreach (KeyValuePair<MeshRenderer, Material> pair in originalMaterials)
+			{
+				if (pair.Key == null)
+					continue;
+				pair.Key.sharedMaterial = pair.Value;
+			}
+
+			Debug.Log($"[WaterSlot] Reverted {originalMaterials.Count} WaterRenderer(s).");
+			originalMaterials.Clear();
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **WaterRenderer** 마커 컴포넌트 신규 (`[RequireComponent(typeof(MeshRenderer))]`) — 호수/바다 GameObject 식별 마커
- **WaterSlot** 스텁 → 실 구현 — `FindObjectsByType<WaterRenderer>` 로 탐지 후 `MeshRenderer.sharedMaterial` 백업·교체·복원

## 결정 (사용자 컨펌)

호수/바다 GameObject 식별 방법 = **Component marker** (Tag/Layer/Singleton registry 후보 중 채택).

이유: Tag/Layer 는 *문자열·번호 매칭* 이라 typo fragile + 의미 oversaturate (Layer 는 rendering/physics 용도). Component marker = type-safe + 의미 명시적 + 다중 호수/바다 자연 + 미래 노브 (스플래시·물결 등) 박을 자리. WM 의 명시적 구조 패턴 정합.

## Test plan

- [x] 컴파일 검증 — Unity Build Gate (TASK-WM-060, self-hosted runner) 자동
- [ ] 사용자 main pull 후: 호수/바다 GameObject 에 `WaterRenderer` 컴포넌트 추가 (Inspector → Add Component)
- [ ] 셰이더팩 manifest 에 `{"id":"water","assetName":"<Material>","blendMode":"replace","priority":0}` 박은 팩 작성 후 Apply → 호수/바다 시각 변화 확인
- [ ] Revert 시 원본 sharedMaterial 복원 확인

## 관련

- TASK-WM-058 — `memo/wm/tasks/TASK-WM-058-P2-환경슬롯-Skybox-Water.md`
- 부모 TASK-WM-055 — 셰이더 모딩 P2 환경 슬롯
- 의존: PR #115 (P2-A 인프라) 머지 완료 ✅