### PR TITLE
refactor(WM-109-E): cascade trigger 통합 — DiCascade static helper

### DIFF
--- a/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/DiCascade.cs
+++ b/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/DiCascade.cs
@@ -1,0 +1,74 @@
+using UnityEngine;
+using VContainer;
+using VContainer.Unity;
+
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// TASK-WM-109-E — cascade inject 분산(17 callsite) 통합 helper.
+	/// 시점·owner 별 분산은 SRP 정합 결과로 유지(중앙 집중 X), 공통 boilerplate 만 추출.
+	/// 결정 트리는 PR #WM-109-E / `DI/VCONTAINER-MECHANISM.md` § cascade 결정 트리 참고.
+	/// </summary>
+	public static class DiCascade
+	{
+		/// <summary>
+		/// owner-push 패턴: <c>owner.AddComponent&lt;T&gt;()</c> + <c>container.Inject</c>.
+		/// UIRoot.CreateViews / UIManager.Start / UIManager.CreateToolkitPanel 의
+		/// boilerplate 통일 (TASK-WM-109-E).
+		///
+		/// AddComponent 가 새 컴포넌트의 Awake 를 *즉시* 트리거 (Unity 고정). owner GO 가
+		/// 활성이면 Awake → OnEnable 이 Inject *전* 발화 가능 → deps null NRE. 이 helper 는
+		/// 그 시점을 owner 관할 책임으로 남겨둔다 (caller 가 시점 보장 — Construct/Start 호출).
+		/// </summary>
+		public static T AddInjected<T>(IObjectResolver container, GameObject owner) where T : Component
+		{
+			T component = owner.AddComponent<T>();
+			container.Inject(component);
+			return component;
+		}
+
+		/// <summary>
+		/// 비활성 Instantiate → 자식 전체 Inject → 활성. TASK-WM-115 R2 검증 패턴 정본.
+		/// active prefab 을 그냥 Instantiate 하면 자식 OnEnable 이 Inject *전* 발화 → deps null NRE.
+		/// (UIManager.InstantiateInjectedActive 흡수. ObjectPoolManager.CreateObject 와 동일 canonical.)
+		/// </summary>
+		public static T InstantiateInjected<T>(IObjectResolver container, T prefab, Transform parent, bool activateAfter) where T : Component
+		{
+			bool prefabWasActive = prefab.gameObject.activeSelf;
+			if (prefabWasActive)
+				prefab.gameObject.SetActive(false);
+
+			T instance = Object.Instantiate(prefab, parent);
+
+			if (prefabWasActive)
+				prefab.gameObject.SetActive(true);
+
+			// InjectGameObject = VContainer 표준 cascade primitive
+			// (ObjectResolverUnityExtensions.cs:36-64, GetComponents 자기 + 자식 트랜스폼 재귀).
+			container.InjectGameObject(instance.gameObject);
+
+			if (activateAfter)
+				instance.gameObject.SetActive(true);
+
+			return instance;
+		}
+
+		/// <summary>
+		/// self-cascade: root 의 자식 MonoBehaviour 들을 inject. root 자신은 *이미 inject 중*
+		/// (예: root.Construct 안에서 호출 — VContainer 가 root 를 inject 하면서 Construct 가
+		/// 발화) 라 제외. Player.Construct 의 canonical 패턴 (TASK-WM-078 2026-05-16).
+		///
+		/// 왜 InjectGameObject(root.gameObject) 가 아니라 foreach 인가:
+		/// InjectGameObject 는 root 자체 도 다시 inject 시도 (VContainer 멱등이지만 비효율).
+		/// self-cascade 는 *root 의 Construct 진행 중*이라 root 자신 재inject 의미 X.
+		/// </summary>
+		public static void InjectChildren(IObjectResolver container, MonoBehaviour root)
+		{
+			foreach (MonoBehaviour childComponent in root.GetComponentsInChildren<MonoBehaviour>(true))
+			{
+				if (childComponent != root)
+					container.Inject(childComponent);
+			}
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/DiCascade.cs.meta
+++ b/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/DiCascade.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eff73cc20b824dbaa12fc26a64e8b500

--- a/Assets/_WitchMendokusai/Domain/Doll/_Common/Scripts/Player.cs
+++ b/Assets/_WitchMendokusai/Domain/Doll/_Common/Scripts/Player.cs
@@ -45,11 +45,8 @@ namespace WitchMendokusai
 			// InteractiveMarker/AutoAimMarker/UnitMovement 등). RegisterComponentInHierarchy<Player> 는 Player
 			// 컴포넌트만 inject — 자식은 컨테이너가 모름. 컨테이너 주입 root 가 비등록 자식 cascade =
 			// UIRoot.Construct / ObjectPoolManager.InjectGameObject 와 동일 canonical 패턴 (TASK-WM-078, 2026-05-16).
-			foreach (MonoBehaviour childComponent in GetComponentsInChildren<MonoBehaviour>(true))
-			{
-				if (childComponent != this)
-					container.Inject(childComponent);
-			}
+			// TASK-WM-109-E — DiCascade.InjectChildren 으로 self-cascade 명시화.
+			DiCascade.InjectChildren(container, this);
 		}
 
 		private void Awake()

--- a/Assets/_WitchMendokusai/Domain/UI/UIManager.cs
+++ b/Assets/_WitchMendokusai/Domain/UI/UIManager.cs
@@ -54,14 +54,10 @@ namespace WitchMendokusai
 		/// Toolkit IUIPanel 을 글로벌 UIRoot 에 AddComponent + DI 주입해 생성.
 		/// 씬 prefab 미배치 Toolkit 패널의 owner-push 생성 경로 (InventoryView 등 선례 동형).
 		/// 호출 시점 = panel-group Init(Awake, Construct 후) → uiRoot/container 보장.
-		/// TASK-WM-113 S2 substrate.
+		/// TASK-WM-113 S2 substrate. TASK-WM-109-E — DiCascade 통합.
 		/// </summary>
 		public T CreateToolkitPanel<T>() where T : UIToolkitPanel
-		{
-			T panel = uiRoot.gameObject.AddComponent<T>();
-			container.Inject(panel);
-			return panel;
-		}
+			=> DiCascade.AddInjected<T>(container, uiRoot.gameObject);
 	
 		[SerializeField] private UIDungeon dungeonPrefab = null;
 		[SerializeField] private UIAdventurerGuild adventurerGuildPrefab = null;
@@ -137,42 +133,16 @@ namespace WitchMendokusai
 				Instance = null;
 		}
 
