### PR TITLE
feat(WM-109-C): 씬 직접배치 컴포넌트 DI 등록 누락 audit 자동화

### DIFF
--- a/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditor.cs
+++ b/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditor.cs
@@ -12,35 +12,7 @@ using VContainer;
 
 namespace WitchMendokusai.Editor.DI
 {
-	/// <summary>
-	/// TASK-WM-109-C — 씬 직접배치 컴포넌트의 DI 등록 누락을 *자동* 감지.
-	///
-	/// 배경: TASK-WM-109 이슈 3 — World.unity 에 직접 배치된 컴포넌트 (Dummy/MineralBase/
-	/// InteractiveMarker/AutoAimMarker 등) 가 SceneLifetimeScope 에 등록 누락되면
-	/// 부팅 시 [Inject] Construct 호출 0 → 매니저 ref 가 null → 사용 시점 NRE.
-	/// 매번 NRE → stack trace → .meta GUID 검색 → .unity grep → 등록 추가 → 재발 사이클.
-	/// 본 도구가 정본 SceneLifetimeScope.cs 와 씬 placement 를 *교차 검증* 해 사이클 종결.
-	///
-	/// 정본 = SceneLifetimeScope.cs *소스* (regex 파싱). 별도 registry 도입 X — 자기참조
-	/// 패턴 (resgistration 추가 = audit 자동 인식). SceneLifetimeScope 가 다음 3 카테고리로
-	/// 씬 컴포넌트의 [Inject] 를 해소:
-	///   ① 「Directly Covered」 = Register*&lt;T&gt; / 명시적 container.Inject(x) foreach —
-	///      *이 타입 컴포넌트 1 개만* [Inject] 해소. sibling/child 별도 처리 필요.
-	///   ② 「Hierarchy Covered」 = container.InjectGameObject(x.gameObject) foreach —
-	///      VContainer 표준 *whole-hierarchy* 주입 → 본인 + 자손 컴포넌트 모두 해소.
-	///   ③ 「Root Scope」 = RootLifetimeScope (DDOL 영역, 본 감사 범위 외).
-	///
-	/// 「Inject-needing」 컴포넌트 = MonoBehaviour 서브클래스 중 [Inject] 가 멤버
-	/// (field / property / method) 에 1+ 존재. 씬에 그런 컴포넌트가 *카테고리 ①·② 어디에도*
-	/// 커버되지 않으면 NRE 후보 → 보고. 「Inject-needing」 자체 reflection 으로 결정 (수동
-	/// 유지 X). InteractiveMarker 등 known 타입이 누락 분기에 들어가면 즉시 회귀 발견.
-	///
-	/// 한계: container.Inject (component-only) 가 자식까지 *cascade* 하는 경우 (Player.Construct
-	/// → 자식 코드 호출 패턴) 는 코드 의도여서 정적 audit 으로 판정 불가 — 그 cascade 대상이
-	/// SceneLifetimeScope 에 명시 안 됐어도 본 도구는 보고함 (false-positive 가능). 해소 =
-	/// 보고된 컴포넌트의 부모 GameObject 가 cascade 경로면 SceneLifetimeScope 에 「container.Inject」
-	/// 라인 한 줄 추가 (자기참조 sync).
-	/// </summary>
+	// SceneLifetimeScope.cs 소스 정본과 씬 배치를 교차 검증해 [Inject] 등록 누락을 감지. WM/Audit 메뉴로 수동 실행, EditMode 테스트로 CI 게이트.
 	public static class SceneDiAuditor
 	{
 		private const string SCENE_LIFETIME_SCOPE_PATH =
@@ -66,9 +38,6 @@ namespace WitchMendokusai.Editor.DI
 			@"foreach\s*\(\s*(\w+)\s+\w+\s+in\s+FindObjectsByType<\1>\s*\([^)]*\)\s*\)\s*container\.InjectGameObject\(",
 			RegexOptions.Compiled | RegexOptions.Singleline);
 
-		/// <summary>
-		/// 모든 로드된 어셈블리에서 MonoBehaviour 서브클래스 중 [Inject] 가 1+ 멤버에 붙은 타입 수집.
-		/// </summary>
 		public static HashSet<Type> CollectInjectConsumingTypes()
 		{
 			HashSet<Type> types = new HashSet<Type>();
@@ -126,9 +95,6 @@ namespace WitchMendokusai.Editor.DI
 			return false;
 		}
 
-		/// <summary>
-		/// SceneLifetimeScope.cs 소스를 파싱해 「Directly Covered」 + 「Hierarchy Covered」 타입 이름을 수집.
-		/// </summary>
 		public static SceneCoverageMap CollectSceneCoverage()
 		{
 			string fullPath = Path.GetFullPath(SCENE_LIFETIME_SCOPE_PATH);
@@ -157,8 +123,7 @@ namespace WitchMendokusai.Editor.DI
 				direct.Add(match.Groups[1].Value); // InjectGameObject 도 본인 컴포넌트는 직접 커버.
 			}
 
-			// Root scope 도 등록 타입은 「씬 직접배치 NRE」 와 무관하지만, 본 감사의 false-positive 를
-			// 줄이기 위해 Root 등록 타입도 「Directly Covered」 에 포함 (예: GameManager / TimeManager).
+			// Root 등록 타입도 DirectlyCovered 에 포함 — 씬-배치 컴포넌트와 무관하지만 false-positive 감소.
 			if (File.Exists(Path.GetFullPath(ROOT_LIFETIME_SCOPE_PATH)) == true)
 			{
 				string rootSource = File.ReadAllText(Path.GetFullPath(ROOT_LIFETIME_SCOPE_PATH));
@@ -171,9 +136,6 @@ namespace WitchMendokusai.Editor.DI
 			return new SceneCoverageMap(direct, hierarchy);
 		}
 
-		/// <summary>
-		/// 본 폴더 하위 모든 .unity 경로 (패키지 제외).
-		/// </summary>
 		public static IEnumerable<string> EnumerateProjectScenePaths()
 		{
 			foreach (string guid in AssetDatabase.FindAssets("t:Scene", new[] { SCENES_ROOT }))
@@ -191,9 +153,7 @@ namespace WitchMendokusai.Editor.DI
 			}
 		}
 
