### PR TITLE
feat(WM-084): Phase A — UGC JSON serializer + SaveData schema

### DIFF
--- a/Assets/_WitchMendokusai/Core/Scripts/UGC/JsonUgcSerializer.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/UGC/JsonUgcSerializer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -10,6 +9,7 @@ namespace WitchMendokusai
 		{
 			PropertyNameCaseInsensitive = true,
 			WriteIndented = true,
+			IncludeFields = true,
 			Converters = { new JsonStringEnumConverter() }
 		};
 

--- a/Assets/_WitchMendokusai/Core/Scripts/UGC/JsonUgcSerializer.cs
+++ b/Assets/_WitchMendokusai/Core/Scripts/UGC/JsonUgcSerializer.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WitchMendokusai
+{
+	public static class JsonUgcSerializer
+	{
+		private static readonly JsonSerializerOptions DefaultOptions = new()
+		{
+			PropertyNameCaseInsensitive = true,
+			WriteIndented = true,
+			Converters = { new JsonStringEnumConverter() }
+		};
+
+		public static string SerializeItem(ItemInfoSaveData itemData)
+		{
+			return JsonSerializer.Serialize(itemData, DefaultOptions);
+		}
+
+		public static ItemInfoSaveData DeserializeItem(string json)
+		{
+			if (string.IsNullOrWhiteSpace(json) == false)
+			{
+				return JsonSerializer.Deserialize<ItemInfoSaveData>(json, DefaultOptions);
+			}
+			return default;
+		}
+
+		public static string SerializeSeedItem(SeedItemInfoSaveData seedItemData)
+		{
+			return JsonSerializer.Serialize(seedItemData, DefaultOptions);
+		}
+
+		public static SeedItemInfoSaveData DeserializeSeedItem(string json)
+		{
+			if (string.IsNullOrWhiteSpace(json) == false)
+			{
+				return JsonSerializer.Deserialize<SeedItemInfoSaveData>(json, DefaultOptions);
+			}
+			return default;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Domain/Item/Scripts/ItemDataExtensions.cs
+++ b/Assets/_WitchMendokusai/Domain/Item/Scripts/ItemDataExtensions.cs
@@ -1,0 +1,46 @@
+namespace WitchMendokusai
+{
+	public static class ItemDataExtensions
+	{
+		public static ItemInfoSaveData ToSaveData(this ItemData itemData)
+		{
+			if (itemData == null)
+			{
+				return default;
+			}
+
+			return new ItemInfoSaveData
+			{
+				ID = itemData.ID,
+				Name = itemData.Name,
+				Description = itemData.Description,
+				Grade = itemData.Grade,
+				Type = itemData.Type,
+				MaxAmount = itemData.MaxAmount,
+				PurchasePrice = itemData.PurchasePrice,
+				SalePrice = itemData.SalePrice
+			};
+		}
+
+		public static SeedItemInfoSaveData ToSaveData(this SeedItemData seedItemData)
+		{
+			if (seedItemData == null)
+			{
+				return default;
+			}
+
+			return new SeedItemInfoSaveData
+			{
+				ID = seedItemData.ID,
+				Name = seedItemData.Name,
+				Description = seedItemData.Description,
+				Grade = seedItemData.Grade,
+				Type = seedItemData.Type,
+				MaxAmount = seedItemData.MaxAmount,
+				PurchasePrice = seedItemData.PurchasePrice,
+				SalePrice = seedItemData.SalePrice,
+				GrowSeconds = seedItemData.GrowSeconds
+			};
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Item/ItemInfoSaveData.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Item/ItemInfoSaveData.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace WitchMendokusai
+{
+	[Serializable]
+	public struct ItemInfoSaveData
+	{
+		public int ID;
+		public string Name;
+		public string Description;
+		public ItemGrade Grade;
+		public ItemType Type;
+		public int MaxAmount;
+		public int PurchasePrice;
+		public int SalePrice;
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Item/SeedItemInfoSaveData.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Item/SeedItemInfoSaveData.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace WitchMendokusai
+{
+	[Serializable]
+	public struct SeedItemInfoSaveData
+	{
+		public int ID;
+		public string Name;
+		public string Description;
+		public ItemGrade Grade;
+		public ItemType Type;
+		public int MaxAmount;
+		public int PurchasePrice;
+		public int SalePrice;
+		public float GrowSeconds;
+	}
+}


### PR DESCRIPTION
DomainSDK 에 ItemInfoSaveData, SeedItemInfoSaveData (POCO) 추가.
Core 에 JsonUgcSerializer (System.Text.Json 기반) 구현.
Domain 에 ItemDataExtensions (ToSaveData() 변환) 추가.

Phase A 기초 인프라: DataSO → external JSON 직렬화 가능.
Recipes/HarvestLoots 복잡한 필드는 Phase B 에서 확장.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