-		// TASK-WM-115 R2 — Instantiate-before-Inject NRE 차단 seam.
-		// prefab 을 비활성 토글한 채 Instantiate → 인스턴스 자식 OnEnable 미발화 →
-		// container.Inject 로 deps 주입 완료 후 활성 → OnEnable 이 valid deps 로 실행.
-		// (ObjectPoolManager.ObjectPool.CreateObject 와 동일 canonical 패턴.)
-		private T InstantiateInjectedActive<T>(T prefab, Transform parent, bool activateAfter) where T : Component
-		{
-			bool prefabWasActive = prefab.gameObject.activeSelf;
-			if (prefabWasActive)
-				prefab.gameObject.SetActive(false);
-
-			T inst = Instantiate(prefab, parent);
-
-			if (prefabWasActive)
-				prefab.gameObject.SetActive(true);
-
-			foreach (MonoBehaviour mb in inst.GetComponentsInChildren<MonoBehaviour>(true))
-				container.Inject(mb);
-
-			if (activateAfter)
-				inst.gameObject.SetActive(true);
-
-			return inst;
-		}
-
 		private void Start()
 		{
 			// container 의존 UI 생성/주입 — Awake(container null) 도 Construct(SceneLifetimeScope Build 중 →
 			// 대량 container.Inject 재진입 = ValueFactory catastrophe) 도 아닌 Start.
 			// Start = Construct 후 + Build 완료 후 → container valid, 재진입 0 (캐스케이드 d405bfde 검증 패턴, TASK-WM-078 2026-05-16).
 			// Content UIs — 계층 전체 inject (UIDungeonRuntime / UIDungeonResult / UIDungeonEntrance 등)
-			// TASK-WM-115 R2 — 비활성 Instantiate → 자식 전체 Inject → 활성. active prefab 을
-			// 그냥 Instantiate 하면 자식 OnEnable 이 container.Inject *전* 발화 → deps null NRE
-			// (UIQuestGrid.OnEnable timeManager null). ObjectPoolManager.CreateObject 와 동일 검증 패턴.
-			UIDungeon dungeonInst = InstantiateInjectedActive(dungeonPrefab, BaseCanvas.transform, activateAfter: true);
+			// TASK-WM-109-E — DiCascade 로 owner-push / 비활성-Instantiate 패턴 통일.
+			UIDungeon dungeonInst = DiCascade.InstantiateInjected(container, dungeonPrefab, BaseCanvas.transform, activateAfter: true);
 
-			adventurerGuild = InstantiateInjectedActive(adventurerGuildPrefab, BaseCanvas.transform, activateAfter: false);
+			adventurerGuild = DiCascade.InstantiateInjected(container, adventurerGuildPrefab, BaseCanvas.transform, activateAfter: false);
 
 			// Common UIs
 			CutSceneModule = FindAnyObjectByType<CutSceneModule>(FindObjectsInactive.Include);
@@ -187,31 +157,20 @@ namespace WitchMendokusai
 			// InjectGameObject = VContainer 표준 계층-재귀 (established 패턴 수렴).
 			container.InjectGameObject(NPC.gameObject);
 
-			// 씬 한정 view 등록 — 글로벌 UIRoot 에 AddComponent
+			// 씬 한정 view 등록 — 글로벌 UIRoot 에 AddComponent + Inject (DiCascade.AddInjected).
 			GameObject uiRootGameObject = uiRoot.gameObject;
-			inventoryView = uiRootGameObject.AddComponent<InventoryView>();
-			container.Inject(inventoryView);
-			hotbarView = uiRootGameObject.AddComponent<HotbarView>();
-			container.Inject(hotbarView);
-			buildingBarView = uiRootGameObject.AddComponent<BuildingBarView>();
-			container.Inject(buildingBarView);
-			questView = uiRootGameObject.AddComponent<QuestView>();
-			container.Inject(questView);
-			dollView = uiRootGameObject.AddComponent<DollView>();
-			container.Inject(dollView);
-			statusView = uiRootGameObject.AddComponent<StatusView>();
-			container.Inject(statusView);
-			popupView = uiRootGameObject.AddComponent<PopupView>();
-			container.Inject(popupView);
-			stagePopupView = uiRootGameObject.AddComponent<StagePopupView>();
-			container.Inject(stagePopupView);
-			floatingText = uiRootGameObject.AddComponent<FloatingTextView>();
-			container.Inject(floatingText);
-			SpeechBubble = uiRootGameObject.AddComponent<SpeechBubbleView>();
-			container.Inject(SpeechBubble);
+			inventoryView = DiCascade.AddInjected<InventoryView>(container, uiRootGameObject);
+			hotbarView = DiCascade.AddInjected<HotbarView>(container, uiRootGameObject);
+			buildingBarView = DiCascade.AddInjected<BuildingBarView>(container, uiRootGameObject);
+			questView = DiCascade.AddInjected<QuestView>(container, uiRootGameObject);
+			dollView = DiCascade.AddInjected<DollView>(container, uiRootGameObject);
+			statusView = DiCascade.AddInjected<StatusView>(container, uiRootGameObject);
+			popupView = DiCascade.AddInjected<PopupView>(container, uiRootGameObject);
+			stagePopupView = DiCascade.AddInjected<StagePopupView>(container, uiRootGameObject);
+			floatingText = DiCascade.AddInjected<FloatingTextView>(container, uiRootGameObject);
+			SpeechBubble = DiCascade.AddInjected<SpeechBubbleView>(container, uiRootGameObject);
 			// DialogueRunner — SceneLifetimeScope.RegisterComponentOnNewGameObject 추출. 여기서 AddComponent X.
-			Transition = uiRootGameObject.AddComponent<TransitionView>();
-			container.Inject(Transition);
+			Transition = DiCascade.AddInjected<TransitionView>(container, uiRootGameObject);
 
 			RegisterOverlayUI(NPC);
 		}

