### PR TITLE
fix(save): SaveManager.cs `using UnityEngine;` 추가 — Debug 컴파일 에러

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/Data/Save/SaveManager.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Data/Save/SaveManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using KarmoLabs;
+using UnityEngine;
 using static WitchMendokusai.SOHelper;
 
 namespace WitchMendokusai


### PR DESCRIPTION
## Summary

main 컴파일 에러 fix — 1줄 (`using UnityEngine;` 추가).

## 원인

PR #106 (TASK-WM-013 prototype) 가 main 머지되면서 `SaveManager.cs:104` 에 `Debug.Log` 호출 추가했는데 `using UnityEngine;` 누락. `dotnet build` 결과:

\`\`\`
SaveManager.cs(104,5): error CS0103: 'Debug' 이름이 현재 컨텍스트에 없습니다.
오류 1개
\`\`\`

Unity Build Gate (TASK-WM-060) 도입 *전* 머지된 PR 이라 자동 컴파일 검증 0 → main 에 에러 박힌 채 머지됨.

## 영향

- main 빌드 실패 → 모든 PR 검증 막힘
- 특히 TASK-WM-056-D D1 (#118) + D3 (#121) verify 흐름 진입 불가
- 본 fix 가 다른 PR 검증의 *전제 조건*

## 검증

\`\`\`bash
dotnet build Assembly-CSharp.csproj -v quiet --nologo --property:RunAnalyzers=false
# → 오류 0개 (warning 55개 — 별 영역)
\`\`\`

Unity Build Gate 가 PR check 로 자동 재검증.

## 후속

- D1 #118 + D3 #121 검증 진입 (이 PR 머지 후 main 컴파일 정상 → verify 브랜치 reimport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)