### PR TITLE
feat(sky): TASK-WM-054-C C6 — Shader Modding Contract standard uniform 노출

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyDirector.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/Sky/SkyDirector.cs
@@ -4,9 +4,9 @@ using UnityEngine.Rendering;
 namespace WitchMendokusai
 {
 	// 시간대별 하늘·라이팅 lerp. WorldClock 의 시간 → SkyPresetSO 의 Gradient 평가
-	// → Skybox material property + DirLight + Fog/Ambient 적용.
+	// → Skybox material property + DirLight + Fog/Ambient + Shader Global 적용.
 	// SO 값 캐싱 X — 인스펙터 런타임 변경 즉시 반영.
-	// (TASK-WM-054-C C1: Skybox 만 / C2: DirLight / C3a: Fog/Ambient)
+	// (TASK-WM-054-C C1: Skybox 만 / C2: DirLight / C3a: Fog/Ambient / C6: Shader Modding Contract)
 	public class SkyDirector : Singleton<SkyDirector>
 	{
 		[field: SerializeField] public SkyPresetSO ActivePreset { get; set; }
@@ -30,6 +30,17 @@ namespace WitchMendokusai
 		private static readonly int SunDiscColorId = Shader.PropertyToID("_SunDiscColor");
 		private static readonly int SunDirectionId = Shader.PropertyToID("_SunDirection");
 		private static readonly int StarAlphaId = Shader.PropertyToID("_StarAlpha");
+
+		// Shader Modding Contract (C6) — 모더 ShaderGraph 가 받을 standard global uniform 7개.
+		// 매 프레임 SetGlobal 로 노출 → WM-058 P2-B SkyboxSlot 가 RenderSettings.skybox 교체 시
+		// 모더 Material 이 자동으로 base 시간대 색감 받음 (base+overlay 합성 모델).
+		private static readonly int WMSkyZenithId = Shader.PropertyToID("_WMSkyZenith");
+		private static readonly int WMSkyHorizonId = Shader.PropertyToID("_WMSkyHorizon");
+		private static readonly int WMSkySunId = Shader.PropertyToID("_WMSkySun");
+		private static readonly int WMSkyStarAlphaId = Shader.PropertyToID("_WMSkyStarAlpha");
+		private static readonly int WMSunAltitudeId = Shader.PropertyToID("_WMSunAltitude");
+		private static readonly int WMSunDirectionId = Shader.PropertyToID("_WMSunDirection");
+		private static readonly int WMNormalizedTimeId = Shader.PropertyToID("_WMNormalizedTime");
 
 		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
 		private static void EnsureSingletonOnPlay()
@@ -120,12 +131,29 @@ namespace WitchMendokusai
 			cachedNormalizedTime = normalizedTime;
 
 			ApplySky(normalizedTime);
+			ApplyShaderGlobals(normalizedTime);
 
 			if (applyDirectionalLight == true)
 				ApplyDirectionalLight(normalizedTime);
 
 			if (applyEnvironment == true)
 				ApplyEnvironment(normalizedTime);
+		}
+
+		// 모더 ShaderGraph contract — SkyboxMaterial 유무와 무관하게 항상 노출.
+		// 모더 Skybox/Water/PostFX 등 셰이더가 _WM* 글로벌 받아 시간대 색감 합성.
+		private void ApplyShaderGlobals(float normalizedTime)
+		{
+			Shader.SetGlobalColor(WMSkyZenithId, ActivePreset.ZenithColor.Evaluate(normalizedTime));
+			Shader.SetGlobalColor(WMSkyHorizonId, ActivePreset.HorizonColor.Evaluate(normalizedTime));
+			Shader.SetGlobalColor(WMSkySunId, ActivePreset.SunDiscColor.Evaluate(normalizedTime));
+			Shader.SetGlobalFloat(WMSkyStarAlphaId, ActivePreset.StarAlpha.Evaluate(normalizedTime));
+
+			float altitude = ActivePreset.SunAltitude.Evaluate(normalizedTime);
+			Shader.SetGlobalFloat(WMSunAltitudeId, altitude);
+			Shader.SetGlobalVector(WMSunDirectionId, ComputeSunDirection(altitude));
+
+			Shader.SetGlobalFloat(WMNormalizedTimeId, normalizedTime);
 		}
 
 		private static float ComputeNormalizedTime(WorldClock worldClock)
@@ -215,6 +243,7 @@ namespace WitchMendokusai
 		{
 			cachedNormalizedTime = -1f;
 			ApplySky(t);
+			ApplyShaderGlobals(t);
 			if (applyDirectionalLight == true)
 				ApplyDirectionalLight(t);
 			if (applyEnvironment == true)


### PR DESCRIPTION
## 목적

WM-058 P2-B SkyboxSlot 차단 해소. SkyDirector 가 매 프레임 `Shader.SetGlobal*` 로 standard uniform 7개 노출 → 모더 ShaderGraph 가 받을 *base 시간대 색감 contract*.

## 변경

`Assets/_WitchMendokusai/Core/Scripts/Sky/SkyDirector.cs` — `ApplyShaderGlobals(t)` 신규 메서드:

| uniform | 타입 | 출처 |
| --- | --- | --- |
| `_WMSkyZenith` | Color | `ZenithColor.Evaluate(t)` |
| `_WMSkyHorizon` | Color | `HorizonColor.Evaluate(t)` |
| `_WMSkySun` | Color | `SunDiscColor.Evaluate(t)` |
| `_WMSkyStarAlpha` | float | `StarAlpha.Evaluate(t)` |
| `_WMSunAltitude` | float | `SunAltitude.Evaluate(t)` |
| `_WMSunDirection` | Vector3 | `ComputeSunDirection(altitude)` |
| `_WMNormalizedTime` | float | `t` (0~1) |

`ApplyPreset` + `DebugApplyAtTime` 에서 `ApplyShaderGlobals` 호출 추가.

## 설계

- **`ApplyShaderGlobals` 별도 메서드** — `ApplySky` (SkyboxMaterial property) 와 분리. SkyboxMaterial 이 null 이어도 SetGlobal 은 항상 노출되어야 모더 Water/PostFX 셰이더도 받을 수 있음 (base+overlay 합성 모델).
- **`Shader.PropertyToID` 캐싱** — 매 프레임 호출이라 hash lookup 비용 회피.
- **uniform 풀 7개** = WM-058 design doc 일치 + 모더 자유도 최대 (사용자 컨펌).

## 검증

- worktree 의 `Assembly-CSharp.csproj` 부재 → `dotnet build` 검증 불가 (다중 세션 룰).
- 코드 변경 31줄 + 표준 Unity API (`Shader.SetGlobalColor/Float/Vector`) → 컴파일 위험 매우 낮음.
- 시각 변화 0 (모더 셰이더 없으면 SetGlobal 가 무 영향) → 사용자 플레이 검증 부담 0.
- 사용자 main pull 후 Unity reimport 시점에 컴파일 자동 검증.

## 후속

- TASK-WM-058 P2-B SkyboxSlot 진입 가능 — `RenderSettings.skybox` 백업/교체/복원.
- TASK-WM-058 P2-D 샘플 셰이더팩 (`aurora-sky` 등) 의 ShaderGraph 가 본 uniform contract 받음.