### PR TITLE
feat(NodeGraph): TASK-WM-034 H1 — 런타임 NodeGraphRuntimeView foundation

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/Runtime/EdgeRuntimeElement.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/Runtime/EdgeRuntimeElement.cs
@@ -1,0 +1,103 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace WitchMendokusai.NodeGraph.Runtime
+{
+	/// <summary>
+	/// 두 노드 사이 엣지 라인 (런타임). Painter2D 로 LineTo 그림 — 곡선/화살표 자유.
+	/// 엔드포인트 (source/target VisualElement) 의 layout 변동 시 자동 MarkDirtyRepaint.
+	///
+	/// H1: 직선 라인 + 단일 색. 후속 단계: H3 Provider 가 도메인별 색/굵기/곡선/화살표 결정.
+	/// </summary>
+	public class EdgeRuntimeElement : VisualElement
+	{
+		public const string USS_CLASS = "wm-edge-runtime";
+
+		private VisualElement sourceElement;
+		private VisualElement targetElement;
+		private Color lineColor = new Color(0.7f, 0.7f, 0.8f, 1f);
+		private float lineWidth = 2f;
+
+		public EdgeRuntimeElement()
+		{
+			AddToClassList(USS_CLASS);
+
+			pickingMode = PickingMode.Ignore;
+			style.position = Position.Absolute;
+			style.left = 0;
+			style.top = 0;
+			style.right = 0;
+			style.bottom = 0;
+
+			generateVisualContent += OnGenerateVisualContent;
+			RegisterCallback<DetachFromPanelEvent>(OnDetachFromPanel);
+		}
+
+		/// <summary>엔드포인트 설정 — source / target 의 layout 변동 시 자동 repaint.</summary>
+		public void SetEndpoints(VisualElement source, VisualElement target)
+		{
+			UnregisterEndpointCallbacks();
+
+			sourceElement = source;
+			targetElement = target;
+
+			if (sourceElement != null)
+				sourceElement.RegisterCallback<GeometryChangedEvent>(OnEndpointGeometryChanged);
+
+			if (targetElement != null)
+				targetElement.RegisterCallback<GeometryChangedEvent>(OnEndpointGeometryChanged);
+
+			MarkDirtyRepaint();
+		}
+
+		public void SetLineColor(Color color)
+		{
+			lineColor = color;
+			MarkDirtyRepaint();
+		}
+
+		public void SetLineWidth(float width)
+		{
+			lineWidth = width;
+			MarkDirtyRepaint();
+		}
+
+		private void OnEndpointGeometryChanged(GeometryChangedEvent evt) => MarkDirtyRepaint();
+
+		private void OnDetachFromPanel(DetachFromPanelEvent evt) => UnregisterEndpointCallbacks();
+
+		private void UnregisterEndpointCallbacks()
+		{
+			if (sourceElement != null)
+				sourceElement.UnregisterCallback<GeometryChangedEvent>(OnEndpointGeometryChanged);
+
+			if (targetElement != null)
+				targetElement.UnregisterCallback<GeometryChangedEvent>(OnEndpointGeometryChanged);
+		}
+
+		private void OnGenerateVisualContent(MeshGenerationContext context)
+		{
+			if (sourceElement == null || targetElement == null)
+				return;
+
+			Rect sourceLayout = sourceElement.layout;
+			Rect targetLayout = targetElement.layout;
+
+			if (sourceLayout.width <= 0f || targetLayout.width <= 0f)
+				return;
+
+			Vector2 fromCenter = sourceLayout.center;
+			Vector2 toCenter = targetLayout.center;
+
+			Painter2D painter = context.painter2D;
+			painter.strokeColor = lineColor;
+			painter.lineWidth = lineWidth;
+			painter.lineCap = LineCap.Round;
+
+			painter.BeginPath();
+			painter.MoveTo(fromCenter);
+			painter.LineTo(toCenter);
+			painter.Stroke();
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/Runtime/NodeGraphRuntimeView.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/Runtime/NodeGraphRuntimeView.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace WitchMendokusai.NodeGraph.Runtime
+{
+	/// <summary>
+	/// 런타임 노드 그래프 시각 (UI Toolkit). NodeGraph SO 받아 노드/엣지 인스턴스화 + 화면 표시.
+	/// Editor 측 GraphView (단계 B) 와 sibling — 데이터 모델 (NodeGraph + NodeBase + NodeConnection) 공유.
+	///
+	/// H1 단계 (2026-05-08): generic only — 라벨+박스 노드 + Painter2D 라인 엣지. read-only.
+	/// 후속 단계: H2 줌/팬, H3 Provider 패턴 (도메인별 커스텀 비주얼), H4 클릭/hover 이벤트.
+	/// </summary>
+	public class NodeGraphRuntimeView : VisualElement
+	{
+		public const string USS_CLASS = "wm-nodegraph-runtime";
+		public const string USS_CANVAS = "wm-nodegraph-runtime__canvas";
+
+		private readonly VisualElement canvas;
+		private readonly Dictionary<string, NodeRuntimeElement> nodeElementsById = new();
+		private readonly List<EdgeRuntimeElement> edgeElements = new();
+
+		private NodeGraph boundGraph;
+
+		public IReadOnlyDictionary<string, NodeRuntimeElement> NodeElementsById => nodeElementsById;
+
+		public NodeGraphRuntimeView()
+		{
+			AddToClassList(USS_CLASS);
+
+			style.overflow = Overflow.Hidden;
+			style.flexGrow = 1;
+
+			canvas = new VisualElement();
+			canvas.AddToClassList(USS_CANVAS);
+			canvas.style.position = Position.Absolute;
+			canvas.style.left = 0;
+			canvas.style.top = 0;
+			canvas.style.right = 0;
+			canvas.style.bottom = 0;
+			canvas.pickingMode = PickingMode.Ignore;
+			Add(canvas);
+		}
+
+		/// <summary>그래프 바인딩 — 호출마다 전체 재구성. 노드/엣지 위치는 NodeBase.EditorPosition + NodeConnection.</summary>
+		public void Bind(NodeGraph graph)
+		{
+			boundGraph = graph;
+			Refresh();
+		}
+
+		/// <summary>그래프 데이터 변동 시 명시 호출. (자동 hot reload 는 1차 X — 후속 H 후속.)</summary>
+		public void Refresh()
+		{
+			canvas.Clear();
+			nodeElementsById.Clear();
+			edgeElements.Clear();
+
+			if (boundGraph == null)
+				return;
+
+			foreach (NodeBase node in boundGraph.Nodes)
+			{
+				if (node == null)
+					continue;
+
+				NodeRuntimeElement nodeElement = new();
+				nodeElement.Bind(node);
+				nodeElement.style.position = Position.Absolute;
+				nodeElement.style.left = node.EditorPosition.x;
+				nodeElement.style.top = node.EditorPosition.y;
+				nodeElementsById[node.Id] = nodeElement;
+			}
+
+			foreach (NodeConnection connection in boundGraph.Connections)
+			{
+				if (connection == null)
+					continue;
+
+				if (nodeElementsById.TryGetValue(connection.SourceNodeId, out NodeRuntimeElement sourceElement) == false)
+					continue;
+
+				if (nodeElementsById.TryGetValue(connection.TargetNodeId, out NodeRuntimeElement targetElement) == false)
+					continue;
+
+				EdgeRuntimeElement edgeElement = new();
+				edgeElement.SetEndpoints(sourceElement, targetElement);
+				canvas.Add(edgeElement);
+				edgeElements.Add(edgeElement);
+			}
+
+			foreach (NodeRuntimeElement nodeElement in nodeElementsById.Values)
+				canvas.Add(nodeElement);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/Runtime/NodeRuntimeElement.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/NodeGraph/Runtime/NodeRuntimeElement.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace WitchMendokusai.NodeGraph.Runtime
+{
+	/// <summary>
+	/// 단일 노드 비주얼 (런타임). H1: generic 라벨+박스 — 노드 타입 이름 표시.
+	/// H3 (Provider 패턴) 진입 시: NodeRuntimeProviderRegistry lookup → 도메인별 커스텀 VisualElement 로 본문 교체.
+	/// </summary>
+	public class NodeRuntimeElement : VisualElement
+	{
+		public const string USS_CLASS = "wm-node-runtime";
+		public const string USS_TITLE = "wm-node-runtime__title";
+		public const string USS_BODY = "wm-node-runtime__body";
+
+		private readonly Label titleLabel;
+		private readonly VisualElement body;
+
+		public NodeBase Node { get; private set; }
+
+		public NodeRuntimeElement()
+		{
+			AddToClassList(USS_CLASS);
+
+			style.minWidth = 100;
+			style.minHeight = 30;
+			style.paddingTop = 4;
+			style.paddingBottom = 4;
+			style.paddingLeft = 8;
+			style.paddingRight = 8;
+			style.backgroundColor = new Color(0.18f, 0.18f, 0.22f, 0.95f);
+			style.borderTopWidth = 1;
+			style.borderBottomWidth = 1;
+			style.borderLeftWidth = 1;
+			style.borderRightWidth = 1;
+			Color borderColor = new Color(0.4f, 0.4f, 0.5f, 1f);
+			style.borderTopColor = borderColor;
+			style.borderBottomColor = borderColor;
+			style.borderLeftColor = borderColor;
+			style.borderRightColor = borderColor;
+			style.borderTopLeftRadius = 4;
+			style.borderTopRightRadius = 4;
+			style.borderBottomLeftRadius = 4;
+			style.borderBottomRightRadius = 4;
+
+			titleLabel = new Label();
+			titleLabel.AddToClassList(USS_TITLE);
+			titleLabel.style.color = new Color(0.9f, 0.9f, 0.95f, 1f);
+			titleLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
+			Add(titleLabel);
+
+			body = new VisualElement();
+			body.AddToClassList(USS_BODY);
+			Add(body);
+		}
+
+		/// <summary>노드 데이터 바인딩 — 라벨 갱신. H3 진입 시 Provider 가 body 교체.</summary>
+		public void Bind(NodeBase node)
+		{
+			Node = node;
+			titleLabel.text = node == null ? "?" : node.GetType().Name;
+		}
+
+		/// <summary>H3 Provider 패턴 진입 시 — body 안에 도메인별 비주얼 주입.</summary>
+		public VisualElement Body => body;
+	}
+}


### PR DESCRIPTION
## Summary

TASK-WM-034 「공통 노드 그래프 시스템」의 단계 H (런타임 view) 첫 commit. Editor GraphView (단계 B) 의 sibling — UI Toolkit `VisualElement` 위에서 NodeGraph SO 를 시각화. read-only.

본 단계 = TASK-WM-059 (MagicBook UI Toolkit 마이그) 의 blocker — H done 후 059 진입.

## 신규 파일

`Assets/_WitchMendokusai/Core/Scripts/NodeGraph/Runtime/` (런타임 안전, Editor deps X):

- `NodeGraphRuntimeView.cs` — `VisualElement`. `Bind(NodeGraph)` API. 노드/엣지 인스턴스화 + 캔버스 표시
- `NodeRuntimeElement.cs` — 단일 노드 비주얼 (generic 라벨+박스). H3 Provider 패턴 진입 시 body 교체
- `EdgeRuntimeElement.cs` — Painter2D 라인 (직선, 단일 색). source/target `GeometryChangedEvent` 자동 repaint

## 결정 슬롯 컨펌 (TASK-WM-034 § H)

| # | 항목 | 답 |
| --- | --- | --- |
| 1 | 노드 시각 모델 | Provider 패턴 (H3 분리, H1 은 generic 만) |
| 2 | Edge 그리기 | Painter2D 라인 (정식) |
| 3 | 줌/팬 모델 | 자체 transform (H2) |
| 4 | Read-only 강도 | 클릭/hover 이벤트 (H4) |
| 5 | 그래프 데이터 소스 | NodeGraph SO 만 (사용처 어댑터) |

## H 단계 진행 계획

- ✅ H1 = 본 PR — generic foundation
- H2 = RuntimePanZoomManipulator (Pan + Zoom)
- H3 = Provider 패턴 + NodeRuntimeProviderRegistry
- H4 = OnNodeClicked / OnNodeHovered 이벤트
- H5 = 검증 씬 (TestGraph dummy 표시)
- H6 = TASK-WM-059 hand-off (MagicBookGraphProvider)

## Test plan

- [ ] dotnet build 통과 (Unity Build Gate CI)
- [ ] 사용자 main pull 후 unity-refresh — `.cs.meta` 자동 생성 + Editor.log 컴파일 에러 0
- [ ] (H5 단계) TestGraph dummy 그래프 (Constant + Add + Output) 가 런타임 view 에 노드 3개 + 엣지 2개로 표시

## 의존

- 종속 TASK: TASK-WM-059 (MagicBook 마이그) — 본 H 완료 후 진입
- foundation TASK: TASK-WM-034 단계 A/B/C done 위에 sibling

🤖 Generated with [Claude Code](https://claude.com/claude-code)