### PR TITLE
feat(sky): TASK-WM-054-C C3a — Fog/Ambient 환경광 활성화 + FogDensity SO 노브

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyDirector.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyDirector.cs
@@ -14,7 +14,7 @@ namespace WitchMendokusai
 
 		[Header("C2 / C3a — 단계별 활성")]
 		[SerializeField] private bool applyDirectionalLight = true;
-		[SerializeField] private bool applyEnvironment = false;
+		[SerializeField] private bool applyEnvironment = true;
 
 		[Header("C2 — Sun Rotation")]
 		[SerializeField, Range(0f, 360f)] private float sunAzimuth = 30f;
@@ -188,7 +188,11 @@ namespace WitchMendokusai
 		{
 			RenderSettings.ambientMode = AmbientMode.Flat;
 			RenderSettings.ambientLight = ActivePreset.AmbientColor.Evaluate(t);
+
+			RenderSettings.fog = true;
+			RenderSettings.fogMode = ActivePreset.FogMode;
 			RenderSettings.fogColor = ActivePreset.FogColor.Evaluate(t);
+			RenderSettings.fogDensity = ActivePreset.FogDensity.Evaluate(t);
 		}
 
 		[ContextMenu("Debug/Reapply Now")]

--- a/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyPresetSO.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyPresetSO.cs
@@ -36,6 +36,13 @@ namespace WitchMendokusai
 		[field: Tooltip("PostFX saturation (-100~100). C3b 에서 사용 (sub-C 후속)")]
 		[field: SerializeField] public AnimationCurve PostSaturation { get; private set; } = AnimationCurve.Constant(0f, 1f, 0f);
 
+		[field: Header("Fog (C3a)")]
+		[field: Tooltip("Fog mode (Linear / Exponential / ExponentialSquared 권장)")]
+		[field: SerializeField] public FogMode FogMode { get; private set; } = UnityEngine.FogMode.ExponentialSquared;
+
+		[field: Tooltip("Fog density 시간대별 (ExponentialSquared 권장 0.005~0.02)")]
+		[field: SerializeField] public AnimationCurve FogDensity { get; private set; } = DefaultFogDensity();
+
 		// ─── 모동숲 디폴트 색 (사용자 인스펙터 조정 전제) ───
 
 		private static Gradient DefaultZenith()
@@ -130,6 +137,17 @@ namespace WitchMendokusai
 			curve.AddKey(0.50f, 1.00f);  // 정오 천정
 			curve.AddKey(0.75f, 0.00f);  // sunset 수평선
 			curve.AddKey(1.00f, -0.30f);
+			return curve;
+		}
+
+		private static AnimationCurve DefaultFogDensity()
+		{
+			AnimationCurve curve = new AnimationCurve();
+			curve.AddKey(0.00f, 0.012f); // 한밤 약간 진한 안개
+			curve.AddKey(0.20f, 0.018f); // dawn 아침안개 가장 진함
+			curve.AddKey(0.50f, 0.005f); // 정오 맑음
+			curve.AddKey(0.78f, 0.010f); // sunset 약간
+			curve.AddKey(1.00f, 0.012f);
 			return curve;
 		}
 

--- a/Assets/_WitchMendokusai/Editor/Sky/SkyDirectorBootstrapMenu.cs
+++ b/Assets/_WitchMendokusai/Editor/Sky/SkyDirectorBootstrapMenu.cs
@@ -106,6 +106,13 @@ namespace WitchMendokusai
 					changed = true;
 				}
 
+				SerializedProperty applyEnvProp = serializedObject.FindProperty("applyEnvironment");
+				if (applyEnvProp != null && applyEnvProp.boolValue == false)
+				{
+					applyEnvProp.boolValue = true;
+					changed = true;
+				}
+
 				if (changed == false)
 					return;
 


### PR DESCRIPTION
## Summary

TASK-WM-054-C **C3a** — 시간대별 Fog + Ambient 환경광 적용.

- `applyEnvironment` default `false` → `true` (C3a 활성)
- `ApplyEnvironment` 확장 — `RenderSettings.fog=true` + `fogMode` + `fogDensity` 추가 (이전엔 `fogColor` 만 박혀 fog enable 안 되면 무효)
- `SkyPresetSO` 에 `FogMode` (enum, default ExponentialSquared) + `FogDensity` (AnimationCurve) 노출 — § 수치 노출 / 런타임 tweak
- `DefaultFogDensity` — 모동숲 톤: dawn 0.018 (아침안개 가장 진함) / 정오 0.005 (맑음) / sunset 0.010 / 밤 0.012
- `SkyDirectorBootstrapMenu.EnsurePrefabFlags` 에 `applyEnvironment` idempotent — 기존 prefab 자동 갱신

## Test plan

- [ ] (사용자 main pull 후) Unity Editor — `SkyDirector` prefab 의 `applyEnvironment=true` 확인 + `SkyPreset_AnimalCrossing` 의 `FogMode=ExponentialSquared` + `FogDensity` curve 보임
- [ ] Play 시 시간 흐름에 따라 ambient 색 전환 (밤=남보라 / 정오=흰빛 / sunset=주황빛)
- [ ] dawn (~0.20) 시점 fog 진해짐 / 정오 (~0.50) 거의 사라짐 — 거리감 변화 시각 확인
- [ ] 인스펙터 `FogDensity` curve 점 끌어 0.05 같은 진한 값 → 즉시 반영

## 컴파일 검증

작은 SerializeField 추가 + 기존 EnsurePrefabFlags 패턴 그대로 — 컴파일 안전. Unity Build Gate (TASK-WM-060, self-hosted runner) 가 PR check 로 정확 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)