### PR TITLE
chore(ci): TASK-WM-062 sub-G — CodeRabbit/Copilot 자동 review 비활성화

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,6 +2,11 @@
 # 코드 리뷰 룰의 정본은 WitchMendokusai/CLAUDE.md — CodeRabbit 이 자동 픽업.
 # 본 yaml 은 CodeRabbit 자체에 대한 메타 설정만 (language, profile 등).
 # https://docs.coderabbit.ai/knowledge-base/code-guidelines
+
+# 2026-05-08 (TASK-WM-062 sub-G): 자동 review + chat 비활성화.
+# 사유: Claude primary review (claude.yml claude-review job) 도입 후 secondary 가
+# 중복 + 무료 플랜 45분 쿨타임으로 게이트 의미 빠짐. 다중 AI primary review = 노이즈
+# + 의견 충돌 + fix-loop 비효율. 수동 invoke (`@coderabbitai review`) 는 가능.
 language: "ko-KR"
 
 reviews:
@@ -12,8 +17,8 @@ reviews:
   review_status: true
   collapse_walkthrough: false
   auto_review:
-    enabled: true
-    drafts: true
+    enabled: false
+    drafts: false
 
 chat:
-  auto_reply: true
+  auto_reply: false

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -88,60 +88,7 @@ jobs:
               * actionable 지적 1+ → request_changes
               * 큰 아키텍처 지적만 → comment
 
-  claude-coderabbit:
-    if: github.event_name == 'pull_request_review' && github.event.review.user.login == 'coderabbitai[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Apply CodeRabbit suggestions
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "coderabbitai[bot]"
-          prompt: |
-            CodeRabbit이 이 PR에 코드 리뷰를 남겼습니다. 리뷰의 actionable 제안을 검토해 적절한 것만 적용하세요.
-
-            적용 기준:
-            - 버그, 명백한 코딩 스타일 위반, 논리 오류 → 적용
-            - nitpick / 주관적 스타일 의견 → 건너뜀
-            - 아키텍처·설계 변경이 필요한 큰 지적 → 코드 변경 없이 코멘트로 설명만
-            - WitchMendokusai CLAUDE.md 룰 (Allman, == false, var 금지, 변수명 풀네임) 준수
-
-  claude-copilot:
-    if: github.event_name == 'pull_request_review' && github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Apply Copilot suggestions
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "copilot-pull-request-reviewer[bot]"
-          prompt: |
-            GitHub Copilot이 이 PR에 코드 리뷰를 남겼습니다. 리뷰의 actionable 제안을 검토해 적절한 것만 적용하세요.
-
-            적용 기준:
-            - 버그, 명백한 코딩 스타일 위반, 논리 오류 → 적용
-            - nitpick / 주관적 스타일 의견 → 건너뜀
-            - 아키텍처·설계 변경이 필요한 큰 지적 → 코드 변경 없이 코멘트로 설명만
-            - WitchMendokusai CLAUDE.md 룰 (Allman, == false, var 금지, 변수명 풀네임) 준수
+# claude-coderabbit / claude-copilot fix-loop job 은 TASK-WM-062 sub-G (2026-05-08) 에서 제거.
+# 사유: Claude primary review (claude-review job) 도입 + .coderabbit.yaml auto_review.enabled=false
+# + GitHub repo Copilot review off → secondary review 자체 비활성화 → fix-loop 트리거 없음.
+# 후속 활용 시 다시 추가 — anthropics/claude-code-action 의 allowed_bots 패턴 사용.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,7 @@ pwsh memo/dotfiles/scripts/unity-refresh.ps1
 
 ## Git Workflow
 
-본 § 가 본 레포 git workflow 의 정본. CodeRabbit 이 자동 픽업해 같은 룰로 PR 리뷰.
+본 § 가 본 레포 git workflow 의 정본. CodeRabbit / Copilot 자동 review 는 비활성화 (TASK-WM-062 sub-G, 2026-05-08) — Claude primary review (`claude.yml` claude-review job) 가 *유일한 AI 리뷰어*.
 
 ### 브랜치 + PR 강제 (AI Native 게이트)
 
@@ -281,18 +281,15 @@ pwsh memo/dotfiles/scripts/unity-refresh.ps1
 - `chore/<주제>` — 빌드·CI·의존성·환경 설정·문서
 - `refactor/<주제>` — 동작 변화 없는 정리
 