--- a/Assets/_WitchMendokusai/Domain/UI/UIRoot.cs
+++ b/Assets/_WitchMendokusai/Domain/UI/UIRoot.cs
@@ -42,11 +42,8 @@ namespace WitchMendokusai
 			this.windowManager = windowManager;
 			// VContainer: prefab 비활성화 후 Instantiate → Awake 는 SetActive(true) 이후 발화.
 			// CreateViews 를 Construct 선두로 이동 — inactive GO 에서도 AddComponent 정상 작동.
+			// CreateViews 자체가 DiCascade.AddInjected 로 AddComponent+Inject 동시 수행 (TASK-WM-109-E).
 			CreateViews();
-			container.Inject(SettingView);
-			container.Inject(KeybindHelpView);
-			container.Inject(MagicBookView);
-			container.Inject(WorldClockView);
 		}
 
 		public UIDocument Document { get; private set; }
@@ -79,15 +76,16 @@ namespace WitchMendokusai
 		}
 
 		/// <summary>
-		/// 글로벌 View 컴포넌트를 동적으로 생성. 씬 무관 시스템 메뉴.
+		/// 글로벌 View 컴포넌트를 동적으로 생성 + DI 주입. 씬 무관 시스템 메뉴.
 		/// 씬별 view (Inventory/Hotbar/BuildingBar 등) 는 해당 씬 매니저 (UIManager 등) 가 직접 AddComponent / OnDestroy 정리.
