### PR TITLE
feat(sky): TASK-WM-054-C C2 — DirectionalLight 회전 + sunAzimuth 노출

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyDirector.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyDirector.cs
@@ -13,8 +13,11 @@ namespace WitchMendokusai
 		[field: SerializeField] public Material SkyboxMaterial { get; private set; }
 
 		[Header("C2 / C3a — 단계별 활성")]
-		[SerializeField] private bool applyDirectionalLight = false;
+		[SerializeField] private bool applyDirectionalLight = true;
 		[SerializeField] private bool applyEnvironment = false;
+
+		[Header("C2 — Sun Rotation")]
+		[SerializeField, Range(0f, 360f)] private float sunAzimuth = 30f;
 
 		[Header("Debug")]
 		[SerializeField] private bool debugLogStartup = false;
@@ -178,7 +181,7 @@ namespace WitchMendokusai
 
 			float altitude = ActivePreset.SunAltitude.Evaluate(t);
 			float pitchDegrees = altitude * 90f;
-			directionalLight.transform.rotation = Quaternion.Euler(pitchDegrees, 30f, 0f);
+			directionalLight.transform.rotation = Quaternion.Euler(pitchDegrees, sunAzimuth, 0f);
 		}
 
 		private void ApplyEnvironment(float t)

--- a/Assets/_WitchMendokusai/Editor/Sky/SkyDirectorBootstrapMenu.cs
+++ b/Assets/_WitchMendokusai/Editor/Sky/SkyDirectorBootstrapMenu.cs
@@ -90,14 +90,28 @@ namespace WitchMendokusai
 					return;
 
 				SerializedObject serializedObject = new SerializedObject(skyDirector);
+				bool changed = false;
+
 				SerializedProperty dontDestroyProp = serializedObject.FindProperty("dontDestroyOnLoad");
-				if (dontDestroyProp == null || dontDestroyProp.boolValue == true)
+				if (dontDestroyProp != null && dontDestroyProp.boolValue == false)
+				{
+					dontDestroyProp.boolValue = true;
+					changed = true;
+				}
+
+				SerializedProperty applyDirLightProp = serializedObject.FindProperty("applyDirectionalLight");
+				if (applyDirLightProp != null && applyDirLightProp.boolValue == false)
+				{
+					applyDirLightProp.boolValue = true;
+					changed = true;
+				}
+
+				if (changed == false)
 					return;
 
-				dontDestroyProp.boolValue = true;
 				serializedObject.ApplyModifiedProperties();
 				PrefabUtility.SaveAsPrefabAsset(prefabRoot, PREFAB_PATH);
-				Debug.Log($"[SkyDirectorBootstrap] Updated {PREFAB_PATH} (dontDestroyOnLoad=true)");
+				Debug.Log($"[SkyDirectorBootstrap] Updated {PREFAB_PATH}");
 			}
 			finally
 			{


### PR DESCRIPTION
## Summary

TASK-WM-054-C **C2** — DirectionalLight 시간대 회전 활성화 + 방위각(`sunAzimuth`) 노브 노출.

- `applyDirectionalLight` default `false` → `true` — C1 (Skybox 만) 단계 → C2 (DirLight 추가)
- `sunAzimuth` SerializeField `[Range(0, 360)]` = 30f — 하드코드 30f 제거 (§ 수치 노출 / 런타임 tweak)
- `SkyDirectorBootstrapMenu.EnsurePrefabFlags` 다중 flag idempotent — 기존 prefab 의 `applyDirectionalLight` 자동 갱신

## Test plan

- [ ] (사용자 main pull 후) Unity Editor — `SkyDirector` prefab 의 `applyDirectionalLight=true` + `sunAzimuth=30` 확인
- [ ] Play 시 시간 흐름에 따라 DirLight pitch 변화 (낮 = 천정 / 밤 = 수평선 아래)
- [ ] 인스펙터 `sunAzimuth` 슬라이더 0~360 변경 시 즉시 반영

## 컴파일 검증

- 본인: `dotnet build` 시도 (worktree csproj 부재 — main worktree csproj copy 후 ProjectReference 절대경로 변환). Reference 누락 warning 다수 + 한글 폴더 mojibake 1 error (encoding) — 본 PR 변경 자체와 무관. **Unity Build Gate (self-hosted runner)** 가 PR check 로 정확 검증 (TASK-WM-060)

🤖 Generated with [Claude Code](https://claude.com/claude-code)