-**Default Ready PR 생성** (`gh pr create` 에 `--draft` *제거*) + `.github/pull_request_template.md` 의도 채움 → push → 자동 폐쇄 루프가 머지 + cascade 처리. AI Native 라 사용자 검토 슬롯 = AI 리뷰 (**Claude primary review** + CodeRabbit/Copilot secondary + Claude review-fix) 가 대체.
+**Default Ready PR 생성** (`gh pr create` 에 `--draft` *제거*) + `.github/pull_request_template.md` 의도 채움 → push → 자동 폐쇄 루프가 머지 + cascade 처리. AI Native 라 사용자 검토 슬롯 = AI 리뷰 (**Claude primary review**) 가 대체.
 
-### AI Native 자동 폐쇄 루프 (2026-05-07 도입, 2026-05-08 Claude primary review 추가)
+### AI Native 자동 폐쇄 루프 (2026-05-07 도입, 2026-05-08 Claude primary review 단일화)
 
 ```
 PR opened (Default Ready)
   ├─ claude.yml `claude-review` job (anthropics/claude-code-action@v1, mode=review)
   │    ↓ Claude primary review — 버그/보안/성능/품질 + WM 룰 체크 → review submit
   │      (approve / request_changes / comment)
-  ├─ CodeRabbit / Copilot review (secondary informative — 무료 플랜 쿨타임 종속)
-  │    ↓ review.submitted 이벤트 → claude.yml `claude-coderabbit` / `claude-copilot` job
-  │      → Claude 가 actionable 제안만 fix-loop
   └─ auto-merge.yml (BOT_TOKEN, user actor)  ─── ready_for_review 이벤트 받아 gh pr merge --auto --squash
        ↓ Required 게이트 통과 (Code Quality typo strict + GitGuardian + claude-review + 옵셔널 Unity Build Gate)
        ↓ squash 머지 (user actor → push event 발생)
@@ -306,6 +303,8 @@ main push event
   │       Claude 자동 conflict 해결 + push → 다시 게이트
   └─ Stack PR: GitHub 자동 retarget (base=feature → main) → 자동 머지 cascade
 ```