+		/// TASK-WM-109-E — DiCascade.AddInjected 로 owner-push 패턴 통일 (전 17 callsite 중 4건).
 		/// </summary>
 		private void CreateViews()
 		{
-			SettingView = gameObject.AddComponent<SettingView>();
-			KeybindHelpView = gameObject.AddComponent<KeybindHelpView>();
-			MagicBookView = gameObject.AddComponent<MagicBookView>();
-			WorldClockView = gameObject.AddComponent<WorldClockView>();
+			SettingView = DiCascade.AddInjected<SettingView>(container, gameObject);
+			KeybindHelpView = DiCascade.AddInjected<KeybindHelpView>(container, gameObject);
+			MagicBookView = DiCascade.AddInjected<MagicBookView>(container, gameObject);
+			WorldClockView = DiCascade.AddInjected<WorldClockView>(container, gameObject);
 		}
 
 		private void OnEnable()


### PR DESCRIPTION
## TASK-WM-109-E — cascade inject 분산 통합 / 정규화

### 진단

스펙의 "11+ 분산" 을 전수 매핑 → 실제 **17 cascade trigger callsite**:

| # | 위치 | 패턴 |
|---|------|------|
| 1-2 | `SceneLifetimeScope.Configure / RegisterBuildCallback` | `RegisterInHierarchyIfPresent<T>` × 33 + `ResolveIfPresent<T>` × 33 |
| 3-7 | `SceneLifetimeScope.RegisterBuildCallback foreach` | MonsterObject/ResourceNodeObject InjectGameObject + Player/Marker container.Inject |
| 8 | `ObjectPoolManager.ObjectPool.CreateObject` | `InjectGameObject(g)` (pool spawn) |
| 9 | `UIManager.Start.InstantiateInjectedActive` | 비활성 Instantiate + foreach Inject |
| 10 | `UIManager.Start` | `AddComponent<T>+Inject` × 12 (owner-push view) |
| 11-12 | `UIManager.Start` | `InjectGameObject(NPC)` + `Inject(Chat)` |
| 13 | `UIManager.CreateToolkitPanel<T>` | `AddComponent + Inject` (동적 toolkit) |
| 14 | `UIRoot.Construct/CreateViews` | `AddComponent<T> + Inject` × 4 (global view) |
| 15 | `Player.Construct` | `foreach GetComponentsInChildren + Inject` (self-cascade) |
| 16 | `DungeonManager.Construct` | `Inject(monsterSpawner/resourceNodeSpawner)` |
| 17 | `LobbyManager.Awake` | `scope?.Container.Inject(this)` (self-inject) |

