### PR TITLE
feat(WM-109-B): InjectGameObjectExcludingSelf — self-cascade 무한 재귀 guard 표준화

### DIFF
--- a/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/ObjectResolverHierarchyExtensions.cs
+++ b/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/ObjectResolverHierarchyExtensions.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using VContainer;
+
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// IObjectResolver 계층 주입 헬퍼 — self-cascade 무한 재귀 guard 표준화 (TASK-WM-109-B).
+	///
+	/// 배경: <c>container.InjectGameObject(go)</c> 는 go 계층의 모든 MonoBehaviour 에 Inject 를
+	/// 재귀 적용한다 (VContainer 1.17.0 <c>ObjectResolverUnityExtensions.InjectGameObjectRecursive</c>,
+	/// DI/VCONTAINER-MECHANISM.md §5). caller 컴포넌트의 <c>[Inject] Construct</c> 안에서 자기
+	/// gameObject 를 그대로 InjectGameObject 하면 → 자기 자신도 다시 Inject → Construct
+	/// 재호출 → 무한 재귀 → StackOverflow → Unity crash.
+	/// (commit ad920ca2 도입 → bcb59577 revert. TASK-WM-109 이슈 2.
+	///  `process.md § 황금의 정신 — 설계 자가 검토` 위반 사례.)
+	///
+	/// 본 헬퍼 = VContainer <c>InjectGameObject</c> 와 동일한 계층-재귀 의미(자식·inactive 포함)
+	/// 이되, 지정한 self 컴포넌트 1개만 제외한다. caller 의 Construct 내부에서 형제·자식
+	/// cascade 를 안전하게 수행하는 정본 진입점.
+	///
+	/// 계약(중요): 한 prefab/계층에서 cascade 를 트리거하는 root 컴포넌트는 *하나* 여야 한다.
+	/// self 만 제외하므로, 두 컴포넌트가 서로 본 헬퍼를 자기 Construct 안에서 호출하면 상호
+	/// 재귀(A→B→A…)가 다시 성립한다. 자식 컴포넌트는 cascade 를 재트리거하지 말고
+	/// <c>[Inject] Construct</c> 로 deps 만 받는다 (Player.prefab = Player 단일 root, 자식
+	/// PlayerObject/PlayerRotation/UnitMovement 등은 deps-only).
+	///
+	/// 사용처: <c>Player.Construct</c> (TASK-WM-108/115). 향후 "자기 Construct 안에서 자기
+	/// 계층 cascade" 가 필요한 root 컴포넌트는 raw InjectGameObject 대신 본 헬퍼를 사용한다.
+	/// raw <c>InjectGameObject</c> 는 caller 가 계층 *밖* 일 때만 안전
+	/// (ObjectPoolManager / SceneLifetimeScope / UIManager — 자기 자신을 주입하지 않음).
+	/// </summary>
+	public static class ObjectResolverHierarchyExtensions
+	{
+		/// <summary>
+		/// <paramref name="root"/> 계층의 모든 MonoBehaviour(자식·inactive 포함)에 Inject 를
+		/// 적용하되, <paramref name="self"/> 컴포넌트 1개는 제외한다.
+		///
+		/// caller 의 <c>[Inject] Construct</c> 내부에서 <c>this</c> 를 self 로 넘겨 호출하면
+		/// 자기 Construct 재진입이 차단되어 무한 재귀가 발생하지 않는다.
+		/// </summary>
+		/// <param name="resolver">VContainer 컨테이너 (caller 의 Construct 가 주입받은 IObjectResolver).</param>
+		/// <param name="root">cascade 대상 계층의 루트 GameObject (보통 caller 의 gameObject).</param>
+		/// <param name="self">제외할 caller 컴포넌트 (보통 <c>this</c>).</param>
+		public static void InjectGameObjectExcludingSelf(
+			this IObjectResolver resolver, GameObject root, MonoBehaviour self)
+		{
+			// GetComponentsInChildren<MonoBehaviour>(true) = VContainer InjectGameObject 와
+			// 동일 집합(루트+모든 자손, inactive 포함). 주입은 컴포넌트 단위 멱등이라 순서 무관.
+			foreach (MonoBehaviour component in root.GetComponentsInChildren<MonoBehaviour>(true))
+			{
+				if (component != self)
+					resolver.Inject(component);
+			}
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/ObjectResolverHierarchyExtensions.cs.meta
+++ b/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/ObjectResolverHierarchyExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b0d1f5aab48c41118d8fe021d8c76df7

--- a/Assets/_WitchMendokusai/Domain/Doll/_Common/Scripts/Player.cs
+++ b/Assets/_WitchMendokusai/Domain/Doll/_Common/Scripts/Player.cs
@@ -45,11 +45,10 @@ namespace WitchMendokusai
 			// InteractiveMarker/AutoAimMarker/UnitMovement 등). RegisterComponentInHierarchy<Player> 는 Player
 			// 컴포넌트만 inject — 자식은 컨테이너가 모름. 컨테이너 주입 root 가 비등록 자식 cascade =
 			// UIRoot.Construct / ObjectPoolManager.InjectGameObject 와 동일 canonical 패턴 (TASK-WM-078, 2026-05-16).
-			foreach (MonoBehaviour childComponent in GetComponentsInChildren<MonoBehaviour>(true))
-			{
-				if (childComponent != this)
-					container.Inject(childComponent);
-			}
+			//
+			// raw InjectGameObject 대신 self-exclude 정본 헬퍼 사용 — 자기 Construct 재진입으로 인한
+			// 무한 재귀(StackOverflow) 차단. TASK-WM-109-B / ObjectResolverHierarchyExtensions.
+			container.InjectGameObjectExcludingSelf(gameObject, this);
 		}
 
 		private void Awake()

--- a/Assets/_WitchMendokusai/Tests/EditMode/InjectGameObjectExcludingSelfTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/InjectGameObjectExcludingSelfTest.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using VContainer;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-109-B — <see cref="ObjectResolverHierarchyExtensions.InjectGameObjectExcludingSelf"/>
+	/// self-cascade 무한 재귀 guard 검증.
+	///
+	/// 회귀 배경: Player.Construct 가 raw <c>container.InjectGameObject(gameObject)</c> 를
+	/// 호출 → Player 자신도 재주입 → Player.Construct 재호출 → 무한 재귀 → StackOverflow →
+	/// Unity crash (commit ad920ca2 도입 → bcb59577 revert. TASK-WM-109 이슈 2).
+	///
+	/// 본 테스트는 *실제 VContainer 컨테이너* 로 그 시나리오를 재현한다:
+	///   ① 계층 전체(자식·inactive·손자 포함)가 주입되는지 + self 만 제외되는지
+	///   ② caller 의 Construct 안에서 헬퍼를 호출해도(= Player 패턴) 무한 재귀 없이
+	///      caller Construct 가 정확히 1회만 실행되는지 (guard 의 본질).
+	///
+	/// 결정적(ms, RNG/시간/FS/씬/PlayMode 무관) — EditMode 신뢰 루프.
+	/// </summary>
+	public sealed class InjectGameObjectExcludingSelfTest
+	{
+		private readonly List<GameObject> spawned = new List<GameObject>();
+
+		[TearDown]
+		public void TearDown()
+		{
+			foreach (GameObject go in spawned)
+			{
+				if (go != null)
+					Object.DestroyImmediate(go);
+			}
+			spawned.Clear();
+		}
+
+		private GameObject NewGameObject(string name, GameObject parent = null, bool active = true)
+		{
+			GameObject go = new GameObject(name);
+			if (parent != null)
+				go.transform.SetParent(parent.transform);
+			go.SetActive(active);
+			spawned.Add(go);
+			return go;
+		}
+
+		private static IObjectResolver BuildEmptyContainer()
+		{
+			// 등록 0 — Construct 가 파라미터 없는 메서드라 resolve 불필요.
+			// BuildRegistry + 인스턴스화 경로를 정상 통과(Composition Root 와 동일 API).
+			return new ContainerBuilder().Build();
+		}
+
+		// 파라미터 없는 [Inject] Construct — VContainer 가 주입 시 1회 호출, 카운트 누적.
+		public sealed class ConstructCounter : MonoBehaviour
+		{
+			public int ConstructCount;
+
+			[Inject]
+			public void Construct() => ConstructCount++;
+		}
+
+		// Player 패턴 재현: 자기 Construct 안에서 자기 계층을 self 제외 cascade.
+		public sealed class SelfCascadingRoot : MonoBehaviour
+		{
+			public int ConstructCount;
+
+			[Inject]
+			public void Construct(IObjectResolver container)
+			{
+				ConstructCount++;
+				container.InjectGameObjectExcludingSelf(gameObject, this);
+			}
+		}
+
+		[Test]
+		public void InjectsAllDescendants_ExceptSelf()
+		{
+			IObjectResolver container = BuildEmptyContainer();
+
+			GameObject root = NewGameObject("Root");
+			ConstructCounter rootSelf = root.AddComponent<ConstructCounter>();
+
+			GameObject activeChild = NewGameObject("ActiveChild", root, active: true);
+			ConstructCounter activeChildCounter = activeChild.AddComponent<ConstructCounter>();
+
+			GameObject inactiveChild = NewGameObject("InactiveChild", root, active: false);
+			ConstructCounter inactiveChildCounter = inactiveChild.AddComponent<ConstructCounter>();
+
+			GameObject grandChild = NewGameObject("GrandChild", activeChild, active: true);
+			ConstructCounter grandChildCounter = grandChild.AddComponent<ConstructCounter>();
+
+			container.InjectGameObjectExcludingSelf(root, rootSelf);
+
+			Assert.That(rootSelf.ConstructCount, Is.EqualTo(0),
+				"self 컴포넌트는 제외돼야 한다 (caller Construct 재진입 차단)");
+			Assert.That(activeChildCounter.ConstructCount, Is.EqualTo(1),
+				"active 자식은 1회 주입돼야 한다");
+			Assert.That(inactiveChildCounter.ConstructCount, Is.EqualTo(1),
+				"inactive 자식도 1회 주입돼야 한다 (VContainer InjectGameObject 와 동일 의미)");
+			Assert.That(grandChildCounter.ConstructCount, Is.EqualTo(1),
+				"손자(재귀)도 1회 주입돼야 한다");
+		}
+
+		[Test]
+		public void FromWithinSelfConstruct_DoesNotRecurseInfinitely()
+		{
+			// TASK-WM-109 이슈 2 시나리오 정확 재현: caller 가 자기 Construct 안에서
+			// 자기 계층을 cascade. guard 없으면 여기서 StackOverflow → 프로세스 crash.
+			IObjectResolver container = BuildEmptyContainer();
+
+			GameObject root = NewGameObject("Root");
+			SelfCascadingRoot selfCascading = root.AddComponent<SelfCascadingRoot>();
+
+			GameObject child = NewGameObject("Child", root, active: true);
+			ConstructCounter childCounter = child.AddComponent<ConstructCounter>();
+
+			// Player 가 SceneLifetimeScope 에서 주입되는 경로(container.Inject(player)) 동일.
+			container.Inject(selfCascading);
+
+			Assert.That(selfCascading.ConstructCount, Is.EqualTo(1),
+				"caller Construct 는 정확히 1회 — self-exclude 로 재진입 차단 (무한 재귀 X)");
+			Assert.That(childCounter.ConstructCount, Is.EqualTo(1),
+				"자식은 caller Construct 의 cascade 로 1회 주입");
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/InjectGameObjectExcludingSelfTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/InjectGameObjectExcludingSelfTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: faf272319ed243649bc28dc1ec669f06


### PR DESCRIPTION
## TASK-WM-109-B — VContainer self-cascade 무한 재귀 guard

TASK-WM-109 이슈 2 해결. raw `container.InjectGameObject(gameObject)` 를 caller 의 `[Inject] Construct` 안에서 호출 시 caller 자신도 재주입 → Construct 재호출 → 무한 재귀 → StackOverflow → Unity crash (commit ad920ca2 도입 → bcb59577 revert. `process.md § 황금의 정신 — 설계 자가 검토` 위반 사례).

## 해결안 비교 (스펙 3안)

| 안 | 선택 | 사유 |
|---|---|---|
| 1. self-exclude guard (`InjectGameObjectExcludingSelf`) | ✅ | explicit·safe-by-default, Player.cs 가 이미 inline 으로 하던 패턴과 *동작 동일* (zero behavior change). VContainer `InjectGameObject` 와 같은 계층-재귀 의미(자식·inactive 포함) + self 1개 제외. |
| 2. InjectChildren/InjectSelf 분리 | ❌ | API 복잡도 ↑, caller 는 거의 항상 "자식만" 원하므로 unsplit 가 직관적. |
| 3. SceneLifetimeScope 중앙집중 | ❌ | Construct 시기 제어 상실. TASK-WM-115 R3a — Player.Object/Rotation 을 `Awake < Construct` 순서로 확정해야 → cascade 가 Construct 안에 있어야 함. 중앙집중 시 Awake 가 먼저 발화. |

## 변경 파일

- **`ObjectResolverHierarchyExtensions.cs` (신규, WM.Domain)** — `IObjectResolver.InjectGameObjectExcludingSelf(root, self)` 정본 헬퍼. `GetComponentsInChildren<MonoBehaviour>(true)` (VContainer `InjectGameObjectRecursive` 와 동일 집합) + `if (component != self) resolver.Inject(component)`. 계약 주석: 한 prefab 에서 cascade root 는 *하나* (상호 self-exclude 가 무한 재귀 다시 성립 방지).
- **`Player.cs` Construct** — inline foreach 자기제외 루프 → `container.InjectGameObjectExcludingSelf(gameObject, this)` 1줄로 교체. **zero behavior change** (동일 집합·동일 제외).
- **`InjectGameObjectExcludingSelfTest.cs` (신규, WM.Tests.EditMode)** — 실제 `ContainerBuilder().Build()` 컨테이너 사용:
  - `InjectsAllDescendants_ExceptSelf` — root + active 자식 + inactive 자식 + 손자 = 자식 3 모두 Construct 1회, root self 는 0회.
  - `FromWithinSelfConstruct_DoesNotRecurseInfinitely` — Player 패턴(자기 Construct 안 cascade) 정확 재현. guard 없으면 StackOverflow → 프로세스 crash. 통과 시 caller Construct 정확히 1회 + 자식 1회.

## 회귀 인증

- TASK-WM-109-A 정독 산출 `DI/VCONTAINER-MECHANISM.md §5` — `InjectGameObject` 는 `InjectGameObjectRecursive` (자기 GameObject 의 모든 MonoBehaviour + 자식 트랜스폼 재귀). 본 헬퍼 = 그 정확한 집합 - self.
- raw `InjectGameObject` 의 안전 사용처는 **caller 가 계층 밖** 인 경우만 — `ObjectPoolManager.cs:137`, `SceneLifetimeScope.cs:143/145`, `UIManager.cs:188`. 이들은 *자기 자신을 주입하지 않으므로* 무관. 헬퍼 도입은 caller-in-hierarchy 경우(`Player.Construct` = 유일 사용처) 만 변경.

## Test plan

- [ ] 사용자: Unity Editor 에서 `Window > General > Test Runner > EditMode` → `InjectGameObjectExcludingSelfTest` 2개 테스트 PASS 확인 (결정적 ms).
- [ ] 사용자: `wm-boot-smoke.ps1` (또는 World 씬 Play) → Player 부팅 + 자식 PlayerObject/PlayerRotation/UnitMovement deps 주입 확인 (zero behavior change 이므로 회귀 0 기대).
- [ ] 사용자: `read_console(types=["error","warning"])` 0 entries 확인.

## 정본 사용

향후 *자기 Construct 안에서 자기 계층 cascade* 가 필요한 root 컴포넌트는 raw `InjectGameObject` 대신 본 헬퍼 사용. 계층 *밖* caller (SceneLifetimeScope / ObjectPoolManager / UIManager) 는 raw 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)