+
+> *CodeRabbit / Copilot 자동 review 비활성화 (TASK-WM-062 sub-G)* — 다중 AI primary review = 노이즈 + 의견 충돌 + fix-loop 비효율 + CodeRabbit 무료 쿨타임 게이트 빠짐. 후속 활용 검토 사항은 § AI 리뷰 게이트 참고.
 
 호출 (autopilot / 사람 PR 동일):
 ```bash
@@ -437,7 +436,7 @@ runs-on: [self-hosted, windows, wm-unity]
 - 시각·런타임 검증 X — 컴파일 only. 시각은 사용자 main pull 후 Play Mode (현재 흐름 그대로).
 - Unity 두 인스턴스 동시 실행 — 같은 PC 에서 가능 (다른 projectPath). main worktree Unity 와 runner Unity 별도 worktree 라 OK.
 
-**현 게이트** (Unity Build Gate 추가 후): `Code Quality typo + GitGuardian + Unity Build Gate + Claude primary review + CodeRabbit/Copilot 리뷰 (secondary)` — auto-merge 자동 폐쇄 루프.
+**현 게이트**: `Code Quality typo + GitGuardian + Unity Build Gate + Claude primary review` — auto-merge 자동 폐쇄 루프. CodeRabbit/Copilot 자동 review 는 비활성화 (TASK-WM-062 sub-G).
 
 ### AI 리뷰 게이트 — Claude primary review
 
@@ -465,16 +464,32 @@ jobs:
 
 **배경**: PR #119 (TASK-WM-058 P2-C) 가 push 후 26초 만에 머지됐는데 CodeRabbit 무료 플랜 45분 쿨타임으로 review 시작 X → AI 리뷰 0 으로 머지. 룰 본문 「AI 리뷰가 사용자 검토 슬롯 대체」 정합 깨짐.
 
-**해결 흐름**:
-- Claude = *primary reviewer* (쿨타임 X, OAuth 구독 비용 0)
-- CodeRabbit / Copilot = *secondary informative* (review 도착 시 Claude 가 actionable fix-loop)
+**해결 흐름** (sub-G, 2026-05-08 단일화):
+- Claude = *유일한 AI 리뷰어* (쿨타임 X, OAuth 구독 비용 0)
+- CodeRabbit / Copilot 자동 review 비활성화 — `.coderabbit.yaml` `auto_review.enabled: false` + GitHub repo Settings > Code review > Copilot off
+- claude.yml 의 `claude-coderabbit` / `claude-copilot` fix-loop job 도 제거 (트리거 X)
 - `claude-review` job 의 status check 가 Branch Protection 의 Required 로 등록되면 머지 차단 게이트로 작동
 
 **사용자 1회 셋업**:
 
 1. `CLAUDE_CODE_OAUTH_TOKEN` secret — 이미 등록 (TASK-WM-062 sub-A 진단 결과)
 2. Branch Protection (`main`) 의 *Required status checks* 에 `claude-review` 추가 (sub-B 머지 후 1번 작동 시 check name 등록 → 그 후 추가 가능)
+3. GitHub repo Settings > Code review > Copilot review off (자동 review 트리거 차단)
 
 **한계**:
 - claude-review job 의 *job success* 만 status check 통과 신호 — review state (request_changes) 는 *관찰* 만, 머지 차단 X (GitHub 한계 — Required reviews 는 human reviewer 만 인정)
 - 즉 Claude 가 *부정적 review* (request_changes) 를 남기더라도 Required check 통과는 됨. **review 코멘트** 가 머지 후 사용자에게 정합성 신호 역할.
+
+**CodeRabbit / Copilot 후속 활용 검토** (sub-G, 비활성화 상태):
+
+비활성화 사유 = *primary review 중복* + *쿨타임 게이트 빠짐* + *fix-loop 비효율*. *secondary 가치 자체* 는 부정 X — 후속 활용 시점 검토:
+
+- **수동 invoke** — PR 코멘트 `@coderabbitai review` / Copilot `Re-request review` 로 *필요 시* 호출. Claude 가 미스 한 영역 (예: 라이브러리 deprecation 패턴 / 문서 표현) 보강.
+- **유료 플랜** — CodeRabbit Pro ($20/mo) / Copilot Pro 로 쿨타임 제거 + secondary 자동화 재개. 비용 대비 *Claude review 가 안 잡는 영역 가치* 가 정당화 시점에.
+- **영역 분담** — Claude = 코드 품질·룰 체크, CodeRabbit = 보안 audit / 의존성 freshness, Copilot = 일반 best practice. paths filter 로 영역별 트리거.
+- **Claude review 사후 보완** — Claude 가 끝낸 후 CodeRabbit 에 사후 invoke → "Claude 가 놓친 게 있나?" 식 cross-check. 무료 플랜 쿨타임 OK (한 PR 당 1번).
+
+재활성화 시 변경:
+- `.coderabbit.yaml` `auto_review.enabled: true` (또는 `paths` filter 로 영역 한정)
+- claude.yml `claude-coderabbit` / `claude-copilot` job 복원 (allowed_bots 패턴)
+- WM CLAUDE.md § AI Native 자동 폐쇄 루프 도식 갱신


### PR DESCRIPTION
## Summary

CodeRabbit / Copilot 자동 review 양쪽 끝 다 비활성화. Claude primary review 단일화.

**3 영역**:
- \`.coderabbit.yaml\`: \`reviews.auto_review.enabled: false\` + \`chat.auto_reply: false\`
- \`.github/workflows/claude.yml\`: \`claude-coderabbit\` + \`claude-copilot\` fix-loop job 제거
- \`WitchMendokusai/CLAUDE.md\` § Git Workflow: 본문 + 도식 + § AI 리뷰 게이트 갱신 (비활성화 사유 + 후속 활용 검토 메모)

## Why

다중 AI primary review = 노이즈 + 의견 충돌 + fix-loop 비효율. CodeRabbit 무료 45분 쿨타임 = 게이트 의미 빠짐 (PR #119 사후 진단). Claude primary review (sub-B 도입) 만으로 룰 정합성 회복.

## 후속 활용 검토 (CLAUDE.md 본문에 박음)

비활성화 사유 = primary review 중복 + 쿨타임 게이트 빠짐 + fix-loop 비효율. *secondary 가치 자체* 는 부정 X — 후속 활용 시점:

- **수동 invoke** — \`@coderabbitai review\` 로 필요 시 호출 (Claude 가 미스 한 영역 보강)
- **유료 플랜** — CodeRabbit Pro / Copilot Pro 로 쿨타임 제거 후 secondary 자동화 재개
- **영역 분담** — paths filter 로 Claude=코드 품질, CodeRabbit=보안 audit, Copilot=일반 best practice
- **Claude review 사후 보완** — Claude 끝난 후 CodeRabbit 에 사후 invoke → cross-check (한 PR 당 1번이라 무료 쿨타임 OK)

## Test plan

- [x] yaml syntax 검증
- [ ] 본 PR 자체 — claude-review 단독 작동 확인 (CodeRabbit/Copilot 트리거 X)
- [ ] 사용자: GitHub repo Settings > Code review > Copilot review off

## 관련

- TASK-WM-062 sub-G — \`memo/wm/tasks/TASK-WM-062-*.md\`
- sub-B PR #125 (머지됨) — Claude primary review 도입
- sub-D PR #126 (머지됨) — CLAUDE.md § Git Workflow 본문 (그 본문이 본 PR 에서 sub-G 갱신)