-		/// <summary>
-		/// 단일 씬 audit. 씬을 additive 로 열어 walk 후 닫음 (저장 X — 비파괴).
-		/// </summary>
+		// 씬을 additive 로 열어 walk 후 닫음 — 비파괴 (저장 X).
 		public static List<SceneDiOffender> AuditScene(
 			string scenePath,
 			SceneCoverageMap coverage,

--- a/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditor.cs
+++ b/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditor.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using VContainer;
+
+namespace WitchMendokusai.Editor.DI
+{
+	/// <summary>
+	/// TASK-WM-109-C — 씬 직접배치 컴포넌트의 DI 등록 누락을 *자동* 감지.
+	///
+	/// 배경: TASK-WM-109 이슈 3 — World.unity 에 직접 배치된 컴포넌트 (Dummy/MineralBase/
+	/// InteractiveMarker/AutoAimMarker 등) 가 SceneLifetimeScope 에 등록 누락되면
+	/// 부팅 시 [Inject] Construct 호출 0 → 매니저 ref 가 null → 사용 시점 NRE.
+	/// 매번 NRE → stack trace → .meta GUID 검색 → .unity grep → 등록 추가 → 재발 사이클.
+	/// 본 도구가 정본 SceneLifetimeScope.cs 와 씬 placement 를 *교차 검증* 해 사이클 종결.
+	///
+	/// 정본 = SceneLifetimeScope.cs *소스* (regex 파싱). 별도 registry 도입 X — 자기참조
+	/// 패턴 (resgistration 추가 = audit 자동 인식). SceneLifetimeScope 가 다음 3 카테고리로
+	/// 씬 컴포넌트의 [Inject] 를 해소:
+	///   ① 「Directly Covered」 = Register*&lt;T&gt; / 명시적 container.Inject(x) foreach —
+	///      *이 타입 컴포넌트 1 개만* [Inject] 해소. sibling/child 별도 처리 필요.
+	///   ② 「Hierarchy Covered」 = container.InjectGameObject(x.gameObject) foreach —
+	///      VContainer 표준 *whole-hierarchy* 주입 → 본인 + 자손 컴포넌트 모두 해소.
+	///   ③ 「Root Scope」 = RootLifetimeScope (DDOL 영역, 본 감사 범위 외).
+	///
+	/// 「Inject-needing」 컴포넌트 = MonoBehaviour 서브클래스 중 [Inject] 가 멤버
+	/// (field / property / method) 에 1+ 존재. 씬에 그런 컴포넌트가 *카테고리 ①·② 어디에도*
+	/// 커버되지 않으면 NRE 후보 → 보고. 「Inject-needing」 자체 reflection 으로 결정 (수동
+	/// 유지 X). InteractiveMarker 등 known 타입이 누락 분기에 들어가면 즉시 회귀 발견.
+	///
+	/// 한계: container.Inject (component-only) 가 자식까지 *cascade* 하는 경우 (Player.Construct
+	/// → 자식 코드 호출 패턴) 는 코드 의도여서 정적 audit 으로 판정 불가 — 그 cascade 대상이
+	/// SceneLifetimeScope 에 명시 안 됐어도 본 도구는 보고함 (false-positive 가능). 해소 =
+	/// 보고된 컴포넌트의 부모 GameObject 가 cascade 경로면 SceneLifetimeScope 에 「container.Inject」
+	/// 라인 한 줄 추가 (자기참조 sync).
+	/// </summary>
+	public static class SceneDiAuditor
+	{
+		private const string SCENE_LIFETIME_SCOPE_PATH =
+			"Assets/_WitchMendokusai/Domain/Application/Scripts/DI/SceneLifetimeScope.cs";
+
+		private const string ROOT_LIFETIME_SCOPE_PATH =
+			"Assets/_WitchMendokusai/Domain/Application/Scripts/DI/RootLifetimeScope.cs";
+
+		// 「scene-direct」 = 본 폴더 하위 모든 .unity. 패키지 / 외부 씬 제외.
+		public const string SCENES_ROOT = "Assets/_WitchMendokusai/Scenes";
+
+		private static readonly Regex DIRECT_REGISTER_PATTERN = new Regex(
+			@"(?:RegisterInHierarchyIfPresent|RegisterComponentInNewPrefab|RegisterComponentOnNewGameObject|RegisterLeaf|ResolveIfPresent|BootGuard\.EagerResolve|Resources\.Load|builder\.Register)<(\w+)>",
+			RegexOptions.Compiled);
+
+		// container.Inject(x) foreach — component-only. `\s` 가 LF/CR/TAB/SPACE 포함, 한 줄/여러 줄 모두 매치.
+		private static readonly Regex INJECT_FOREACH_PATTERN = new Regex(
+			@"foreach\s*\(\s*(\w+)\s+\w+\s+in\s+FindObjectsByType<\1>\s*\([^)]*\)\s*\)\s*container\.Inject\(\s*\w+\s*\)\s*;",
+			RegexOptions.Compiled | RegexOptions.Singleline);
+
+		// container.InjectGameObject(x.gameObject) foreach — whole-hierarchy.
+		private static readonly Regex INJECT_GAMEOBJECT_FOREACH_PATTERN = new Regex(
+			@"foreach\s*\(\s*(\w+)\s+\w+\s+in\s+FindObjectsByType<\1>\s*\([^)]*\)\s*\)\s*container\.InjectGameObject\(",
+			RegexOptions.Compiled | RegexOptions.Singleline);
+
+		/// <summary>
+		/// 모든 로드된 어셈블리에서 MonoBehaviour 서브클래스 중 [Inject] 가 1+ 멤버에 붙은 타입 수집.
+		/// </summary>
+		public static HashSet<Type> CollectInjectConsumingTypes()
+		{
+			HashSet<Type> types = new HashSet<Type>();
+			foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+			{
+				Type[] assemblyTypes;
+				try
+				{
+					assemblyTypes = assembly.GetTypes();
+				}
+				catch (ReflectionTypeLoadException reflectionTypeLoadException)
+				{
+					assemblyTypes = reflectionTypeLoadException.Types.Where(loadedType => loadedType != null).ToArray();
+				}
+
+				foreach (Type type in assemblyTypes)
+				{
+					if (type == null)
+					{
+						continue;
+					}
+					if (type.IsAbstract == true)
+					{
+						continue;
+					}
+					if (typeof(MonoBehaviour).IsAssignableFrom(type) == false)
+					{
+						continue;
+					}
+					if (HasInjectAttribute(type) == true)
+					{
+						types.Add(type);
+					}
+				}
+			}
+			return types;
+		}
+
+		private static bool HasInjectAttribute(Type type)
+		{
+			BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+
+			Type current = type;
+			while (current != null && current != typeof(MonoBehaviour) && current != typeof(object))
+			{
+				foreach (MemberInfo member in current.GetMembers(flags))
+				{
+					if (member.IsDefined(typeof(InjectAttribute), inherit: false) == true)
+					{
+						return true;
+					}
+				}
+				current = current.BaseType;
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// SceneLifetimeScope.cs 소스를 파싱해 「Directly Covered」 + 「Hierarchy Covered」 타입 이름을 수집.
+		/// </summary>
+		public static SceneCoverageMap CollectSceneCoverage()
+		{
+			string fullPath = Path.GetFullPath(SCENE_LIFETIME_SCOPE_PATH);
+			if (File.Exists(fullPath) == false)
+			{
+				throw new FileNotFoundException(
+					$"SceneLifetimeScope 소스 미발견 — audit 진행 불가: {SCENE_LIFETIME_SCOPE_PATH}");
+			}
+
+			string source = File.ReadAllText(fullPath);
+
+			HashSet<string> direct = new HashSet<string>(StringComparer.Ordinal);
+			foreach (Match match in DIRECT_REGISTER_PATTERN.Matches(source))
+			{
+				direct.Add(match.Groups[1].Value);
+			}
+			foreach (Match match in INJECT_FOREACH_PATTERN.Matches(source))
+			{
+				direct.Add(match.Groups[1].Value);
+			}
+
+			HashSet<string> hierarchy = new HashSet<string>(StringComparer.Ordinal);
+			foreach (Match match in INJECT_GAMEOBJECT_FOREACH_PATTERN.Matches(source))
+			{
+				hierarchy.Add(match.Groups[1].Value);
+				direct.Add(match.Groups[1].Value); // InjectGameObject 도 본인 컴포넌트는 직접 커버.
+			}
+
+			// Root scope 도 등록 타입은 「씬 직접배치 NRE」 와 무관하지만, 본 감사의 false-positive 를
+			// 줄이기 위해 Root 등록 타입도 「Directly Covered」 에 포함 (예: GameManager / TimeManager).
+			if (File.Exists(Path.GetFullPath(ROOT_LIFETIME_SCOPE_PATH)) == true)
+			{
+				string rootSource = File.ReadAllText(Path.GetFullPath(ROOT_LIFETIME_SCOPE_PATH));
+				foreach (Match match in DIRECT_REGISTER_PATTERN.Matches(rootSource))
+				{
+					direct.Add(match.Groups[1].Value);
+				}
+			}
+
+			return new SceneCoverageMap(direct, hierarchy);
+		}
+
+		/// <summary>
+		/// 본 폴더 하위 모든 .unity 경로 (패키지 제외).
+		/// </summary>
+		public static IEnumerable<string> EnumerateProjectScenePaths()
+		{
+			foreach (string guid in AssetDatabase.FindAssets("t:Scene", new[] { SCENES_ROOT }))
+			{
+				string path = AssetDatabase.GUIDToAssetPath(guid);
+				if (string.IsNullOrEmpty(path) == true)
+				{
+					continue;
+				}
+				if (path.StartsWith("Packages/") == true)
+				{
+					continue;
+				}
+				yield return path;
+			}
+		}
+
+		/// <summary>
+		/// 단일 씬 audit. 씬을 additive 로 열어 walk 후 닫음 (저장 X — 비파괴).
+		/// </summary>
+		public static List<SceneDiOffender> AuditScene(
+			string scenePath,
+			SceneCoverageMap coverage,
+			HashSet<Type> injectConsumingTypes)
+		{
+			List<SceneDiOffender> offenders = new List<SceneDiOffender>();
+
+			Scene scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+			try
+			{
+				foreach (GameObject root in scene.GetRootGameObjects())
+				{
+					WalkHierarchy(scenePath, root, parentHierarchyCovers: false, coverage, injectConsumingTypes, offenders);
+				}
+			}
+			finally
+			{
+				EditorSceneManager.CloseScene(scene, removeScene: true);
+			}
+
+			return offenders;
+		}
+
+		private static void WalkHierarchy(
+			string scenePath,
+			GameObject gameObject,
+			bool parentHierarchyCovers,
+			SceneCoverageMap coverage,
+			HashSet<Type> injectConsumingTypes,
+			List<SceneDiOffender> offenders)
+		{
+			// 이 GameObject 자체가 InjectGameObject 대상 타입이면 자손까지 hierarchy-covered.
+			bool selfTriggersHierarchy = false;
+			MonoBehaviour[] components = gameObject.GetComponents<MonoBehaviour>();
+			foreach (MonoBehaviour component in components)
+			{
+				if (component == null)
+				{
+					continue;
+				}
+				if (coverage.HierarchyCovered.Contains(component.GetType().Name) == true)
+				{
+					selfTriggersHierarchy = true;
+					break;
+				}
+			}
+
+			bool effectiveHierarchyCovers = parentHierarchyCovers == true || selfTriggersHierarchy == true;
+
+			foreach (MonoBehaviour component in components)
+			{
+				if (component == null)
+				{
+					continue;
+				}
+				Type type = component.GetType();
+				if (injectConsumingTypes.Contains(type) == false)
+				{
+					continue;
+				}
+				if (effectiveHierarchyCovers == true)
+				{
+					continue;
+				}
+				if (coverage.DirectlyCovered.Contains(type.Name) == true)
+				{
+					continue;
+				}
+
+				offenders.Add(new SceneDiOffender
+				{
+					ScenePath = scenePath,
+					GameObjectPath = BuildGameObjectPath(component.transform),
+					ComponentTypeName = type.Name,
+					ComponentFullTypeName = type.FullName,
+				});
+			}
+
+			foreach (Transform child in gameObject.transform)
+			{
+				WalkHierarchy(scenePath, child.gameObject, effectiveHierarchyCovers, coverage, injectConsumingTypes, offenders);
+			}
+		}
+
+		private static string BuildGameObjectPath(Transform transform)
+		{
+			List<string> segments = new List<string>();
+			Transform current = transform;
+			while (current != null)
+			{
+				segments.Add(current.name);
+				current = current.parent;
+			}
+			segments.Reverse();
+			return string.Join("/", segments);
+		}
+	}
+
+	public sealed class SceneCoverageMap
+	{
+		public HashSet<string> DirectlyCovered { get; }
+		public HashSet<string> HierarchyCovered { get; }
+
+		public SceneCoverageMap(HashSet<string> directlyCovered, HashSet<string> hierarchyCovered)
+		{
+			DirectlyCovered = directlyCovered;
+			HierarchyCovered = hierarchyCovered;
+		}
+	}
+
+	public sealed class SceneDiOffender
+	{
+		public string ScenePath;
+		public string GameObjectPath;
+		public string ComponentTypeName;
+		public string ComponentFullTypeName;
+	}
+}

--- a/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditor.cs.meta
+++ b/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 225778af96eb58b1f0a3a2f23fb0d1d1

--- a/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditorMenu.cs
+++ b/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditorMenu.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+
+namespace WitchMendokusai.Editor.DI
+{
+	/// <summary>
+	/// TASK-WM-109-C — SceneDiAuditor 의 Editor 메뉴 진입점.
+	///
+	/// Menu = `WM/Audit/Scene DI Coverage` — `Assets/_WitchMendokusai/Scenes/` 하위
+	/// 모든 .unity 를 audit, Console 에 「누락 컴포넌트 + GameObject path + 타입」
+	/// 보고. 부작용 0 (씬 저장 X, 씬 상태 복원).
+	/// </summary>
+	public static class SceneDiAuditorMenu
+	{
+		private const string MENU_AUDIT_ALL = "WM/Audit/Scene DI Coverage (모든 씬)";
+		private const string MENU_AUDIT_ACTIVE = "WM/Audit/Scene DI Coverage (활성 씬만)";
+
+		[MenuItem(MENU_AUDIT_ALL, priority = 2100)]
+		private static void AuditAllScenes()
+		{
+			HashSet<Type> injectConsumingTypes = SceneDiAuditor.CollectInjectConsumingTypes();
+			SceneCoverageMap coverage = SceneDiAuditor.CollectSceneCoverage();
+
+			List<SceneDiOffender> offenders = new List<SceneDiOffender>();
+			int scenesScanned = 0;
+			foreach (string scenePath in SceneDiAuditor.EnumerateProjectScenePaths())
+			{
+				offenders.AddRange(SceneDiAuditor.AuditScene(scenePath, coverage, injectConsumingTypes));
+				scenesScanned++;
+			}
+
+			LogReport(offenders, scenesScanned, injectConsumingTypes.Count, coverage);
+		}
+
+		[MenuItem(MENU_AUDIT_ACTIVE, priority = 2101)]
+		private static void AuditActiveScene()
+		{
+			UnityEngine.SceneManagement.Scene activeScene = UnityEditor.SceneManagement.EditorSceneManager.GetActiveScene();
+			if (string.IsNullOrEmpty(activeScene.path) == true)
+			{
+				Debug.LogWarning("[SceneDiAuditor] 활성 씬이 저장되지 않은 상태 — 먼저 씬을 저장하세요.");
+				return;
+			}
+
+			HashSet<Type> injectConsumingTypes = SceneDiAuditor.CollectInjectConsumingTypes();
+			SceneCoverageMap coverage = SceneDiAuditor.CollectSceneCoverage();
+
+			List<SceneDiOffender> offenders = SceneDiAuditor.AuditScene(activeScene.path, coverage, injectConsumingTypes);
+			LogReport(offenders, scenesScanned: 1, injectConsumingTypes.Count, coverage);
+		}
+
+		private static void LogReport(
+			List<SceneDiOffender> offenders,
+			int scenesScanned,
+			int injectConsumingTypeCount,
+			SceneCoverageMap coverage)
+		{
+			StringBuilder report = new StringBuilder();
+			report.AppendLine($"[SceneDiAuditor] 스캔 완료 — 씬 {scenesScanned} 개 / [Inject] 소비 타입 {injectConsumingTypeCount} 종 / Directly-covered {coverage.DirectlyCovered.Count} / Hierarchy-covered {coverage.HierarchyCovered.Count}");
+
+			if (offenders.Count == 0)
+			{
+				report.AppendLine("  ✅ 씬 직접배치 컴포넌트 [Inject] 누락 0 — SceneLifetimeScope 커버리지 완전.");
+				Debug.Log(report.ToString());
+				return;
+			}
+
+			report.AppendLine($"  ⚠ 씬 직접배치 [Inject] 미해소 컴포넌트 {offenders.Count} 건 발견:");
+			foreach (SceneDiOffender offender in offenders)
+			{
+				report.AppendLine($"    [{offender.ScenePath}] {offender.GameObjectPath}  ::  {offender.ComponentTypeName}");
+			}
+			report.AppendLine("  대응: 해당 컴포넌트 타입을 SceneLifetimeScope.cs 의 Configure 또는 RegisterBuildCallback");
+			report.AppendLine("        foreach (container.Inject / container.InjectGameObject) 에 추가. 또는 부모 GameObject 가");
+			report.AppendLine("        InjectGameObject 경로면 false-positive (부모 타입을 hierarchy-cover 에 명시).");
+			Debug.LogWarning(report.ToString());
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditorMenu.cs
+++ b/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditorMenu.cs
@@ -6,13 +6,6 @@ using UnityEngine;
 
 namespace WitchMendokusai.Editor.DI
 {
-	/// <summary>
-	/// TASK-WM-109-C — SceneDiAuditor 의 Editor 메뉴 진입점.
-	///
-	/// Menu = `WM/Audit/Scene DI Coverage` — `Assets/_WitchMendokusai/Scenes/` 하위
-	/// 모든 .unity 를 audit, Console 에 「누락 컴포넌트 + GameObject path + 타입」
-	/// 보고. 부작용 0 (씬 저장 X, 씬 상태 복원).
-	/// </summary>
 	public static class SceneDiAuditorMenu
 	{
 		private const string MENU_AUDIT_ALL = "WM/Audit/Scene DI Coverage (모든 씬)";

--- a/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditorMenu.cs.meta
+++ b/Assets/_WitchMendokusai/Editor/DI/SceneDiAuditorMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a27b79d31d832a3f1a843713faa95b34

--- a/Assets/_WitchMendokusai/Tests/EditMode/SceneDiCoverageTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/SceneDiCoverageTest.cs
@@ -6,20 +6,6 @@ using WitchMendokusai.Editor.DI;
 
 namespace WitchMendokusai.Tests
 {
-	/// <summary>
-	/// TASK-WM-109-C — 씬 직접배치 컴포넌트의 DI 등록 누락 *CI 게이트*.
-	///
-	/// 배경: TASK-WM-109 이슈 3 — 새 컴포넌트가 World.unity 에 직접 배치됐는데 SceneLifetimeScope
-	/// 누락 → 부팅 [Inject] 0 → 사용 시점 NRE → cascade. 매번 stack trace → meta GUID → grep
-	/// 사이클. 본 테스트가 그 사이클의 *진입* 자체를 차단 — Composition Root 그래프 검증
-	/// (CompositionRootResolveTest) 과 동급의 *씬 실재* 검증.
-	///
-	/// 검증 단위: `SceneDiAuditor.AuditScene` — 씬 additive open + walk + close.
-	/// SceneLifetimeScope.cs 소스 *정본* 자기참조 → 새 registration 추가 시 audit 자동 인식.
-	///
-	/// 실행: `unity -runTests -batchmode -testPlatform EditMode -assemblyNames WM.Tests.EditMode`
-	/// (격리 worktree = MCP / 에디터 락 무관, ~1-2분).
-	/// </summary>
 	public sealed class SceneDiCoverageTest
 	{
 		[Test]

--- a/Assets/_WitchMendokusai/Tests/EditMode/SceneDiCoverageTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/SceneDiCoverageTest.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using WitchMendokusai.Editor.DI;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-109-C — 씬 직접배치 컴포넌트의 DI 등록 누락 *CI 게이트*.
+	///
+	/// 배경: TASK-WM-109 이슈 3 — 새 컴포넌트가 World.unity 에 직접 배치됐는데 SceneLifetimeScope
+	/// 누락 → 부팅 [Inject] 0 → 사용 시점 NRE → cascade. 매번 stack trace → meta GUID → grep
+	/// 사이클. 본 테스트가 그 사이클의 *진입* 자체를 차단 — Composition Root 그래프 검증
+	/// (CompositionRootResolveTest) 과 동급의 *씬 실재* 검증.
+	///
+	/// 검증 단위: `SceneDiAuditor.AuditScene` — 씬 additive open + walk + close.
+	/// SceneLifetimeScope.cs 소스 *정본* 자기참조 → 새 registration 추가 시 audit 자동 인식.
+	///
+	/// 실행: `unity -runTests -batchmode -testPlatform EditMode -assemblyNames WM.Tests.EditMode`
+	/// (격리 worktree = MCP / 에디터 락 무관, ~1-2분).
+	/// </summary>
+	public sealed class SceneDiCoverageTest
+	{
+		[Test]
+		public void ProjectScenes_HaveNoUnregisteredInjectConsumingComponents()
+		{
+			HashSet<Type> injectConsumingTypes = SceneDiAuditor.CollectInjectConsumingTypes();
+			SceneCoverageMap coverage = SceneDiAuditor.CollectSceneCoverage();
+
+			List<SceneDiOffender> offenders = new List<SceneDiOffender>();
+			int scenesScanned = 0;
+			foreach (string scenePath in SceneDiAuditor.EnumerateProjectScenePaths())
+			{
+				offenders.AddRange(SceneDiAuditor.AuditScene(scenePath, coverage, injectConsumingTypes));
+				scenesScanned++;
+			}
+
+			Assert.That(scenesScanned, Is.GreaterThan(0),
+				$"프로젝트 씬 0 — `{SceneDiAuditor.SCENES_ROOT}` 하위 .unity 자산 검색 실패. 폴더 구조 확인.");
+
+			if (offenders.Count == 0)
+			{
+				return;
+			}
+
+			StringBuilder message = new StringBuilder();
+			message.AppendLine($"씬 직접배치 [Inject] 미해소 컴포넌트 {offenders.Count} 건 (스캔 씬 {scenesScanned} 개):");
+			foreach (SceneDiOffender offender in offenders)
+			{
+				message.AppendLine($"  [{offender.ScenePath}] {offender.GameObjectPath}  ::  {offender.ComponentTypeName} ({offender.ComponentFullTypeName})");
+			}
+			message.AppendLine("원인: SceneLifetimeScope.Configure / RegisterBuildCallback 의 foreach 에서 누락 → 부팅 [Inject] 0 → 사용 시점 NRE.");
+			message.AppendLine("처리: ① 해당 타입을 SceneLifetimeScope 에 등록 (RegisterInHierarchyIfPresent 또는 container.Inject / InjectGameObject foreach).");
+			message.AppendLine("       ② 부모 GameObject 가 InjectGameObject 경로면 false-positive — SceneLifetimeScope 에 부모 타입을 InjectGameObject foreach 로 명시 (현재 누락 시).");
+			message.AppendLine("진단 메뉴: WM/Audit/Scene DI Coverage (모든 씬)");
+			Assert.Fail(message.ToString());
+		}
+
+		[Test]
+		public void SceneLifetimeScope_CoverageMap_IsParsedNonEmpty()
+		{
+			// 소스 파싱이 실패해 빈 set 가 되면 audit 전체가 무용지물 (모두 누락 보고). 정본 sanity.
+			SceneCoverageMap coverage = SceneDiAuditor.CollectSceneCoverage();
+			Assert.That(coverage.DirectlyCovered.Count, Is.GreaterThan(0),
+				"SceneLifetimeScope.cs 의 Register*<T> / Inject foreach 파싱 실패 — Auditor regex 정합 깨짐.");
+			Assert.That(coverage.HierarchyCovered.Count, Is.GreaterThan(0),
+				"SceneLifetimeScope.cs 의 InjectGameObject foreach 파싱 실패 — Auditor regex 정합 깨짐.");
+		}
+
+		[Test]
+		public void InjectConsumingTypes_AreDetected()
+		{
+			// reflection 이 0 을 내면 audit 가 silently pass — 정본 sanity.
+			HashSet<Type> injectConsumingTypes = SceneDiAuditor.CollectInjectConsumingTypes();
+			Assert.That(injectConsumingTypes.Count, Is.GreaterThan(0),
+				"[Inject] 소비 컴포넌트 reflection 결과 0 — 어셈블리 로드 / VContainer.InjectAttribute 참조 깨짐.");
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/SceneDiCoverageTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/SceneDiCoverageTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f9b796fc5e7ba8ddc06b909f9aa7434f

--- a/Assets/_WitchMendokusai/Tests/EditMode/WM.Tests.EditMode.asmdef
+++ b/Assets/_WitchMendokusai/Tests/EditMode/WM.Tests.EditMode.asmdef
@@ -5,6 +5,7 @@
         "WitchMendokusai.DomainSDK",
         "WM.Domain",
         "WM.Core",
+        "WM.Editor",
         "VContainer"
     ],
     "includePlatforms": [


### PR DESCRIPTION
## Summary

TASK-WM-109 이슈 3 — 씬 직접배치 컴포넌트의 DI 등록 누락 NRE 사이클을 *자동 audit* 으로 종결.

- **`SceneDiAuditor.cs`** — 정본 로직. SceneLifetimeScope.cs 소스 regex 파싱 → 새 registration 자동 인식 (별도 registry 도입 X = 자기참조 sync). reflection 으로 MonoBehaviour + [Inject] 멤버 자동 검출. InjectGameObject 부모 hierarchy-cover 전파로 자손 false-positive 0.
- **`SceneDiAuditorMenu.cs`** — `WM/Audit/Scene DI Coverage (모든 씬)` / `(활성 씬만)` 메뉴.
- **`SceneDiCoverageTest.cs`** — EditMode 테스트 CI 게이트. 누락 1+ 시 즉시 fail (NRE 가 게임 부팅 전에 차단).

## 설계 결정

TASK 스펙의 4 옵션 중 **옵션 1(audit script) + 옵션 3 의 *테스트 변형*** 채택. 옵션 2(marker interface) 와 옵션 4(수동 registry) 는 SceneLifetimeScope 와 *이중 정본* 생성 → 동기 부담. SceneLifetimeScope 가 *단일 정본* 으로 audit 가 자기참조.

## Coverage 카테고리 (SceneLifetimeScope.cs 정본 자기참조)

- **Directly Covered** = `RegisterInHierarchyIfPresent<T>` / `Register*<T>` / `container.Inject(x)` foreach. 본 컴포넌트만 cover (sibling/child X).
- **Hierarchy Covered** = `container.InjectGameObject(x.gameObject)` foreach. 본인 + 자손 전체 cover.
- **Root Scope** = RootLifetimeScope (DDOL 영역). audit 의 false-positive 감소 목적으로 union 에 포함.

## 한계 (명시)

- `container.Inject(x)` 가 자식 코드로 cascade 하는 경우 (Player.Construct → 자식 cascade) 는 정적 audit 으로 판정 불가 — 보고됨. 해소 = SceneLifetimeScope 의 foreach 라인 한 줄 추가.
- 검출은 *타입 단위* — 같은 타입의 다른 instance 가 누락된 GameObject 에 있어도 type-level 로 cover 처리.

## Test plan

- [ ] **컴파일 검증 (Unity Editor)** — autopilot 환경 dotnet build 폐기 (CLAUDE.md § 컴파일 에러 확인). Unity Editor 가 PR 머지 전에 *MCP `read_console(types=[\"error\", \"warning\"])`* 또는 Editor.log fallback grep 으로 error/warning 0 확인.
- [ ] **EditMode 테스트 실행** — `WM.Tests.EditMode/SceneDiCoverageTest`:
  - [ ] `SceneLifetimeScope_CoverageMap_IsParsedNonEmpty` PASS (regex parse sanity)
  - [ ] `InjectConsumingTypes_AreDetected` PASS (reflection sanity)
  - [ ] `ProjectScenes_HaveNoUnregisteredInjectConsumingComponents` PASS (main 검증)
- [ ] **메뉴 동작 확인** — `WM/Audit/Scene DI Coverage (모든 씬)` 실행, Console 보고 확인.
- [ ] **회귀 시뮬레이션 (선택)** — SceneLifetimeScope 의 `RegisterInHierarchyIfPresent<InteractiveMarker>` (혹은 해당 foreach) 한 줄 임시 주석 → test FAIL 확인 (정확한 detection capability 검증) → 원복.

## PowerShell 사전 검증

regex 가 SceneLifetimeScope.cs / RootLifetimeScope.cs 의 현재 등록을 모두 캡처함을 로컬 PowerShell 로 검증 완료:
- Scene direct: 34 종 (Player/UIManager/CardManager 등 전부)
- Scene Inject foreach: Player / InteractiveMarker / AutoAimMarker
- Scene InjectGameObject foreach: MonsterObject / ResourceNodeObject
- Root: 29 종 (TimeManager / InputManager / GameManager 등 전부, RegisterLeaf / builder.Register 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)