### PR TITLE
feat(WM-109-B): InjectGameObjectExcludingSelf — self-cascade 무한 재귀 guard 표준화

### DIFF
--- a/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/ObjectResolverHierarchyExtensions.cs
+++ b/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/ObjectResolverHierarchyExtensions.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using VContainer;
+
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// IObjectResolver 계층 주입 헬퍼 — self-cascade 무한 재귀 guard 표준화 (TASK-WM-109-B).
+	///
+	/// 배경: <c>container.InjectGameObject(go)</c> 는 go 계층의 모든 MonoBehaviour 에 Inject 를
+	/// 재귀 적용한다 (VContainer 1.17.0 <c>ObjectResolverUnityExtensions.InjectGameObjectRecursive</c>,
+	/// DI/VCONTAINER-MECHANISM.md §5). caller 컴포넌트의 <c>[Inject] Construct</c> 안에서 자기
+	/// gameObject 를 그대로 InjectGameObject 하면 → 자기 자신도 다시 Inject → Construct
+	/// 재호출 → 무한 재귀 → StackOverflow → Unity crash.
+	/// (commit ad920ca2 도입 → bcb59577 revert. TASK-WM-109 이슈 2.
+	///  process.md § 황금의 정신 — 설계 자가 검토 위반 사례.)
+	///
+	/// 본 헬퍼 = VContainer <c>InjectGameObject</c> 와 동일한 계층-재귀 의미(자식·inactive 포함)
+	/// 이되, 지정한 self 컴포넌트 1개만 제외한다. caller 의 Construct 내부에서 형제·자식
+	/// cascade 를 안전하게 수행하는 정본 진입점.
+	///
+	/// 계약(중요): 한 prefab/계층에서 cascade 를 트리거하는 root 컴포넌트는 *하나* 여야 한다.
+	/// self 만 제외하므로, 두 컴포넌트가 서로 본 헬퍼를 자기 Construct 안에서 호출하면 상호
+	/// 재귀(A→B→A…)가 다시 성립한다. 자식 컴포넌트는 cascade 를 재트리거하지 말고
+	/// <c>[Inject] Construct</c> 로 deps 만 받는다 (Player.prefab = Player 단일 root, 자식
+	/// PlayerObject/PlayerRotation/UnitMovement 등은 deps-only).
+	///
+	/// 사용처: <c>Player.Construct</c> (TASK-WM-108/115). 향후 "자기 Construct 안에서 자기
+	/// 계층 cascade" 가 필요한 root 컴포넌트는 raw InjectGameObject 대신 본 헬퍼를 사용한다.
+	/// raw <c>InjectGameObject</c> 는 caller 가 계층 *밖* 일 때만 안전
+	/// (ObjectPoolManager / SceneLifetimeScope — 자기 자신을 주입하지 않음).
+	/// </summary>
+	public static class ObjectResolverHierarchyExtensions
+	{
+		/// <summary>
+		/// <paramref name="root"/> 계층의 모든 MonoBehaviour(자식·inactive 포함)에 Inject 를
+		/// 적용하되, <paramref name="self"/> 컴포넌트 1개는 제외한다.
+		///
+		/// caller 의 <c>[Inject] Construct</c> 내부에서 <c>this</c> 를 self 로 넘겨 호출하면
+		/// 자기 Construct 재진입이 차단되어 무한 재귀가 발생하지 않는다.
+		/// </summary>
+		/// <param name="resolver">VContainer 컨테이너 (caller 의 Construct 가 주입받은 IObjectResolver).</param>
+		/// <param name="root">cascade 대상 계층의 루트 GameObject (보통 caller 의 gameObject).</param>
+		/// <param name="self">제외할 caller 컴포넌트 (보통 <c>this</c>).</param>
+		public static void InjectGameObjectExcludingSelf(
+			this IObjectResolver resolver, GameObject root, MonoBehaviour self)
+		{
+			// GetComponentsInChildren<MonoBehaviour>(true) = VContainer InjectGameObject 와
+			// 동일 집합(루트+모든 자손, inactive 포함). 주입은 컴포넌트 단위 멱등이라 순서 무관.
+			foreach (MonoBehaviour component in root.GetComponentsInChildren<MonoBehaviour>(true))
+			{
+				if (component != self)
+					resolver.Inject(component);
+			}
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/ObjectResolverHierarchyExtensions.cs.meta
+++ b/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/ObjectResolverHierarchyExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5d5b3d548928455dbd30f04a27370fcd

--- a/Assets/_WitchMendokusai/Domain/Doll/_Common/Scripts/Player.cs
+++ b/Assets/_WitchMendokusai/Domain/Doll/_Common/Scripts/Player.cs
@@ -45,11 +45,9 @@ namespace WitchMendokusai
 			// InteractiveMarker/AutoAimMarker/UnitMovement 등). RegisterComponentInHierarchy<Player> 는 Player
 			// 컴포넌트만 inject — 자식은 컨테이너가 모름. 컨테이너 주입 root 가 비등록 자식 cascade =
 			// UIRoot.Construct / ObjectPoolManager.InjectGameObject 와 동일 canonical 패턴 (TASK-WM-078, 2026-05-16).
-			foreach (MonoBehaviour childComponent in GetComponentsInChildren<MonoBehaviour>(true))
-			{
-				if (childComponent != this)
-					container.Inject(childComponent);
-			}
+			// raw InjectGameObject(gameObject) 는 *자기 자신* 도 재귀 inject → Construct 재호출 → StackOverflow
+			// (TASK-WM-109 이슈 2, ad920ca2 도입 → bcb59577 revert). self-exclude 헬퍼로 차단 (TASK-WM-109-B).
+			container.InjectGameObjectExcludingSelf(gameObject, this);
 		}
 
 		private void Awake()

--- a/Assets/_WitchMendokusai/Tests/EditMode/InjectGameObjectExcludingSelfTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/InjectGameObjectExcludingSelfTest.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using VContainer;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-109-B — <see cref="ObjectResolverHierarchyExtensions.InjectGameObjectExcludingSelf"/>
+	/// self-cascade 무한 재귀 guard 검증.
+	///
+	/// 회귀 배경: Player.Construct 가 raw <c>container.InjectGameObject(gameObject)</c> 를
+	/// 호출 → Player 자신도 재주입 → Player.Construct 재호출 → 무한 재귀 → StackOverflow →
+	/// Unity crash (commit ad920ca2 도입 → bcb59577 revert. TASK-WM-109 이슈 2).
+	///
+	/// 본 테스트는 *실제 VContainer 컨테이너* 로 그 시나리오를 재현한다:
+	///   ① 계층 전체(자식·inactive·손자 포함)가 주입되는지 + self 만 제외되는지
+	///   ② caller 의 Construct 안에서 헬퍼를 호출해도(= Player 패턴) 무한 재귀 없이
+	///      caller Construct 가 정확히 1회만 실행되는지 (guard 의 본질).
+	///
+	/// 결정적(ms, RNG/시간/FS/씬/PlayMode 무관) — EditMode 신뢰 루프.
+	/// </summary>
+	public sealed class InjectGameObjectExcludingSelfTest
+	{
+		private readonly List<GameObject> spawned = new List<GameObject>();
+
+		[TearDown]
+		public void TearDown()
+		{
+			foreach (GameObject go in spawned)
+			{
+				if (go != null)
+					Object.DestroyImmediate(go);
+			}
+			spawned.Clear();
+		}
+
+		private GameObject NewGameObject(string name, GameObject parent = null, bool active = true)
+		{
+			GameObject go = new GameObject(name);
+			if (parent != null)
+				go.transform.SetParent(parent.transform);
+			go.SetActive(active);
+			spawned.Add(go);
+			return go;
+		}
+
+		private static IObjectResolver BuildEmptyContainer()
+		{
+			// 등록 0 — Construct 가 파라미터 없는 메서드라 resolve 불필요.
+			// BuildRegistry + 인스턴스화 경로를 정상 통과(Composition Root 와 동일 API).
+			return new ContainerBuilder().Build();
+		}
+
+		// 파라미터 없는 [Inject] Construct — VContainer 가 주입 시 1회 호출, 카운트 누적.
+		public sealed class ConstructCounter : MonoBehaviour
+		{
+			public int ConstructCount;
+
+			[Inject]
+			public void Construct() => ConstructCount++;
+		}
+
+		// Player 패턴 재현: 자기 Construct 안에서 자기 계층을 self 제외 cascade.
+		public sealed class SelfCascadingRoot : MonoBehaviour
+		{
+			public int ConstructCount;
+
+			[Inject]
+			public void Construct(IObjectResolver container)
+			{
+				ConstructCount++;
+				container.InjectGameObjectExcludingSelf(gameObject, this);
+			}
+		}
+
+		[Test]
+		public void InjectsAllDescendants_ExceptSelf()
+		{
+			IObjectResolver container = BuildEmptyContainer();
+
+			GameObject root = NewGameObject("Root");
+			ConstructCounter rootSelf = root.AddComponent<ConstructCounter>();
+
+			GameObject activeChild = NewGameObject("ActiveChild", root, active: true);
+			ConstructCounter activeChildCounter = activeChild.AddComponent<ConstructCounter>();
+
+			GameObject inactiveChild = NewGameObject("InactiveChild", root, active: false);
+			ConstructCounter inactiveChildCounter = inactiveChild.AddComponent<ConstructCounter>();
+
+			GameObject grandChild = NewGameObject("GrandChild", activeChild, active: true);
+			ConstructCounter grandChildCounter = grandChild.AddComponent<ConstructCounter>();
+
+			container.InjectGameObjectExcludingSelf(root, rootSelf);
+
+			Assert.That(rootSelf.ConstructCount, Is.EqualTo(0),
+				"self 컴포넌트는 제외돼야 한다 (caller Construct 재진입 차단)");
+			Assert.That(activeChildCounter.ConstructCount, Is.EqualTo(1),
+				"active 자식은 1회 주입돼야 한다");
+			Assert.That(inactiveChildCounter.ConstructCount, Is.EqualTo(1),
+				"inactive 자식도 1회 주입돼야 한다 (VContainer InjectGameObject 와 동일 의미)");
+			Assert.That(grandChildCounter.ConstructCount, Is.EqualTo(1),
+				"손자(재귀)도 1회 주입돼야 한다");
+		}
+
+		[Test]
+		public void FromWithinSelfConstruct_DoesNotRecurseInfinitely()
+		{
+			// TASK-WM-109 이슈 2 시나리오 정확 재현: caller 가 자기 Construct 안에서
+			// 자기 계층을 cascade. guard 없으면 여기서 StackOverflow → 프로세스 crash.
+			IObjectResolver container = BuildEmptyContainer();
+
+			GameObject root = NewGameObject("Root");
+			SelfCascadingRoot selfCascading = root.AddComponent<SelfCascadingRoot>();
+
+			GameObject child = NewGameObject("Child", root, active: true);
+			ConstructCounter childCounter = child.AddComponent<ConstructCounter>();
+
+			// Player 가 SceneLifetimeScope 에서 주입되는 경로(container.Inject(player)) 동일.
+			container.Inject(selfCascading);
+
+			Assert.That(selfCascading.ConstructCount, Is.EqualTo(1),
+				"caller Construct 는 정확히 1회 — self-exclude 로 재진입 차단 (무한 재귀 X)");
+			Assert.That(childCounter.ConstructCount, Is.EqualTo(1),
+				"자식은 caller Construct 의 cascade 로 1회 주입");
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/InjectGameObjectExcludingSelfTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/InjectGameObjectExcludingSelfTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f295aa6e0373451392635e16156494ec


### PR DESCRIPTION
## Summary
- TASK-WM-109 이슈 2 해결 — `container.InjectGameObject(gameObject)` 가 caller 의 `[Inject] Construct` 안에서 호출되면 자기 재진입 → StackOverflow → Unity crash (`ad920ca2` 도입 → `bcb59577` revert) 시나리오의 정본 guard 표준화.
- 새 헬퍼 `IObjectResolver.InjectGameObjectExcludingSelf(GameObject root, MonoBehaviour self)` — VContainer 표준 `InjectGameObject` 와 동일 계층-재귀(자식·inactive 포함) 의미, self 1개만 제외.
- `Player.Construct` 의 inline foreach `(c != this)` 패턴을 헬퍼 호출로 교체 (zero behavior change, 현재 main 동작과 동등).
- `InjectGameObjectExcludingSelfTest` (EditMode, ms 결정적) — 실제 VContainer 컨테이너로 ① 자손 전체 주입 + self 제외 ② caller Construct 안에서 호출 시 정확히 1회 실행(무한 재귀 0) 검증.

### 옵션 trade-off (스펙 § 해결 안 검토)
| 옵션 | 원자성 | 명확성 | 성능 | 결정 |
|---|---|---|---|---|
| **① self-exclude guard 헬퍼** | 1 라인 caller call | API 의미 명확 (root 계층 − self) | `InjectGameObject` 와 동일 (foreach + Inject) | **채택** |
| ② InjectChildren/InjectSelf 분리 | 2 메서드, API 면적 ↑ | self 포함/제외 헷갈림 | 동일 | 기각 |
| ③ SceneLifetimeScope 중앙집중 | 분산 0 | Construct 시기 통제 불가 — TASK-WM-115 R3a (Object/Rotation 을 Awake<Construct 순서로 확정해야 함) 위반 | 동일 | 기각 |

### 단일-root cascade 계약
self 만 제외하므로 두 컴포넌트가 서로 본 헬퍼를 자기 Construct 안에서 호출하면 상호 재귀(A→B→A…)가 다시 성립. 한 prefab/계층에서 cascade 트리거 root 는 *하나* — 자식 컴포넌트는 deps-only `[Inject] Construct`. 헬퍼 주석에 정본화.

### 병행 branch — reviewer 결정 필요
WM-109-E (`feature/agent-team-task-wm-109-e`, `2d137bf9`) 가 동일 패턴을 `DiCascade.InjectChildren(IObjectResolver container, MonoBehaviour root)` static helper 로 추출함 (overlapping). 두 안 중 하나만 채택 권장:

| 측면 | WM-109-B 안 (본 PR) | WM-109-E 안 |
|---|---|---|
| 형태 | `container.InjectGameObjectExcludingSelf(go, this)` extension | `DiCascade.InjectChildren(container, this)` static |
| API 일관성 | VContainer 원시 `container.InjectGameObject(go)` 형태 그대로 (`container.X(...)`) | 새 클래스 `DiCascade` 진입점 |
| self/root 분리 | 명시 (제외할 self 컴포넌트를 별도 인자로) | 묵시 (root 본인을 통째 넘기고 내부 `!= root` 비교) |
| 다른 cascade 패턴 (AddInjected/InstantiateInjected) | 별도 | DiCascade 한 곳에 통합 (스코프 ↑) |

WM-109-B 만 단독 채택 시: Player.cs 만 영향. WM-109-E 와 충돌 영역 = 동일 `Player.cs` cascade 라인 1줄.

## Test plan
- [ ] **Unity Editor + MCP 로 컴파일 검증** — 본 worktree 는 autopilot 격리 환경이라 Unity Editor/MCP 미연결. reviewer (또는 머지 후 CI) 가 `read_console(types=["error","warning"])` 0 entries 확인 필요. 변경면 = 신규 헬퍼 1 파일 (no external deps 추가) + Player.cs 5 라인 → inline 5 라인 교체 + 신규 EditMode 테스트 1 파일.
- [ ] **EditMode 테스트 통과** — `WM.Tests.EditMode` asmdef 에 VContainer 이미 참조됨. `InjectGameObjectExcludingSelfTest.InjectsAllDescendants_ExceptSelf` + `FromWithinSelfConstruct_DoesNotRecurseInfinitely` 둘 다 통과 확인.
- [ ] **부팅 회귀 검증** — `wm-boot-smoke.ps1` 또는 Play Mode 진입으로 Player.Construct cascade 경로 정상 (자식 PlayerObject/PlayerRotation/UnitMovement deps 주입) + 무한 재귀 0 확인.
- [ ] **WM-109-E 와 중복 회피** — reviewer 가 두 PR 중 하나 채택, 다른 안 close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)