### PR TITLE
feat(WM-109-F): post-commit advisory hook + commit discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -609,5 +609,6 @@ set_active_instance(instance="<branch>@<hash>")          # sub worktree
 - ★ **Autopilot 한정 예외** — 자율 모드는 main 직접 push 금지, feature 브랜치 + Draft PR 까지만 (TASK-WM-063 sub-H 옵션 B).
 - ★ **Unity 자연 단위 commit** — `.cs` + 자동생성 `.meta` + 의존 `.asset` / 씬 / `.prefab` 묶어 한 commit (분리 = 빌드 깨짐 / pull race).
 - ★ **Conventional Commits + 한 commit 한 주제** — `feat: / fix: / chore: / refactor: / docs: / style:`. PR 폐기로 단위 자유도 ↑, 더 잘게.
+- ★ **Post-commit advisory + commit 규율 (TASK-WM-109-F)** — bisect 친화 commit 규율 5원칙 + 옵트인 advisory hook(`Tools/git-hooks/`). hook 은 차단 X, ledger(`<git-common-dir>/wm-commit-log.tsv`) 에 `.cs`/`.meta`/MCP 응답 여부 기록 + big-commit(`.cs` > 10) hint + `.cs` ↔ `.cs.meta` 짝 검사 + MCP `:8080` TCP probe. 설치 = `powershell -File Tools/git-hooks/install.ps1`. 상세 = `Tools/git-hooks/README.md`.
 
 세부 (worktree persistent scratch 패턴 / claude-audit POC v1-v4 검증 / Branch Protection 폐기 1회용 gh api / Release flow Tag-only `release.yml` / CHANGELOG 구조 / `Closes #NN` Issue 자동 종료 / CodeRabbit historical / Post-push 정리 / Tag↔bundleVersion drift 등) = wm-git-workflow skill 참고.

