### PR TITLE
feat(ci): TASK-WM-062 sub-B — Claude primary review job (PR opened/synchronize)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,6 +3,8 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
   pull_request_review_comment:
     types: [created]
   issues:
@@ -39,6 +41,52 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+  claude-review:
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Primary Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          mode: review
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            이 PR 을 primary code reviewer 로 검토하고 GitHub PR review 를 submit 해라.
+
+            검토 영역:
+            - 버그 / 논리 오류 / edge case
+            - 보안 (injection, 권한, 데이터 노출)
+            - 성능 (알고리즘, 메모리)
+            - 코드 품질 / 가독성 / 유지보수성
+            - WitchMendokusai CLAUDE.md 룰 준수:
+              * Allman 중괄호 (항상 새 줄)
+              * `== false` (`!` 연산자 금지)
+              * `var` 금지 (명시적 타입)
+              * 변수명 풀네임 (for 의 i, j 외 한 글자 축약 X)
+              * 상수 UPPER_SNAKE_CASE
+              * 이벤트/델리게이트 `delegate { }` 초기화
+              * FastFail (TryGet/null 체크/기본값으로 증상 덮기 X)
+              * 수치는 SO / [SerializeField] / Variable<T>
+              * 입력은 InputManager.RegisterInputEvent (직접 Keyboard.current X)
+              * MenuItem path top-level `WM/...` (`WitchMendokusai/...` X)
+
+            원칙:
+            - Actionable 한 변경 제안만 — nitpick / 주관적 스타일 의견 X
+            - 큰 아키텍처 지적은 코멘트로만 (코드 변경 X)
+            - 검토 결과 review submit:
+              * 문제 없음 → approve
+              * actionable 지적 1+ → request_changes
+              * 큰 아키텍처 지적만 → comment
 
   claude-coderabbit:
     if: github.event_name == 'pull_request_review' && github.event.review.user.login == 'coderabbitai[bot]'


### PR DESCRIPTION
## Summary

`claude.yml` 에 새 `claude-review` job 추가 — PR opened/synchronize/ready_for_review 트리거 + `anthropics/claude-code-action@v1` mode=review. Draft PR skip.

## Why

PR #119 (TASK-WM-058 P2-C) 가 push 후 **26초** 만에 머지됐는데 CodeRabbit 무료 플랜 45분 쿨타임으로 review 시작 X → **AI 리뷰 0 으로 머지**.

룰 본문 ([WitchMendokusai/CLAUDE.md § Git Workflow](../blob/main/CLAUDE.md#git-workflow)) — "AI Native 라 사용자 검토 슬롯 = AI 리뷰 (CodeRabbit / Copilot / Claude review-fix) 가 대체" 정합 깨짐.

기존 인프라 진단:
- ✅ `claude` job — @claude 멘션 핸들링
- ✅ `claude-coderabbit` / `claude-copilot` job — review 도착 시 fix-loop
- ❌ **PR opened 시 *primary review* job 없음** — CodeRabbit/Copilot 외부 의존, 쿨타임 = 게이트 빠짐

## Solution

**Claude 가 primary reviewer**. `CLAUDE_CODE_OAUTH_TOKEN` (Pro/Max 구독) 사용 — 쿨타임 X + 사용자 비용 0. CodeRabbit/Copilot 은 secondary informative.

Prompt: 버그/보안/성능/코드 품질 + WitchMendokusai CLAUDE.md 룰 (Allman, `== false`, `var` 금지, 변수명 풀네임, FastFail, 수치 SO 노출, InputManager, MenuItem `WM/`) 준수. Actionable 만, nitpick X.

## Test plan

이 PR 자체엔 새 job 트리거 X (GitHub Actions 룰: `pull_request` 이벤트는 *base branch* 의 workflow 사용 → main 머지 후 다음 PR 부터 작동).

- [x] yaml syntax 검증 — Read 로 들여쓰기/키 중복 체크 ✅
- [ ] 머지 후 검증 PR 1건 — Claude primary review 코멘트 도착 확인
- [ ] 사용자: GitHub repo Settings > Branches > main protection > Required status checks 에 \`claude-review\` job name 추가 (sub-E)
- [ ] sub-D: WM CLAUDE.md § Git Workflow 룰 본문 갱신 — Claude review primary 명시

## 관련

- TASK-WM-062 — \`memo/wm/tasks/TASK-WM-062-AI-리뷰-게이트-Claude-review-job.md\`
- 사후 진단 PR: #119 (P2-C 머지, AI 리뷰 0)
- 후속 sub-D / sub-E / sub-F (별도 PR / 사용자 작업)