### 통합 전략 평가 (스펙 3안)

| 안 | 결정 | 사유 |
|---|------|------|
| **#1 중앙 집중 (SceneLifetimeScope)** | ❌ 각하 | 4 lifecycle phase 본질적으로 다름 — build callback (부팅 1회) / pool spawn (런타임 동적) / owner-push (MonoBehaviour 생명주기 의존) / self-cascade (Construct 진행 중). 강제 통합 = lifetime cross-cutting 위반 + value factory recursion 재앙 (TASK-WM-078 d405bfde 캐스케이드 사례) |
| **#2 명시적 계층 (`[RequiresInjection]`)** | ❌ 각하 | VContainer `[Inject]` 가 이미 member-level marker 제공 + SceneDiAuditor 가 `HasInjectAttribute` 로 자동 검출. 추가 type-level marker = 의미 중복 |
| **#3 owner-based delegation** | ✅ **선택** | 현재 분산이 SRP 정합 결과 — 각 owner 가 자기 영역 cascade. 진짜 문제 = 분산 자체가 아니라 *공통 boilerplate 부재*. helper 추출로 해결 |

### 변경 — `DiCascade` static helper 추출

`Assets/_WitchMendokusai/Domain/Application/Scripts/DI/DiCascade.cs` 신설:

| Helper | 흡수한 callsite |
|--------|-----------------|
| `DiCascade.AddInjected<T>(container, owner)` | UIRoot.CreateViews × 4, UIManager.Start × 11, UIManager.CreateToolkitPanel × 1 = **16건** |
| `DiCascade.InstantiateInjected<T>(container, prefab, parent, activateAfter)` | `UIManager.InstantiateInjectedActive` 폐기 + 2 callsite 흡수 (UIDungeon/UIAdventurerGuild) |