--- a/Tools/git-hooks/README.md
+++ b/Tools/git-hooks/README.md
@@ -1,0 +1,158 @@
+# WM git hooks — TASK-WM-109-F
+
+> 큰 변경 누적 시 회귀 commit 식별 비용 ↓. *post-commit advisory* 가 2차 안전망,
+> **commit 규율(§ 커밋 규율)이 1차 안전망**. hook 은 차단 X — 정보만 흐른다.
+
+## 동기
+
+TASK-WM-109 이슈 6 — 한 세션 35+ commits 누적 → 사용자 Play 진입 → NRE 폭발
+→ 어느 commit 이 원인인지 식별 비용 폭발 (5+ 회귀 사이클).
+
+원인은 매 commit 후 *컴파일+부팅 검증 없이* 다음 commit 으로 진행한 것. CLAUDE.md
+가 정한 검증 흐름 (`refresh_unity` → `read_console`) 을 매 commit 단위로 실행하지
+않으면 `git bisect` 가 사실상 무력화된다 (모든 commit 이 NRE 면 갈라낼 게 없다).
+
+## 무엇이 들어있나
+
+| 파일 | 역할 |
+|---|---|
+| `post-commit` | bash POSIX hook. 매 commit 후 자동. PS verify 스크립트에 위임 (없으면 silent skip). 항상 exit 0 — *commit 차단 X*. |
+| `wm-commit-verify.ps1` | 실제 검증 로직 (PowerShell). ledger append + `.cs` / `.meta` / `.asset` / `.prefab` / `.unity` 카운트 + `.cs` ↔ `.cs.meta` 짝 검사 + Unity-MCP `:8080` TCP probe + big-commit hint. *Unity 호출 X* (hook 은 빨라야). |
+| `install.ps1` | `.git/hooks/post-commit` 으로 hook 복사. git common dir 사용 → 메인 + 모든 worktree 한 번에 적용. idempotent (이미 설치돼 있으면 no-op). `-Force` / `-Uninstall` 지원. |
+
+## 설치
+
+```powershell
+powershell -File Tools/git-hooks/install.ps1
+```
+
+- 재설치: `-Force`
+- 제거: `-Uninstall`
+
+옵트인 — 자동 활성화 X. 팀에서 적용 합의되면 각 환경에서 한 번씩 실행. (`.git/hooks/`
+는 git 추적 외 — 레포 clone 직후엔 비어있어, 매 머신·worktree 셋업의 일부.)
+
+## 산출 — `<git-common-dir>/wm-commit-log.tsv`
+
+매 commit 마다 한 행 append. 컬럼:
+
+```
+ts  sha  author  cs  meta  asset  prefab  scene  mcp  parents  subject
+```
+
+- `ts` — ISO-8601 (timezone 포함)
+- `sha` — short (12자)
+- `cs`, `meta`, `asset`, `prefab`, `scene` — commit 내 touched 파일 수
+- `mcp` — 0/1, *commit 시점* Unity-MCP `:8080` TCP probe 응답 여부
+- `parents` — 부모 commit 수 (2+ = merge, diff stat 미계산)
+- `subject` — commit subject line (tab → space 정리)
+
+활용:
+
+```powershell
+# 최근 30개 commit 한 눈에
+Get-Content (git rev-parse --git-common-dir | %{ Join-Path $_ wm-commit-log.tsv }) -Tail 30
+
+# big commit 만
+Import-Csv -Delimiter "`t" -Path (...) | Where-Object { [int]$_.cs -gt 10 }
+
+# MCP 응답 없었던 commit (검증 누락 의심 구간)
+Import-Csv -Delimiter "`t" -Path (...) | Where-Object { $_.mcp -eq '0' }
+```
+
+`mcp=0` 구간이 NRE 후보 zone — 그 시점 Editor 가 응답을 안 했으므로 컴파일 검증이
+누락됐을 가능성 ↑. bisect 시 좁히는 단서.
+
+## 커밋 규율 (1차 안전망)
+
+post-commit hook 은 *정보만* — 차단 X. **근본은 commit 규율** (TASK-WM-109-F 의
+핵심 결론). CLAUDE.md § Git Workflow 의 정본 룰을 본 TASK 의 *bisect 친화성* 관점
+으로 재확인:
+
+### 5가지 원칙
+
+1. **1 commit = 1 logical change** — bisect 가능해야. `.cs` 30개 한 commit 은 NRE
+   추적 비용 폭발 (본 TASK 의 동기 그 자체).
+2. **각 commit 은 *독립적으로* 빌드 + 부팅** — 중간 commit 이 compile fail 이면
+   `git bisect` 가 그 구간을 못 가른다. WIP 면 squash 먼저, push 는 그 후.
+3. **`.cs` 와 `.cs.meta` 는 같은 commit** — Unity 가 `.meta` 못 보면 GUID 재발급 →
+   씬 ref 깨짐. CLAUDE.md "Unity 자연 단위 commit" 정합.
+4. **dependent asset 동행** — `.cs` 가 참조하는 SO / `.asset` / `.prefab` / 씬
+   `.unity` 분리 금지. pull race 위험 (다른 worktree 가 절반만 받음).
+5. **Conventional Commits** — `feat:` `fix:` `chore:` `refactor:` `docs:` `style:`.
+   PR 폐기로 단위 자유도 ↑ 이므로 *더 잘게* 잘라도 OK (그 게 bisect 친화).
+
+### bisect 흐름 (회귀 의심 시)
+
+```powershell
+# 1) ledger 에서 마지막 known-good SHA 찾기
+$ledger = Join-Path (git rev-parse --git-common-dir) 'wm-commit-log.tsv'
+Get-Content $ledger -Tail 30
+
+# 2) bisect 시작
+git bisect start
+git bisect bad HEAD              # 현재 = NRE 발생
+git bisect good <known-good-sha> # ledger 에서 본 SHA
+
+# 3) 각 step Unity Editor 에서 Play 검증, 결과 표시
+#    (각 commit 이 § 원칙 2 를 지켰다면 모든 중간 step 이 부팅 가능)
+git bisect good   # 또는 bad
+# ... 반복 ...
+git bisect reset
+```
+
+ledger 의 `cs` / `mcp` 컬럼이 bisect 시작 범위를 좁히는 단서:
+
+- `mcp=1` 연속 구간 = 그 시점 Editor 응답 OK = 검증 가능했던 구간
+- `cs=0` commit = .cs 변경 0 = NRE 발생 가능성 ↓ (스킵 후보)
+
+## Unity-MCP 와의 관계
+
+CLAUDE.md § Unity-MCP layer 의 `read_console` 이 컴파일 검증 정본 (Mono runtime
+직속). hook 자체는 MCP 를 *호출* 하지 않는다:
+
+- JSON-RPC handshake 가 1회성 PS 호출에 무겁고, hook 은 빨라야 한다 (수 ms).
+- MCP 호출 결과로 commit 을 *차단* 할 수도 없다 (post-commit). 정보 가치만 있는데
+  비용이 크다.
+
+대신 *MCP 응답 여부만* TCP probe (~300ms timeout) 로 ledger 에 기록 — 추후 분석
+시 "그 시점 Editor 가 살아있었는지" 단서.
+
+진짜 컴파일 검증은:
+
+- 자동: 에이전트가 `refresh_unity(...)` + `read_console(types=["error","warning"])`
+  실행 (CLAUDE.md 정본).
+- fallback: Editor.log grep (append-only 한계 — § 컴파일 에러 확인 참고).
+- 부팅 검증: `wm-boot-smoke.ps1` (memo dotfiles, batchmode standalone superset).
+
+hook 의 책임은 *유도* + *기록* 뿐, *증명* 이 아니다.
+
+## 비활성화 / 우회
+
+- 영구 비활성화: `powershell -File Tools/git-hooks/install.ps1 -Uninstall`
+- 임시: post-commit hook 은 `git commit --no-verify` 영향을 받지 *않는다* (그 옵션은
+  pre-commit / commit-msg 만). 정말 우회하려면 그 1 commit 동안 hook 파일을 .bak
+  으로 옮기거나 `core.hooksPath` 를 비표준 경로로 일시 변경.
+- 단일 commit 영향 없음 — hook 은 *post* 단계, 이미 commit 된 뒤 실행. 실패해도
+  rollback 안 일어남.
+
+## 트러블슈팅
+
+| 증상 | 원인 / 대처 |
+|---|---|
+| commit 직후 console 출력 없음 | hook 미설치 — `install.ps1` 재실행. `.git/hooks/post-commit` 존재 확인. |
+| `no pwsh/powershell on PATH` | PowerShell 미설치. Windows 면 정상 X. Git Bash 환경변수에서 `powershell` 찾을 수 있는지 확인. |
+| `wm-verify` 라인 보이는데 ledger 안 생김 | `.git/wm-commit-log.tsv` 권한 / 경로 — 메시지의 ledger 경로 확인. |
+| `mcp=0` 으로 계속 찍힘 | Unity Editor 미실행 / `Window > MCP for Unity > Start Server` 미시작. CLAUDE.md § Unity-MCP layer 참고. |
+| 대량 .cs commit 후 [big] 경고 | 의도된 경고 — § 커밋 규율 5원칙 #1 위반 가능 신호. 다음 commit 부터 분할 검토. |
+
+## TASK-WM-109-F 적용 외 사용처
+
+이 ledger 는 회귀 추적 외에도:
+
+- **자가증강 baseline 측정** (agent-mission §2.8-C) — 어떤 시기에 commit 빈도 / .cs
+  density / MCP 가용성이 어땠는지 객관 기록. retro 가 진화 적합도 평가에 사용 가능.
+- **세션 후처리** — Claude 세션 끝나고 "이 세션 commit 들 .cs 총량 / big commit 수"
+  를 ledger 한 번 grep 으로 확인.
+- **자동 단위 분할 가이드** — `cs > N` commit 자동 detect → 다음 작업에서 같은
+  영역 commit 단위 조정 reminder.

--- a/Tools/git-hooks/install.ps1
+++ b/Tools/git-hooks/install.ps1
@@ -1,0 +1,93 @@
+# Tools/git-hooks/install.ps1 — TASK-WM-109-F
+#
+# Installs the WM post-commit hook into the shared .git/hooks/ dir for the
+# main checkout (and, by extension, every linked worktree — git uses the
+# common dir for hooks). Run from any WM checkout / worktree:
+#
+#   powershell -File Tools/git-hooks/install.ps1
+#
+# Re-runnable (no-op if already installed). Variants:
+#   -Force      overwrite existing hook
+#   -Uninstall  remove the hook
+
+[CmdletBinding()]
+param(
+    [switch]$Uninstall,
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+if ([string]::IsNullOrWhiteSpace($repoRoot))
+{
+    Write-Host "[wm-hooks] not in a git repo — abort"
+    exit 1
+}
+
+$commonDir = (git rev-parse --git-common-dir 2>$null).Trim()
+if (-not [System.IO.Path]::IsPathRooted($commonDir))
+{
+    $commonDir = [System.IO.Path]::GetFullPath((Join-Path $repoRoot $commonDir))
+}
+
+$hookSource = Join-Path $repoRoot 'Tools\git-hooks\post-commit'
+$hooksDir = Join-Path $commonDir 'hooks'
+$hookTarget = Join-Path $hooksDir 'post-commit'
+
+if ($Uninstall)
+{
+    if (Test-Path -LiteralPath $hookTarget)
+    {
+        Remove-Item -LiteralPath $hookTarget -Force
+        Write-Host "[wm-hooks] removed: $hookTarget"
+    }
+    else
+    {
+        Write-Host "[wm-hooks] nothing to remove at $hookTarget"
+    }
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $hookSource))
+{
+    Write-Host "ERROR: hook source missing: $hookSource"
+    Write-Host "       (run from inside a WitchMendokusai checkout)"
+    exit 1
+}
+
+if (-not (Test-Path -LiteralPath $hooksDir))
+{
+    New-Item -ItemType Directory -Path $hooksDir -Force | Out-Null
+}
+
+if ((Test-Path -LiteralPath $hookTarget) -and -not $Force)
+{
+    # Detect whether already pointing at our script (idempotent).
+    $existing = Get-Content -LiteralPath $hookTarget -Raw -ErrorAction SilentlyContinue
+    if ($existing -match 'wm-commit-verify\.ps1')
+    {
+        Write-Host "[wm-hooks] already installed: $hookTarget"
+        Write-Host "[wm-hooks]   ledger: $(Join-Path $commonDir 'wm-commit-log.tsv')"
+        exit 0
+    }
+    Write-Host "[wm-hooks] foreign hook already at $hookTarget"
+    Write-Host "[wm-hooks]   overwrite with -Force, or remove first"
+    exit 2
+}
+
+Copy-Item -LiteralPath $hookSource -Destination $hookTarget -Force
+
+# Try to mark executable via Git for Windows' bash (chmod). Best-effort —
+# Windows NTFS will treat shell hooks as executable so long as `sh` can find
+# them; the +x bit is mostly a UX nicety + cross-OS portability.
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($null -ne $bash)
+{
+    $hookPosix = ($hookTarget -replace '\\', '/')
+    & $bash.Source -c "chmod +x '$hookPosix'" 2>$null | Out-Null
+}
+
+Write-Host "[wm-hooks] installed: $hookTarget"
+Write-Host "[wm-hooks]   ledger:  $(Join-Path $commonDir 'wm-commit-log.tsv')"
+Write-Host "[wm-hooks]   docs:    Tools/git-hooks/README.md"

--- a/Tools/git-hooks/post-commit
+++ b/Tools/git-hooks/post-commit
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# WitchMendokusai post-commit hook (TASK-WM-109-F).
+#
+# Records commit metadata + lightweight integrity checks via PowerShell.
+# Non-blocking — exits 0 regardless of script outcome (post-commit cannot
+# undo the commit anyway; goal is information, not enforcement).
+#
+# Canonical version tracked at Tools/git-hooks/post-commit.
+# Install: powershell -File Tools/git-hooks/install.ps1
+
+set -u
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$repo_root" ]; then
+  exit 0
+fi
+
+verify="$repo_root/Tools/git-hooks/wm-commit-verify.ps1"
+if [ ! -f "$verify" ]; then
+  # Tools/ not present (older checkout, partial sync) — silent skip.
+  exit 0
+fi
+
+# Pick PowerShell — prefer pwsh (cross-plat 7+), fallback to Windows PowerShell.
+ps_exe=""
+if command -v pwsh >/dev/null 2>&1; then
+  ps_exe="pwsh"
+elif command -v powershell >/dev/null 2>&1; then
+  ps_exe="powershell"
+else
+  echo "[wm-post-commit] no pwsh/powershell on PATH — verify skipped"
+  exit 0
+fi
+
+sha="$(git rev-parse HEAD 2>/dev/null || true)"
+if [ -z "$sha" ]; then
+  exit 0
+fi
+
+# Run verify; swallow non-zero so a buggy script never blocks the workflow.
+WM_COMMIT_SHA="$sha" "$ps_exe" -NoProfile -ExecutionPolicy Bypass -File "$verify" -Sha "$sha" || true
+
+exit 0

--- a/Tools/git-hooks/wm-commit-verify.ps1
+++ b/Tools/git-hooks/wm-commit-verify.ps1
@@ -1,0 +1,207 @@
+# Tools/git-hooks/wm-commit-verify.ps1 — TASK-WM-109-F
+#
+# Lightweight post-commit verification for WitchMendokusai.
+#
+# Responsibilities:
+#   1. Append commit metadata row to <git-common-dir>/wm-commit-log.tsv (ledger).
+#   2. Count touched .cs / .meta / .asset / .prefab / .unity files in the commit.
+#   3. Pair-check .cs (added/modified) ↔ .cs.meta — Unity GUID-loss canary.
+#   4. Heuristic "big commit" advisory when .cs count exceeds a small threshold.
+#   5. TCP probe of Unity-MCP :8080 (informational only — no MCP RPC).
+#
+# Non-responsibilities:
+#   - Calling Unity (compile / Play). Hooks must be fast; canonical compile
+#     verification stays MCP `read_console` (CLAUDE.md § Unity-MCP layer).
+#   - Blocking commits — this is post-commit; runs always with exit 0.
+#
+# Invoked by .git/hooks/post-commit after install.ps1 sets it up.
+
+[CmdletBinding()]
+param(
+    [string]$Sha = $env:WM_COMMIT_SHA,
+    [int]$BigCommitCsThreshold = 10
+)
+
+$ErrorActionPreference = 'Continue'
+
+function Resolve-RepoPaths
+{
+    $rootRaw = (git rev-parse --show-toplevel 2>$null)
+    if ([string]::IsNullOrWhiteSpace($rootRaw))
+    {
+        return $null
+    }
+    $commonRaw = (git rev-parse --git-common-dir 2>$null)
+    if ([string]::IsNullOrWhiteSpace($commonRaw))
+    {
+        return $null
+    }
+
+    $root = $rootRaw.Trim()
+    $common = $commonRaw.Trim()
+    if (-not [System.IO.Path]::IsPathRooted($common))
+    {
+        $common = [System.IO.Path]::GetFullPath((Join-Path $root $common))
+    }
+    return [pscustomobject]@{
+        Root      = $root
+        CommonDir = $common
+    }
+}
+
+$paths = Resolve-RepoPaths
+if ($null -eq $paths)
+{
+    Write-Host "[wm-verify] not in a git repo — skip"
+    exit 0
+}
+
+if ([string]::IsNullOrWhiteSpace($Sha))
+{
+    $shaRaw = (git rev-parse HEAD 2>$null)
+    if ([string]::IsNullOrWhiteSpace($shaRaw))
+    {
+        Write-Host "[wm-verify] no HEAD — skip"
+        exit 0
+    }
+    $Sha = $shaRaw.Trim()
+}
+
+$shortSha = $Sha.Substring(0, [Math]::Min(12, $Sha.Length))
+$subject = (git log -1 --format=%s $Sha 2>$null)
+$author = (git log -1 --format=%an $Sha 2>$null)
+$parentCount = ((git log -1 --format=%P $Sha 2>$null) -split '\s+' | Where-Object { $_ -ne '' }).Count
+$tsIso = (Get-Date).ToString('yyyy-MM-ddTHH:mm:sszzz')
+
+# Diff name-status — skip for merge commits (multi-parent: nothing meaningful
+# to count, and `git show --name-status` semantics differ).
+$cs = @()
+$meta = @()
+$asset = @()
+$prefab = @()
+$scene = @()
+
+if ($parentCount -le 1)
+{
+    $rawOutput = git show --name-status --format= $Sha 2>$null
+    $lines = @()
+    if ($null -ne $rawOutput)
+    {
+        foreach ($entry in @($rawOutput))
+        {
+            foreach ($line in ($entry -split "`n"))
+            {
+                if (-not [string]::IsNullOrWhiteSpace($line))
+                {
+                    $lines += $line
+                }
+            }
+        }
+    }
+
+    foreach ($line in $lines)
+    {
+        if ($line -match '\t.+\.cs$')     { $cs     += $line; continue }
+        if ($line -match '\t.+\.meta$')   { $meta   += $line; continue }
+        if ($line -match '\t.+\.asset$')  { $asset  += $line; continue }
+        if ($line -match '\t.+\.prefab$') { $prefab += $line; continue }
+        if ($line -match '\t.+\.unity$')  { $scene  += $line; continue }
+    }
+}
+
+$csCount = $cs.Count
+$metaCount = $meta.Count
+$assetCount = $asset.Count
+$prefabCount = $prefab.Count
+$sceneCount = $scene.Count
+
+# .cs (added/modified) ↔ .cs.meta pair check. Renames (R*) are ignored — the
+# original .meta likely already exists; git rename detection handles them.
+$metaPathsInCommit = $meta | ForEach-Object { ($_ -split "`t", 2)[1] }
+$csMissingMeta = @()
+foreach ($line in $cs)
+{
+    $parts = $line -split "`t", 2
+    if ($parts.Count -lt 2) { continue }
+    $status = $parts[0]
+    $path = $parts[1]
+    if ($status -notmatch '^[AM]') { continue }
+
+    $expectedMeta = "$path.meta"
+    if ($metaPathsInCommit -contains $expectedMeta) { continue }
+
+    # Sometimes .meta was committed in a prior commit and remains on disk.
+    # Only flag when there is genuinely no .meta on disk.
+    $absMeta = Join-Path $paths.Root $expectedMeta
+    if (-not (Test-Path -LiteralPath $absMeta))
+    {
+        $csMissingMeta += $path
+    }
+}
+
+$bigCommit = $csCount -gt $BigCommitCsThreshold
+
+# Unity-MCP TCP probe — fast (~300ms timeout). Informational only.
+$mcpUp = $false
+try
+{
+    $tcp = New-Object System.Net.Sockets.TcpClient
+    $iar = $tcp.BeginConnect('127.0.0.1', 8080, $null, $null)
+    if ($iar.AsyncWaitHandle.WaitOne(300, $false))
+    {
+        try
+        {
+            $tcp.EndConnect($iar)
+            $mcpUp = $tcp.Connected
+        }
+        catch
+        {
+            $mcpUp = $false
+        }
+    }
+    $tcp.Close()
+}
+catch
+{
+    $mcpUp = $false
+}
+
+# Ledger — TSV, header on first write.
+$ledger = Join-Path $paths.CommonDir 'wm-commit-log.tsv'
+$header = "ts`tsha`tauthor`tcs`tmeta`tasset`tprefab`tscene`tmcp`tparents`tsubject"
+if (-not (Test-Path -LiteralPath $ledger))
+{
+    Set-Content -LiteralPath $ledger -Value $header -Encoding UTF8
+}
+$cleanSubject = ($subject -replace "`t", ' ').Trim()
+$row = "$tsIso`t$shortSha`t$author`t$csCount`t$metaCount`t$assetCount`t$prefabCount`t$sceneCount`t$([int]$mcpUp)`t$parentCount`t$cleanSubject"
+Add-Content -LiteralPath $ledger -Value $row -Encoding UTF8
+
+# Console summary — single line headline + optional advisories.
+$tag = if ($parentCount -gt 1) { '[merge]' } elseif ($bigCommit) { '[big]' } else { '[ok]' }
+Write-Host "[wm-verify] $tag $shortSha  cs=$csCount meta=$metaCount asset=$assetCount prefab=$prefabCount scene=$sceneCount  mcp=$([int]$mcpUp)"
+
+if ($bigCommit)
+{
+    Write-Host "[wm-verify]   hint: $csCount .cs in one commit — bisect 비용 ↑. 다음엔 단위 분할 검토 (Tools/git-hooks/README.md § 커밋 규율)."
+}
+
+if ($csMissingMeta.Count -gt 0)
+{
+    Write-Host "[wm-verify]   warn: .cs add/modify 인데 짝 .meta 부재 (Unity GUID 누락 가능):"
+    foreach ($p in ($csMissingMeta | Select-Object -First 5))
+    {
+        Write-Host "[wm-verify]     - $p"
+    }
+    if ($csMissingMeta.Count -gt 5)
+    {
+        Write-Host "[wm-verify]     ... +$($csMissingMeta.Count - 5) more"
+    }
+}
+
+if (-not $mcpUp)
+{
+    Write-Host "[wm-verify]   info: Unity-MCP :8080 미응답 — 다음 commit 전 Editor Console / read_console 으로 컴파일 검증 권장."
+}
+
+exit 0


