### PR TITLE
feat(WM-084-B,C): UGC Seed first-use — sample + ApplyTo glue + sandbox test

### DIFF
--- a/Assets/_WitchMendokusai/Domain/Data/UGC/SeedSaveDataExtensions.cs
+++ b/Assets/_WitchMendokusai/Domain/Data/UGC/SeedSaveDataExtensions.cs
@@ -1,7 +1,6 @@
 namespace WitchMendokusai
 {
-	// UGC sandbox 이음매 — JSON 으로 들어온 SeedSaveData (POCO, 5 noise 필드만) 가 TerrainParameters (DataSO) 로 흐르는 *유일한 통로*.
-	// TerrainParameters 의 amplitude / seed / biomes / heightmap 은 의도적으로 무시 — 사용자 UGC 가 schema 밖 필드를 *건드릴 수 없음* 을 코드 위치로 못 박는다.
+	// SeedSaveData → TerrainParameters 유일한 통로. amplitude/seed/biomes/heightmap 는 schema 밖 — 의도적 무시로 sandbox 표면을 코드 위치로 못 박는다.
 	public static class SeedSaveDataExtensions
 	{
 		public static void ApplyTo(this SeedSaveData seedData, TerrainParameters target)

--- a/Assets/_WitchMendokusai/Domain/Data/UGC/SeedSaveDataExtensions.cs
+++ b/Assets/_WitchMendokusai/Domain/Data/UGC/SeedSaveDataExtensions.cs
@@ -1,0 +1,16 @@
+namespace WitchMendokusai
+{
+	// UGC sandbox 이음매 — JSON 으로 들어온 SeedSaveData (POCO, 5 noise 필드만) 가 TerrainParameters (DataSO) 로 흐르는 *유일한 통로*.
+	// TerrainParameters 의 amplitude / seed / biomes / heightmap 은 의도적으로 무시 — 사용자 UGC 가 schema 밖 필드를 *건드릴 수 없음* 을 코드 위치로 못 박는다.
+	public static class SeedSaveDataExtensions
+	{
+		public static void ApplyTo(this SeedSaveData seedData, TerrainParameters target)
+		{
+			target.SetOctaves(seedData.octaves);
+			target.SetFrequency(seedData.frequency);
+			target.SetPersistence(seedData.persistence);
+			target.SetLacunarity(seedData.lacunarity);
+			target.SetBiomeFrequency(seedData.biomeFrequency);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Domain/Data/UGC/SeedSaveDataExtensions.cs.meta
+++ b/Assets/_WitchMendokusai/Domain/Data/UGC/SeedSaveDataExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0cfe80b6feba4438831678f31a7037d9

--- a/Assets/_WitchMendokusai/Domain/Data/UGC/UGCJsonLoader.cs
+++ b/Assets/_WitchMendokusai/Domain/Data/UGC/UGCJsonLoader.cs
@@ -83,6 +83,12 @@ namespace WitchMendokusai
 			return true;
 		}
 
+		public static bool TryLoadSeedFromSample(string fileName, out SeedSaveData seedData, out string error)
+		{
+			string path = UGCPathResolver.GetSamplePath(fileName);
+			return TryLoadSeedFromPath(path, out seedData, out error);
+		}
+
 		public static bool TryLoadSeedFromPath(string path, out SeedSaveData seedData, out string error)
 		{
 			seedData = default;

--- a/Assets/_WitchMendokusai/Tests/EditMode/UGCSeedLoaderTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/UGCSeedLoaderTest.cs
@@ -1,0 +1,155 @@
+using Newtonsoft.Json;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-084 Phase B + C — UGC Seed first-use 회귀 게이트.
+	/// Phase A (SeedSaveData POCO + UGCJsonLoader + UGCJsonValidator) 위에서:
+	///   - Phase B: 첫 sample (ServerData/UGC/Samples/seed_001_forest.json) 가 *게임 안* (TerrainParameters DataSO) 로 흐른다는 것
+	///   - Phase C: UGC JSON 이 SeedSaveData schema 밖 필드를 *건드릴 수 없다* 는 것 (sandbox)
+	/// 을 결정적으로 잠근다.
+	///
+	/// 실행: unity -runTests -batchmode -testPlatform EditMode -assemblyNames WM.Tests.EditMode
+	/// </summary>
+	public sealed class UGCSeedLoaderTest
+	{
+		private const string SAMPLE_FILE = "seed_001_forest.json";
+
+		[Test]
+		public void TryLoadSeedFromSample_ForestStarter_ReturnsExpectedFields()
+		{
+			bool ok = UGCJsonLoader.TryLoadSeedFromSample(SAMPLE_FILE, out SeedSaveData seedData, out string error);
+
+			Assert.That(ok, Is.True, $"sample 로딩 실패: {error}");
+			Assert.That(seedData, Is.Not.Null);
+			Assert.That(seedData.name, Is.EqualTo("Forest Starter"));
+			Assert.That(seedData.octaves, Is.EqualTo(4));
+			Assert.That(seedData.frequency, Is.EqualTo(0.05f).Within(0.0001f));
+			Assert.That(seedData.persistence, Is.EqualTo(0.5f).Within(0.0001f));
+			Assert.That(seedData.lacunarity, Is.EqualTo(2.0f).Within(0.0001f));
+			Assert.That(seedData.biomeFrequency, Is.EqualTo(0.02f).Within(0.0001f));
+		}
+
+		[Test]
+		public void ApplyTo_TerrainParameters_TransfersFiveNoiseFields()
+		{
+			SeedSaveData seedData = new()
+			{
+				name = "Apply Test",
+				octaves = 6,
+				frequency = 0.07f,
+				persistence = 0.42f,
+				lacunarity = 2.5f,
+				biomeFrequency = 0.015f,
+			};
+
+			TerrainParameters target = ScriptableObject.CreateInstance<TerrainParameters>();
+			int originalSeed = target.Seed;
+			float originalAmplitude = target.Amplitude;
+
+			seedData.ApplyTo(target);
+
+			Assert.That(target.Octaves, Is.EqualTo(6));
+			Assert.That(target.Frequency, Is.EqualTo(0.07f).Within(0.0001f));
+			Assert.That(target.Persistence, Is.EqualTo(0.42f).Within(0.0001f));
+			Assert.That(target.Lacunarity, Is.EqualTo(2.5f).Within(0.0001f));
+			Assert.That(target.BiomeFrequency, Is.EqualTo(0.015f).Within(0.0001f));
+
+			// sandbox 보강 — schema 밖 필드는 변경되지 않음
+			Assert.That(target.Seed, Is.EqualTo(originalSeed), "Seed 는 SeedSaveData schema 밖 — 보존되어야 함");
+			Assert.That(target.Amplitude, Is.EqualTo(originalAmplitude).Within(0.0001f), "Amplitude 는 SeedSaveData schema 밖 — 보존되어야 함");
+		}
+
+		[Test]
+		public void TryValidateSeed_RejectsWrongSchemaVersion()
+		{
+			UGCSeedManifestData manifest = MakeValidManifest();
+			manifest.schemaVersion = 99;
+
+			bool ok = UGCJsonValidator.TryValidateSeed(manifest, out string error);
+
+			Assert.That(ok, Is.False);
+			Assert.That(error, Does.Contain("Schema version"));
+		}
+
+		[Test]
+		public void TryValidateSeed_RejectsOctavesOutOfRange()
+		{
+			UGCSeedManifestData manifest = MakeValidManifest();
+			manifest.seedData.octaves = 99;
+
+			bool ok = UGCJsonValidator.TryValidateSeed(manifest, out string error);
+
+			Assert.That(ok, Is.False);
+			Assert.That(error, Does.Contain("octaves"));
+		}
+
+		[Test]
+		public void TryValidateSeed_RejectsEmptySeedName()
+		{
+			UGCSeedManifestData manifest = MakeValidManifest();
+			manifest.seedData.name = "";
+
+			bool ok = UGCJsonValidator.TryValidateSeed(manifest, out string error);
+
+			Assert.That(ok, Is.False);
+			Assert.That(error, Does.Contain("name"));
+		}
+
+		// Phase C — sandbox 증명: SeedSaveData 에 *없는 필드* 를 JSON 에 박아도 deserialize 결과 객체엔 안 들어옴.
+		// MissingMemberHandling.Ignore + POCO 필드 화이트리스트 = 컴파일러 강제 sandbox 의 *실증*.
+		[Test]
+		public void Deserialize_DropsOutOfSchemaFields()
+		{
+			string maliciousJson = @"{
+				""name"": ""Sandbox Probe"",
+				""octaves"": 4,
+				""frequency"": 0.05,
+				""persistence"": 0.5,
+				""lacunarity"": 2.0,
+				""biomeFrequency"": 0.02,
+				""amplitude"": 9999.0,
+				""arbitraryEvilField"": ""attempt-to-escape""
+			}";
+
+			JsonSerializerSettings settings = new()
+			{
+				MissingMemberHandling = MissingMemberHandling.Ignore,
+				NullValueHandling = NullValueHandling.Include,
+			};
+
+			SeedSaveData parsed = JsonConvert.DeserializeObject<SeedSaveData>(maliciousJson, settings);
+
+			Assert.That(parsed, Is.Not.Null);
+			Assert.That(parsed.name, Is.EqualTo("Sandbox Probe"));
+			Assert.That(parsed.octaves, Is.EqualTo(4));
+
+			// SeedSaveData 에 amplitude/arbitraryEvilField 같은 필드가 없으므로 컴파일 자체로 도달 불가 —
+			// 그 사실 자체가 sandbox. 본 테스트는 JSON 페이로드가 *조용히 삭제됨* 을 회귀 게이트로 잠근다.
+			System.Reflection.FieldInfo amplitudeField = typeof(SeedSaveData).GetField("amplitude");
+			Assert.That(amplitudeField, Is.Null, "SeedSaveData 에 amplitude 필드가 생기면 sandbox 표면 확장 — 의도적 결정 필요");
+		}
+
+		private static UGCSeedManifestData MakeValidManifest()
+		{
+			return new UGCSeedManifestData
+			{
+				schemaVersion = 1,
+				seedId = 1,
+				version = 1,
+				author = "test",
+				seedData = new SeedSaveData
+				{
+					name = "Valid",
+					octaves = 4,
+					frequency = 0.05f,
+					persistence = 0.5f,
+					lacunarity = 2.0f,
+					biomeFrequency = 0.02f,
+				},
+			};
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/UGCSeedLoaderTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/UGCSeedLoaderTest.cs
@@ -4,15 +4,6 @@ using UnityEngine;
 
 namespace WitchMendokusai.Tests
 {
-	/// <summary>
-	/// TASK-WM-084 Phase B + C — UGC Seed first-use 회귀 게이트.
-	/// Phase A (SeedSaveData POCO + UGCJsonLoader + UGCJsonValidator) 위에서:
-	///   - Phase B: 첫 sample (ServerData/UGC/Samples/seed_001_forest.json) 가 *게임 안* (TerrainParameters DataSO) 로 흐른다는 것
-	///   - Phase C: UGC JSON 이 SeedSaveData schema 밖 필드를 *건드릴 수 없다* 는 것 (sandbox)
-	/// 을 결정적으로 잠근다.
-	///
-	/// 실행: unity -runTests -batchmode -testPlatform EditMode -assemblyNames WM.Tests.EditMode
-	/// </summary>
 	public sealed class UGCSeedLoaderTest
 	{
 		private const string SAMPLE_FILE = "seed_001_forest.json";
@@ -98,8 +89,6 @@ namespace WitchMendokusai.Tests
 			Assert.That(error, Does.Contain("name"));
 		}
 
-		// Phase C — sandbox 증명: SeedSaveData 에 *없는 필드* 를 JSON 에 박아도 deserialize 결과 객체엔 안 들어옴.
-		// MissingMemberHandling.Ignore + POCO 필드 화이트리스트 = 컴파일러 강제 sandbox 의 *실증*.
 		[Test]
 		public void Deserialize_DropsOutOfSchemaFields()
 		{
@@ -126,8 +115,7 @@ namespace WitchMendokusai.Tests
 			Assert.That(parsed.name, Is.EqualTo("Sandbox Probe"));
 			Assert.That(parsed.octaves, Is.EqualTo(4));
 
-			// SeedSaveData 에 amplitude/arbitraryEvilField 같은 필드가 없으므로 컴파일 자체로 도달 불가 —
-			// 그 사실 자체가 sandbox. 본 테스트는 JSON 페이로드가 *조용히 삭제됨* 을 회귀 게이트로 잠근다.
+			// amplitude 필드 부재 자체가 sandbox 증명 — 생기면 sandbox 표면 확장이므로 의도적 결정 필요.
 			System.Reflection.FieldInfo amplitudeField = typeof(SeedSaveData).GetField("amplitude");
 			Assert.That(amplitudeField, Is.Null, "SeedSaveData 에 amplitude 필드가 생기면 sandbox 표면 확장 — 의도적 결정 필요");
 		}

--- a/Assets/_WitchMendokusai/Tests/EditMode/UGCSeedLoaderTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/UGCSeedLoaderTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bf0db040a84b478c8874e6a0e019811d

--- a/ServerData/UGC/Samples/seed_001_forest.json
+++ b/ServerData/UGC/Samples/seed_001_forest.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "seedId": 1,
+  "version": 1,
+  "author": "WM_System",
+  "seedData": {
+    "name": "Forest Starter",
+    "octaves": 4,
+    "frequency": 0.05,
+    "persistence": 0.5,
+    "lacunarity": 2.0,
+    "biomeFrequency": 0.02
+  },
+  "tags": ["forest", "procedural", "starter"],
+  "meta": {
+    "description": "First-use UGC seed — Forest biome procedural starter preset",
+    "biome": "forest"
+  }
+}


### PR DESCRIPTION
## Summary

TASK-WM-084 Phase B (첫 sample UGC Seed + 게임 안 로딩 검증) + Phase C (sandbox 검증, 회귀 게이트로 잠금).

Phase A (`SeedSaveData` POCO + `UGCJsonLoader.TryLoadSeed*` + `UGCJsonValidator.TryValidateSeed`) 는 이미 main 에 착륙 (commits `dc5b9613` / `00a13d4d`). 본 PR 은 그 위에 *게임 안 흐름의 첫 endpoint* 와 *sandbox 의 실증 게이트* 를 박는다.

### Phase B — 첫 sample UGC + game-side ingress

- **`ServerData/UGC/Samples/seed_001_forest.json`** — Forest preset (5 noise 필드만, schemaVersion=1)
- **`SeedSaveDataExtensions.ApplyTo(TerrainParameters)`** — POCO → DataSO 의 *유일한 통로*. octaves/frequency/persistence/lacunarity/biomeFrequency 만 흐름. amplitude/seed/biomes/heightmap 은 의도적으로 무시 → "schema 밖 필드 거부" 가 *코드 위치* 로 못 박힘 (런타임 권한 시스템 0).
- **`UGCJsonLoader.TryLoadSeedFromSample(fileName)`** — 기존 `TryLoad{TriggerEvents,MapManifest}FromSample` 패턴과 시그니처 동기화 (`UGCPathResolver.GetSamplePath` 자동 해석).

### Phase C — sandbox 회귀 게이트 (6 NUnit 테스트)

`Assets/_WitchMendokusai/Tests/EditMode/UGCSeedLoaderTest.cs`:

1. **`TryLoadSeedFromSample_ForestStarter_ReturnsExpectedFields`** — sample JSON → SeedSaveData 필드 매핑 검증 (Phase B end-to-end)
2. **`ApplyTo_TerrainParameters_TransfersFiveNoiseFields`** — 5 noise 필드 흐름 + Seed/Amplitude 보존 (sandbox 의 *positive* 측면)
3. **`TryValidateSeed_RejectsWrongSchemaVersion`** — schemaVersion 불일치 거부
4. **`TryValidateSeed_RejectsOctavesOutOfRange`** — octaves 1~8 범위 외 거부
5. **`TryValidateSeed_RejectsEmptySeedName`** — name 필수 검증
6. **`Deserialize_DropsOutOfSchemaFields`** — `amplitude` / `arbitraryEvilField` 같은 schema 밖 페이로드를 `MissingMemberHandling.Ignore` + POCO 필드 화이트리스트가 *조용히 삭제* 함을 실증 (+ reflection 으로 `SeedSaveData.amplitude` 부재 보장 → sandbox 표면 확장이 *의도적 코드 변경* 없이 일어날 수 없음)

### TASK 진행 (PR 설명 정본 — memo 는 cwd 밖)

- **Phase A** ✅ done (이전 commit, main)
- **Phase B** ✅ done (본 PR)
- **Phase C** ✅ done (본 PR, 회귀 테스트로 잠금)
- **Phase D** ⬜ deferred — UGC 도구 (Editor UI Toolkit 패널). 후속 TASK.

## Test plan

- [ ] EditMode 테스트 6개 모두 통과 (Unity Test Runner → WM.Tests.EditMode → UGCSeedLoaderTest)
- [ ] `read_console(types=["error","warning"])` 0 — 컴파일 클린 (`SeedSaveDataExtensions.cs` 신설 + `UGCJsonLoader.cs` 1메서드 추가, Domain asmdef 안)
- [ ] Sample JSON 이 `ServerData/UGC/Samples/seed_001_forest.json` 에 존재 + 게임 외 외부 도구로도 열람·편집 가능 (디자이너 친화)

## Notes

- 이전 worktree (메모리 기록 세션 2605180251) 의 Phase A 시도는 PAT scope 부족으로 push 403 → main 미반영. 본 PR 은 *현재 main 의 Phase A 위* 에서 작업 (commits `dc5b9613` / `00a13d4d` 기준).
- `SeedSaveData` 위치 — 본 PR 에선 main 의 결정 (`Domain/Data/UGC/UGCJsonModels.cs`) 그대로 사용. *DomainSDK* 격상은 별 후속 (architecture.md § DomainSDK 모델 정합 시점).

🤖 Generated with [Claude Code](https://claude.com/claude-code)