> ⚠ 자기-자식 cascade 헬퍼는 **`ObjectResolverHierarchyExtensions.InjectGameObjectExcludingSelf`** (TASK-WM-109-B, #168, main 정본) 가 담당. 본 PR 의 초기 안(`DiCascade.InjectChildren`) 은 동일 의미라 머지 시 폐기 — Player.Construct 는 `container.InjectGameObjectExcludingSelf(gameObject, this)` 사용 (extension method 가 caller-site idiomatic, "self 1 개 제외" 의도 명시적).

남은 callsite (SceneLifetimeScope foreach × 5, ObjectPoolManager, DungeonManager.Construct, LobbyManager.Awake, UIManager 의 Chat/NPC inject) 는 *영역 특화 패턴* — owner 의 SRP 영역이라 helper 강제 통합 X.

머지 후 면적 (main 대비 본 브랜치 고유 변경): **+93 / -67 (net +26)** — `DiCascade.cs` 신설(+67) + UIManager(-43) + UIRoot 정리(-15) + `.cs.meta`.

### 새 component 추가 시 결정 트리 (확장성, `DiCascade.cs` XML doc 인라인)

```
새 component → 누가 만들어/소유?

씬 정적 배치 (Inspector)
├ 1 인스턴스 → SceneLifetimeScope.RegisterInHierarchyIfPresent<T>
├ N 인스턴스 + 자식 cascade → RegisterBuildCallback foreach InjectGameObject
└ 다른 owner 가 AddComponent → 해당 owner 시점에 DiCascade.AddInjected<T>

Prefab Instantiate (런타임 spawn)
├ Pool 사용 → 자동 (ObjectPoolManager.CreateObject InjectGameObject)
└ 명시 → DiCascade.InstantiateInjected<T>

Code spawn (AddComponent) → DiCascade.AddInjected<T>

Self-cascade (Construct 안에서 자기 자식 inject)
  → container.InjectGameObjectExcludingSelf(gameObject, this)
    (WM-109-B, ObjectResolverHierarchyExtensions)
```

### 동등성 인증

- `InjectGameObject(go)` (DiCascade.InstantiateInjected 내부) ≡ `foreach GetComponentsInChildren<MonoBehaviour>(true) Inject(mb)` (구 UIManager.InstantiateInjectedActive 패턴) — *효과 동등*. VContainer 1.17.0 소스 `ObjectResolverUnityExtensions.cs:36-64` 인증: `InjectGameObjectRecursive` = `GetComponents + 자식 transform 재귀` ≡ Unity `GetComponentsInChildren<MonoBehaviour>(true)` (자기 + 자식 inactive 포함).
- `DiCascade.AddInjected` 는 `owner.AddComponent<T> + container.Inject(component)` 시퀀스 그대로.
- Player.Construct 의 self-cascade 는 WM-109-B 의 `InjectGameObjectExcludingSelfTest` 가 ① 자손 전체 주입(active/inactive/손자) + self 제외 ② Construct 내부 호출 시 무한 재귀 0 결정적 재현으로 인증.

### 의도적 *비*추출

- **SceneDiAuditor 확장 (Task #4)** — Auditor 대상은 *씬 직접배치* [Inject] consumer. DiCascade callsite 의 T 는 owner-push 동적 생성 → 씬에 안 배치되는 게 정상 → audit 대상 외. 우연 배치 시 *오히려 경고가 옳음* (Inject 안 됨). 따라서 regex 확장 시 false-negative 가려질 위험만 있고 가치 0 — close.
- **ObjectPoolManager.CreateObject 흡수** — pool semantic (prefab.SetActive 토글 + Push/Pop + parent transform) 이 InstantiateInjected 와 분리되어야 SRP 보존. ObjectPool 의 캡슐화 그대로.
- **SceneLifetimeScope foreach 흡수** — `foreach FindObjectsByType + InjectGameObject` 도 가능하나, 검증된 callsite 5건 + SceneDiAuditor regex 직결 → 이번 PR scope 밖. 후속 sub-TASK 분리 가능.

## Test plan
- [ ] Unity Editor 열어 .meta 자동 import 확인 (DiCascade.cs.meta GUID 동결 박힘)
- [ ] `WM/Audit/Scene DI Coverage` — `SceneDiCoverageTest.ProjectScenes_HaveNoUnregisteredInjectConsumingComponents` PASS (regex 영향 0, 씬 컴포넌트 변경 0)
- [ ] `InjectGameObjectExcludingSelfTest` (WM-109-B, main 기존) PASS — Player.Construct 경로 동등성 인증
- [ ] `CompositionRootResolveTest` (`WM.Tests.EditMode`) PASS — DI 그래프 미변경, ms 검증
- [ ] `wm-boot-smoke.ps1` (TASK-WM-134 정본) PASS — WorldReady + nre0 + bootInvariants(플레이어 바인드) + ddol baseline
- [ ] Play Mode 진입 후 UIManager 의 view 11개 + UIRoot 의 view 4개 정상 inject (Inspector 에서 SerializeField 확인 또는 dev HUD)
- [ ] UIDungeon 진입 → UIDungeonRuntime/UIDungeonResult 정상 표시 (UIManager.Start.InstantiateInjected 검증)
- [ ] Player.prefab 의 자식 컴포넌트 (PlayerObject/PlayerRotation 등) deps 정상 — UnitMovement/CameraGlue 회귀 0

## 자율 게이트 — 이 PR 의 검증 필요 영역
- 현 worktree 에 Unity Editor 미바인드 → MCP `read_console` 검증 불가. 컴파일/PlayMode 검증은 사용자 또는 Unity-MCP routing (TASK-WM-109-G) 이후.
- 동작 동등성은 VContainer 소스 인증으로 정적 보장. 회귀 위험은 *cascade 순서 의존* 컴포넌트 (BFS vs DFS) 만 — 알려진 사례 0, 단 사용자 검증 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)