### PR DESCRIPTION
## TASK

[TASK-WM-109-F](https://github.com/mascari4615/Witch-Mendokusai/issues?q=WM-109-F) — 회귀 디버깅 비용 ↓: commit 검증 hook + 규율.

35+ commits 누적 후 NRE 폭발 → 회귀 원인 commit 식별 비용 폭발 (TASK-WM-109 이슈 6). 한 commit 마다 검증 흐름(`refresh_unity` → `read_console`)이 누락되면 `git bisect` 가 사실상 무력화된다 (모든 중간 commit 이 broken 이면 갈라낼 게 없음).

## 전략 선택 (TASK 다음단계 1·2)

| # | 전략 | 평가 | 채택 |
|---|---|---|---|
| 1 | post-commit hook + Unity Play auto | high cost (각 commit Play), Unity stuck/MCP 의존, post-commit 은 *차단 불가* — Play 자동화의 비용↔가치 비율 ✗ | ⚠ 일부 (probe only) |
| 2 | 1 commit = 1 logical change 정책 + `git bisect` | low overhead, discipline 필요. **근본** | ✅ 1차 안전망 |
| 3 | Validation branch CI | latency↑, push 전 회귀 검출 가능하나 본 TASK 의 *commit 단위 식별* 문제와 결이 다름 | ⏭ TASK-WM-073/wm-boot-smoke CI 가 인접 |

**결론: #2 정책 + #1 의 *경량 advisory* 조합** (TASK 시드 권장과 일치).

post-commit 은 *차단할 수 없으므로* Play 자동 실행은 비용 대비 가치가 낮다. 대신 *유도 + 기록*에 집중: hook 은 `.cs` 카운트 / `.cs`↔`.cs.meta` 짝 / MCP 응답 여부를 ledger 에 적고, big-commit 임계 (>10 .cs) 넘으면 hint 표시. 진짜 컴파일 검증은 CLAUDE.md 정본 흐름 (`refresh_unity` → `read_console(types=["error","warning"])`) 의 책임으로 남긴다.

## 산출 (TASK 다음단계 3)

```
Tools/git-hooks/
├── post-commit              # bash POSIX hook, PS verify 위임, exit 0 강제
├── wm-commit-verify.ps1     # PowerShell core: ledger + 짝검사 + MCP probe
├── install.ps1              # idempotent installer (Force/Uninstall)
└── README.md                # docs + bisect 친화 5원칙 commit 규율
CLAUDE.md                    # § Git Workflow Critical guard 에 한 줄 포인터
```

### post-commit 동작

매 commit 후 ledger `<git-common-dir>/wm-commit-log.tsv` 에 한 행 append:

```
ts  sha  author  cs  meta  asset  prefab  scene  mcp  parents  subject
```

- `cs > 10` → `[big]` hint (단위 분할 검토 신호)
- `.cs` add/modify 인데 `.cs.meta` 부재 (commit + 디스크 모두) → warn (Unity GUID 누락 canary)
- MCP `:8080` TCP probe (~300ms timeout) 결과 `mcp=0/1` 기록 — 해당 commit 시점 검증 창구가 살아있었는지 사후 단서
- **항상 exit 0** — post-commit 은 차단 불가, hook 도 그 정신을 따른다

### 옵트인 설치

```powershell
powershell -File Tools/git-hooks/install.ps1
```

`.git/hooks/` 는 git 추적 외라 clone 직후 자동 활성화 X — 환경별 1회 셋업. `-Force` 재설치, `-Uninstall` 제거.

git common dir 사용 → 메인 + 모든 worktree 가 **한 ledger** 공유. multi-worktree (TASK-WM-069) 와 자연 정합.

### bisect 친화 commit 규율 5원칙 (README § 커밋 규율)

1. **1 commit = 1 logical change** — bisect 가능해야
2. **각 commit 은 독립적으로 빌드+부팅** — 중간 fail commit 은 bisect 단절
3. **`.cs` + `.cs.meta` 같은 commit** — Unity GUID 누락 방지 (CLAUDE.md "Unity 자연 단위 commit" 정합)
4. **dependent asset 동행** (`.asset` / `.prefab` / `.unity`) — pull race 방지
5. **Conventional Commits** — `feat: / fix: / chore: / refactor: / docs: / style:`. PR 폐기 후 단위 자유도 ↑ 이므로 **더 잘게**

## Non-goals (의도된 한계)

- **Unity Play 자동 실행 X** — hook 비용 폭발, post-commit 차단 불가
- **MCP `read_console` 직접 RPC X** — JSON-RPC handshake 비용이 hook 크기에 안 맞음. 응답 여부 TCP probe 만
- **commit 차단 X** — post 단계, exit 0 강제. 차단은 pre-commit/CI 영역
- **`wm-boot-smoke.ps1` 호출 X** — 그 스크립트는 memo dotfiles (이 repo 외부). hook 은 *유도*, README 가 *참조*

## 검증

| 항목 | 결과 |
|---|---|
| 새 `.cs` 파일 X (Unity 영향 0) | ✅ |
| 모든 신규 파일 `.git/hooks/` 외부 = 추적 가능 | ✅ |
| `wm-commit-verify.ps1` smoke run (현재 HEAD) | ✅ ledger 1행 append, `[ok] HEAD cs=0 meta=0 ... mcp=1` |
| Bash hook syntax | ✅ `set -u`, exit 0 강제, pwsh/powershell fallback |
| 설치 스크립트 idempotent | ✅ 기존 wm-commit-verify hook detect → no-op |
| commit 규율 5원칙 본 PR 자체 준수 | ✅ 1 logical change (post-commit infra 도입). 5 files 중 4개는 새 dir 단일 책임 + 1줄 docs 포인터 |

## Test plan

- [ ] (선택, 셋업) `powershell -File Tools/git-hooks/install.ps1` 실행 — `[wm-hooks] installed:` 라인 확인
- [ ] empty commit (`git commit --allow-empty -m "test"`) → 콘솔에 `[wm-verify] [ok] <sha> cs=0 ...` 라인 출력 확인
- [ ] 큰 commit 시뮬레이션 — `.cs` 11+ 파일 한 commit → `[big]` hint 표시 확인
- [ ] `.cs` 만 commit (`.meta` 없이) → warn 라인 표시 확인
- [ ] `Get-Content <git-common-dir>/wm-commit-log.tsv -Tail 5` → ledger 누적 확인
- [ ] Unity Editor 미실행 시 `mcp=0`, 실행 시 `mcp=1` 확인
- [ ] `install.ps1 -Uninstall` 실행 → hook 제거 + 이후 commit 시 출력 없음 확인

## TASK 다음단계 4 (본 세션 commits 분석)

본 worktree 의 자율 세션은 단일 작업 (post-commit infra 도입) 이므로 분석 대상 부재. **본 TASK 산출이 곧 *향후 세션* 의 commit 단위 분석 도구** — ledger 적재 후 다음 세션 끝나면 `Import-Csv -Delimiter "tab"` 으로 `cs` 분포 / `[big]` 빈도 / `mcp=0` 구간 비율 분석 가능 (README § ledger 활용).

## 자가증강 적합도 (agent-mission §2.8-C)

본 hook 은 *팀 자가증강 baseline 측정 인프라*. 채택률 / big-commit 빈도 / MCP 가용성 시계열이 retro 의 측정 게이트 입력 (헌장 §2.8 "이미 있는 신호 재사용"). 퇴행 신호 시 `install.ps1 -Uninstall` 1회 = revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)