### PR TITLE
feat(WM-109-D): MCP auto-bind on Editor startup + Editor.log session fallback

### DIFF
--- a/.claude/scripts/README.md
+++ b/.claude/scripts/README.md
@@ -5,6 +5,11 @@ worktree carries the same tooling. They are **not** the canonical home —
 `memo/dotfiles/scripts/` is — but several helpers must be available *inside*
 the worktree (where Claude Code's cwd lands), so they live here too.
 
+| Script | Purpose | Spec |
+| --- | --- | --- |
+| `wm-mcp-route.ps1` | Worktree-aware Unity-MCP routing (writes `<worktree>/.mcp.json`). | TASK-WM-109-G |
+| `wm-editor-log-tail.ps1` | Editor.log fallback that slices to the latest compile session — surfaces only the *current* errors/warnings, not accumulated history. | TASK-WM-109-D |
+
 ## `wm-mcp-route.ps1` — worktree-aware Unity-MCP routing (TASK-WM-109-G)
 
 ### Why
@@ -97,3 +102,72 @@ write, no-Editor failure, cross-worktree isolation, and `-Port` override.
   per-project -- two Editors share it. Multi-Editor users who want stable
   per-worktree ports should configure each Editor's `HttpBaseUrl` to a
   different value via `Window > MCP for Unity > HTTP URL`.
+
+## `wm-editor-log-tail.ps1` — Editor.log fallback (TASK-WM-109-D)
+
+### Why
+
+`CLAUDE.md § Unity-MCP layer` is explicit that the canonical compile-verify
+channel is Unity-MCP `read_console`, because Editor.log is append-only:
+errors from past compile attempts pile up in the same file, and a naive
+`grep "error CS"` returns *every* error since the Editor was launched.
+TASK-WM-056-A (2026-05-10) is the canonical incident — Editor.log grep
+reported 259 unique CS errors while the actual current state was 6.
+
+But MCP isn't always available — a worktree Editor may be open *without*
+the MCP HTTP server running, the package may be temporarily broken, or a
+Claude session may need a quick sanity check before MCP is bound. In those
+moments we need an Editor.log fallback that *doesn't* leak history.
+
+### What this script does
+
+1. Reads the entire Editor.log (default:
+   `$env:LOCALAPPDATA\Unity\Editor\Editor.log`).
+2. Walks backwards to find the **last** occurrence of Unity's canonical
+   session boundary marker
+   `"Reloading assemblies after forced synchronous recompile"`.
+3. Returns only the lines after that marker that match `-Pattern`
+   (default: `error CS|warning CS` — per CLAUDE.md, warnings are not
+   ignored).
+4. Optionally caps output (`-MaxLines`), emits structured JSON
+   (`-Json`), or surfaces the marker line itself (`-IncludeMarker`).
+
+### Usage
+
+```powershell
+# Default: last compile session, errors + warnings, max 200 lines
+powershell -NoProfile -ExecutionPolicy Bypass -File .claude/scripts/wm-editor-log-tail.ps1
+
+# Errors only, last 50
+powershell -NoProfile -ExecutionPolicy Bypass -File .claude/scripts/wm-editor-log-tail.ps1 -Pattern 'error CS' -MaxLines 50
+
+# Structured JSON for tooling
+powershell -NoProfile -ExecutionPolicy Bypass -File .claude/scripts/wm-editor-log-tail.ps1 -Json
+```
+
+Exit codes:
+
+| Code | Meaning |
+| ---: | --- |
+| 0 | Marker found, scan succeeded (matches may be empty — that means a clean compile). |
+| 2 | Editor.log file does not exist at the resolved path. |
+| 3 | Editor.log present but no reload marker found — log is from a session that never reloaded assemblies; results are unreliable and an empty set is emitted. |
+
+### Tests
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .claude/scripts/wm-editor-log-tail.tests.ps1
+```
+
+Seven fixture-based cases (no Unity required) verify the
+session-isolation behaviour against a synthetic two-session log, plus the
+JSON shape, max-lines cap, pattern override, marker inclusion, no-marker
+exit code, and missing-file exit code.
+
+### Relationship to MCP
+
+This is a **fallback**, not a replacement. The canonical channel remains
+Unity-MCP `read_console` (and `McpAutoBinder.cs` now auto-routes the
+worktree's `.mcp.json` to keep MCP usable across Editor restarts). Use the
+log-tail only when MCP genuinely isn't an option for the current
+worktree-session pair.

--- a/.claude/scripts/wm-editor-log-tail.ps1
+++ b/.claude/scripts/wm-editor-log-tail.ps1
@@ -1,0 +1,168 @@
+<#
+.SYNOPSIS
+  Editor.log fallback for compile-error inspection when Unity-MCP `read_console`
+  is unavailable — returns only the *latest compile session* lines.
+
+.DESCRIPTION
+  CLAUDE.md § Unity-MCP layer states the canonical channel is MCP `read_console`
+  because Editor.log is append-only — accumulated past sessions contaminate
+  every grep result. The TASK-WM-056-A "259 vs 6" mismatch (2026-05-10) is the
+  canonical incident motivating MCP adoption.
+
+  This script makes the *fallback* (when MCP is genuinely unavailable, e.g.
+  Editor is launched but no MCP server is running yet, or the user is reading
+  a previous session's errors after `unity-refresh.ps1`) accurate by:
+
+    1. Reading the entire Editor.log
+    2. Finding the LAST occurrence of the canonical reload marker
+       "Reloading assemblies after forced synchronous recompile"
+    3. Returning only the lines after that marker that match -Pattern
+    4. Reporting the marker timestamp (when available) so callers can sanity
+       check that they're looking at a recent compile, not a stale one
+
+  This does NOT replace MCP `read_console`. It is a strictly-scoped fallback
+  that avoids the "old errors leaking into current grep" failure mode by
+  honouring the same session boundary Unity itself logs.
+
+.PARAMETER LogPath
+  Path to Editor.log. Defaults to
+  `$env:LOCALAPPDATA\Unity\Editor\Editor.log` (Windows standard).
+
+.PARAMETER Pattern
+  Regex used to filter session lines. Default matches compile error/warning
+  diagnostics: `error CS|warning CS`. Per CLAUDE.md "Warning 도 무시 X" both
+  are surfaced by default.
+
+.PARAMETER MaxLines
+  Maximum lines to emit (most recent). 0 = unlimited. Default 200.
+
+.PARAMETER Json
+  Emit a structured JSON payload (counts + lines + marker timestamp) instead
+  of plain stdout. Useful when calling from another script or agent harness.
+
+.PARAMETER IncludeMarker
+  Also include the reload marker line itself at the top of the session
+  window (useful for sanity-checking the timestamp).
+
+.OUTPUTS
+  Plain mode: one matching line per output line.
+  -Json mode: a single-object JSON document with shape
+    { logPath, marker, markerLineIndex, totalLines, sessionLines,
+      pattern, matched, lines }.
+
+.EXAMPLE
+  pwsh -File .claude/scripts/wm-editor-log-tail.ps1
+  # last compile session's CS errors + warnings, max 200 lines
+
+.EXAMPLE
+  pwsh -File .claude/scripts/wm-editor-log-tail.ps1 -Pattern 'error CS' -MaxLines 50
+  # errors only, last 50
+
+.EXAMPLE
+  pwsh -File .claude/scripts/wm-editor-log-tail.ps1 -Json | ConvertFrom-Json
+  # structured form for tooling
+
+.NOTES
+  Exit codes:
+    0  marker found, scan succeeded (whether or not anything matched)
+    2  Editor.log file not present
+    3  Editor.log present but no reload marker found (= no compile session
+       has run since the log started; callers should not trust the contents)
+#>
+
+[CmdletBinding()]
+param(
+    [string]$LogPath,
+    [string]$Pattern = 'error CS|warning CS',
+    [int]$MaxLines = 200,
+    [switch]$Json,
+    [switch]$IncludeMarker
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($LogPath)) {
+    $LogPath = Join-Path $env:LOCALAPPDATA 'Unity\Editor\Editor.log'
+}
+
+if (-not (Test-Path -LiteralPath $LogPath)) {
+    # $ErrorActionPreference = 'Stop' turns Write-Error into a terminating
+    # exception; emit the diagnostic directly to stderr and exit cleanly so
+    # callers observe exit code 2 (per .NOTES) instead of a script throw.
+    [Console]::Error.WriteLine("[wm-editor-log-tail] Editor.log not found: $LogPath")
+    exit 2
+}
+
+# Canonical Unity reload marker. CLAUDE.md § Unity-MCP layer cites this exact
+# substring as the session boundary signal.
+$ReloadMarker = 'Reloading assemblies after forced synchronous recompile'
+
+# Read all lines once; Editor.log is typically a few MB and the cost of one
+# read is small compared to repeated greps over the same file.
+$allLines = @(Get-Content -LiteralPath $LogPath -ErrorAction Stop)
+$totalLines = $allLines.Count
+
+$lastMarkerIdx = -1
+for ($i = $totalLines - 1; $i -ge 0; $i--) {
+    if ($allLines[$i] -match $ReloadMarker) {
+        $lastMarkerIdx = $i
+        break
+    }
+}
+
+if ($lastMarkerIdx -lt 0) {
+    if ($Json) {
+        $payload = [ordered]@{
+            logPath          = $LogPath
+            marker           = $null
+            markerLineIndex  = -1
+            totalLines       = $totalLines
+            sessionLines     = 0
+            pattern          = $Pattern
+            matched          = 0
+            lines            = @()
+            warning          = "No '$ReloadMarker' marker found — log may be from a session that never reloaded assemblies. Results would be unreliable; emitting empty set."
+        }
+        $payload | ConvertTo-Json -Depth 4
+    } else {
+        Write-Warning "No '$ReloadMarker' marker found in $LogPath — log unreliable, emitting empty result."
+    }
+    exit 3
+}
+
+# Slice = [marker .. end]. If IncludeMarker is off we drop the marker line
+# itself so the output is only payload lines (errors/warnings).
+$sliceStart = if ($IncludeMarker) { $lastMarkerIdx } else { $lastMarkerIdx + 1 }
+if ($sliceStart -ge $totalLines) {
+    $sessionLines = @()
+} else {
+    $sessionLines = @($allLines[$sliceStart..($totalLines - 1)])
+}
+
+# Coerce to plain strings — Get-Content attaches ETS metadata (PSPath,
+# PSProvider, etc.) to each line, and ConvertTo-Json would otherwise expand
+# those into nested objects rather than emitting a clean string array.
+$matchedLines = @($sessionLines | Where-Object { $_ -match $Pattern } | ForEach-Object { [string]$_ })
+
+if ($MaxLines -gt 0 -and $matchedLines.Count -gt $MaxLines) {
+    $matchedLines = @($matchedLines | Select-Object -Last $MaxLines)
+}
+
+if ($Json) {
+    $payload = [ordered]@{
+        logPath          = $LogPath
+        marker           = $ReloadMarker
+        markerLineIndex  = $lastMarkerIdx
+        totalLines       = $totalLines
+        sessionLines     = $sessionLines.Count
+        pattern          = $Pattern
+        matched          = $matchedLines.Count
+        lines            = $matchedLines
+    }
+    $payload | ConvertTo-Json -Depth 4
+} else {
+    foreach ($line in $matchedLines) {
+        Write-Output $line
+    }
+}
+exit 0

--- a/.claude/scripts/wm-editor-log-tail.tests.ps1
+++ b/.claude/scripts/wm-editor-log-tail.tests.ps1
@@ -1,0 +1,211 @@
+<#
+.SYNOPSIS
+  Fixture-based smoke tests for wm-editor-log-tail.ps1 — no Unity required.
+
+.DESCRIPTION
+  Writes a synthetic Editor.log with two compile sessions back-to-back (the
+  exact failure shape TASK-WM-056-A documented, where the script SHOULD return
+  only the latest session's errors), then exercises the helper:
+
+    Case 1: Default pattern returns only session-2 lines (not session-1's
+            errors that grep against the whole file would otherwise leak).
+    Case 2: -MaxLines caps output to the most-recent N matches.
+    Case 3: -Json emits structured payload with correct counts.
+    Case 4: -Pattern 'error CS' excludes warnings.
+    Case 5: -IncludeMarker prepends the reload marker.
+    Case 6: Log with no marker exits with code 3 + empty result.
+    Case 7: Missing log file exits with code 2.
+
+  Run from anywhere:
+    pwsh -File .claude/scripts/wm-editor-log-tail.tests.ps1
+
+  This script does NOT depend on Pester; failures throw and the runner exits 1.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $PSCommandPath
+$helper = Join-Path $scriptDir 'wm-editor-log-tail.ps1'
+if (-not (Test-Path -LiteralPath $helper)) {
+    throw "Helper script not found: $helper"
+}
+
+function New-FixtureLog {
+    param(
+        [string]$Path,
+        [string[]]$Lines
+    )
+    $dir = Split-Path -Parent $Path
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    }
+    Set-Content -LiteralPath $Path -Value $Lines -Encoding utf8
+}
+
+function Invoke-Helper {
+    param(
+        [string]$LogPath,
+        [string[]]$ExtraArgs = @()
+    )
+    $exe = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
+    if (-not $exe) {
+        $exe = (Get-Command powershell -ErrorAction SilentlyContinue).Source
+    }
+    if (-not $exe) {
+        throw "Neither pwsh nor powershell found on PATH."
+    }
+    $args = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $helper, '-LogPath', $LogPath) + $ExtraArgs
+
+    # CLAUDE.md: avoid `2>&1` on native exes — Windows PowerShell wraps each
+    # stderr line in a NativeCommandError, and under $ErrorActionPreference =
+    # 'Stop' that terminates the test runner before we can assert on exit code.
+    # Route stderr to a temp file (separate stream redirection avoids the
+    # NativeCommandError wrapping). Use call-operator `&` so PowerShell handles
+    # argument quoting for items containing spaces (Start-Process ArgumentList
+    # would split 'error CS' across two args).
+    $stderrFile = [System.IO.Path]::GetTempFileName()
+    $prevPref = $ErrorActionPreference
+    try {
+        # PowerShell 5.1 surfaces stderr lines from a child native exe as
+        # ErrorRecord even when redirected; under Stop preference that aborts
+        # the test runner. Relax to Continue only for the child invocation so
+        # we can capture exit code and stderr without throw.
+        $ErrorActionPreference = 'Continue'
+        $stdoutLines = & $exe @args 2>$stderrFile
+        $exitCode = $LASTEXITCODE
+        $stdout = ($stdoutLines | Out-String)
+        $stderr = ''
+        if (Test-Path -LiteralPath $stderrFile) {
+            $rawErr = Get-Content -LiteralPath $stderrFile -Raw -ErrorAction SilentlyContinue
+            if ($null -ne $rawErr) { $stderr = $rawErr }
+        }
+        return [PSCustomObject]@{
+            ExitCode = $exitCode
+            Output   = $stdout.TrimEnd("`r", "`n")
+            Stderr   = $stderr.TrimEnd("`r", "`n")
+        }
+    } finally {
+        $ErrorActionPreference = $prevPref
+        Remove-Item -LiteralPath $stderrFile -ErrorAction SilentlyContinue
+    }
+}
+
+function Assert {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+    if (-not $Condition) {
+        throw "ASSERT FAILED: $Message"
+    }
+}
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("wm-editor-log-tail-tests-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8))
+New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
+
+Write-Host "Test fixture root: $tempRoot"
+
+$passes = 0
+$failures = 0
+
+try {
+    # Two-session fixture — session 1 has OLD errors (should NOT leak),
+    # session 2 has NEW errors (should be returned). This matches the exact
+    # leak pattern TASK-WM-056-A caught (259 vs 6).
+    $twoSession = Join-Path $tempRoot 'two-session.log'
+    New-FixtureLog -Path $twoSession -Lines @(
+        '--- session 1 (old) ---',
+        'Reloading assemblies after forced synchronous recompile.',
+        "Assets/Old.cs(10,5): error CS1234: old error A",
+        "Assets/Old.cs(11,5): error CS1234: old error B",
+        "Assets/Old.cs(12,5): warning CS9999: old warning",
+        'Compilation succeeded -- some progress',
+        '--- session 2 (latest) ---',
+        'Reloading assemblies after forced synchronous recompile.',
+        "Assets/New.cs(1,1): error CS0246: new error X",
+        "Assets/New.cs(2,2): warning CS0168: new warning Y",
+        'Compilation succeeded',
+        '... end of log ...'
+    )
+
+    # --- Case 1: default pattern returns only session 2 lines
+    $r1 = Invoke-Helper -LogPath $twoSession
+    Assert ($r1.ExitCode -eq 0) "Case 1 exit code expected 0, got $($r1.ExitCode). Output: $($r1.Output)"
+    Assert ($r1.Output -match 'new error X') "Case 1: must include 'new error X'. Output: $($r1.Output)"
+    Assert ($r1.Output -match 'new warning Y') "Case 1: must include 'new warning Y'. Output: $($r1.Output)"
+    Assert ($r1.Output -notmatch 'old error A') "Case 1: must NOT include 'old error A' (session-1 leak). Output: $($r1.Output)"
+    Assert ($r1.Output -notmatch 'old error B') "Case 1: must NOT include 'old error B'. Output: $($r1.Output)"
+    Assert ($r1.Output -notmatch 'old warning') "Case 1: must NOT include 'old warning'. Output: $($r1.Output)"
+    $passes++; Write-Host "[PASS] Case 1: returns only latest compile session"
+
+    # --- Case 2: -MaxLines 1 keeps only the most-recent match
+    $r2 = Invoke-Helper -LogPath $twoSession -ExtraArgs @('-MaxLines', '1')
+    Assert ($r2.ExitCode -eq 0) "Case 2 exit code expected 0, got $($r2.ExitCode). Output: $($r2.Output)"
+    $lineCount = ($r2.Output -split "`r?`n" | Where-Object { $_.Trim() }).Count
+    Assert ($lineCount -eq 1) "Case 2: -MaxLines 1 must return exactly 1 line, got $lineCount. Output: $($r2.Output)"
+    # most-recent of (X, Y) appears later in file so should be Y
+    Assert ($r2.Output -match 'new warning Y') "Case 2: most-recent match should be 'new warning Y'. Output: $($r2.Output)"
+    $passes++; Write-Host "[PASS] Case 2: -MaxLines caps output"
+
+    # --- Case 3: -Json emits structured payload
+    $r3 = Invoke-Helper -LogPath $twoSession -ExtraArgs @('-Json')
+    Assert ($r3.ExitCode -eq 0) "Case 3 exit code expected 0, got $($r3.ExitCode). Output: $($r3.Output)"
+    $obj = $r3.Output | ConvertFrom-Json
+    Assert ($obj.matched -eq 2) "Case 3: matched count should be 2, got $($obj.matched). Output: $($r3.Output)"
+    Assert ($obj.sessionLines -ge 3) "Case 3: sessionLines should include session-2 body, got $($obj.sessionLines)"
+    Assert ($obj.markerLineIndex -gt 0) "Case 3: markerLineIndex must be positive (latest marker), got $($obj.markerLineIndex)"
+    Assert ($obj.pattern -eq 'error CS|warning CS') "Case 3: pattern should round-trip"
+    Assert ((($obj.lines -join ' ') -match 'new error X')) "Case 3: JSON lines must include 'new error X'"
+    $passes++; Write-Host "[PASS] Case 3: -Json emits structured payload"
+
+    # --- Case 4: -Pattern 'error CS' excludes warnings
+    $r4 = Invoke-Helper -LogPath $twoSession -ExtraArgs @('-Pattern', 'error CS')
+    Assert ($r4.ExitCode -eq 0) "Case 4 exit code expected 0, got $($r4.ExitCode)"
+    Assert ($r4.Output -match 'new error X') "Case 4: must include 'new error X'"
+    Assert ($r4.Output -notmatch 'new warning Y') "Case 4: must NOT include warnings. Output: $($r4.Output)"
+    $passes++; Write-Host "[PASS] Case 4: -Pattern filters out warnings"
+
+    # --- Case 5: -IncludeMarker prepends the reload marker line
+    $r5 = Invoke-Helper -LogPath $twoSession -ExtraArgs @('-IncludeMarker', '-Pattern', 'Reloading|error CS|warning CS')
+    Assert ($r5.ExitCode -eq 0) "Case 5 exit code expected 0, got $($r5.ExitCode)"
+    $firstNonEmpty = ($r5.Output -split "`r?`n" | Where-Object { $_.Trim() })[0]
+    Assert ($firstNonEmpty -match 'Reloading assemblies after forced synchronous recompile') "Case 5: first matching line must be the marker. Output: $($r5.Output)"
+    $passes++; Write-Host "[PASS] Case 5: -IncludeMarker surfaces marker line"
+
+    # --- Case 6: log with NO marker exits 3 + empty
+    $noMarker = Join-Path $tempRoot 'no-marker.log'
+    New-FixtureLog -Path $noMarker -Lines @(
+        'Some Unity boot output',
+        'Loading some package',
+        'Project loaded'
+    )
+    $r6 = Invoke-Helper -LogPath $noMarker
+    Assert ($r6.ExitCode -eq 3) "Case 6 exit code expected 3 (no marker), got $($r6.ExitCode). Output: $($r6.Output)"
+    $passes++; Write-Host "[PASS] Case 6: log without reload marker exits 3"
+
+    # --- Case 7: missing log file exits 2
+    $missing = Join-Path $tempRoot 'does-not-exist.log'
+    $r7 = Invoke-Helper -LogPath $missing
+    Assert ($r7.ExitCode -eq 2) "Case 7 exit code expected 2 (missing log), got $($r7.ExitCode). Output: $($r7.Output)"
+    $passes++; Write-Host "[PASS] Case 7: missing log exits 2"
+
+    Write-Host ""
+    Write-Host "Result: $passes passed, $failures failed"
+} catch {
+    $failures++
+    Write-Host ""
+    Write-Host "Result: $passes passed, $failures failed"
+    Write-Host "ERROR: $($_.Exception.Message)"
+    Write-Host $_.ScriptStackTrace
+    exit 1
+} finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if ($failures -gt 0) { exit 1 }
+exit 0

--- a/Assets/_WitchMendokusai/Editor/Infra/MCPRouting/McpAutoBinder.cs
+++ b/Assets/_WitchMendokusai/Editor/Infra/MCPRouting/McpAutoBinder.cs
@@ -1,0 +1,326 @@
+// Auto-bind <worktree>/.mcp.json to this Editor's MCP HTTP port on startup.
+//
+// Why (TASK-WM-109-D):
+//   WM-109-G shipped the worktree-aware routing primitives (PowerShell script
+//   + WM/MCP menu items + .gitignore for .mcp.json). Both paths still require
+//   a *manual trigger* — the user has to either run the script or click the
+//   menu before Claude's MCP client can talk to this Editor.
+//
+//   In day-to-day multi-worktree work, every new Editor session needs the
+//   same one-shot binding. Doing it manually means the Claude session
+//   silently misroutes (or fails with "Unity Editor for WitchMendokusai not
+//   running") until the human remembers.
+//
+//   This script closes the loop: on Editor load, poll for the MCP HTTP PID
+//   file (the same authoritative signal McpWorktreeBinder uses). When it
+//   appears AND the .mcp.json's port doesn't match, write the file. Done.
+//
+// Safety / scope:
+//   - No-op if port already matches what's in .mcp.json (idempotent).
+//   - No-op if the user has disabled auto-bind via EditorPrefs
+//       "WM.MCP.AutoBindEnabled" = false.
+//   - No-op in batch/CI mode (-batchmode) so headless runs do not stomp on a
+//     human's interactive .mcp.json.
+//   - Polling is bounded: every ~3s for the first 2 minutes after assembly
+//     load, then unsubscribed. Once a successful bind happens, subsequent
+//     polls become cheap no-ops; once the timeout elapses we stop entirely.
+//
+// 정합:
+//   - § Editor 메뉴 (CLAUDE.md) — top-level root = "WM/"
+//   - § Unity-MCP layer (CLAUDE.md) — CoplayDev `com.coplaydev.unity-mcp`
+//     정본, `127.0.0.1:<port>/mcp` URL.
+//   - § 객체 참조 획득 — init-order: this runs from [InitializeOnLoadMethod]
+//     which fires after all assemblies are loaded. We do NOT call any
+//     runtime singletons; only EditorApplication APIs + file I/O.
+//   - § 자동화 우선: replaces a manual menu click. Visual / domain
+//     verification stays with the user.
+
+#if UNITY_EDITOR
+using System;
+using System.IO;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace WitchMendokusai.Editor.Infra.MCPRouting
+{
+    [InitializeOnLoad]
+    public static class McpAutoBinder
+    {
+        private const string MENU_ROOT = "WM/MCP/";
+        private const string AUTO_BIND_TOGGLE_MENU = MENU_ROOT + "Auto-Bind on Editor Startup";
+        private const string RUN_NOW_MENU = MENU_ROOT + "Run Auto-Bind Now";
+        private const string PREF_KEY_ENABLED = "WM.MCP.AutoBindEnabled";
+
+        // Total polling window — the MCP HTTP server takes a few seconds after
+        // domain reload to write its PID file. 2 minutes covers slow CI boxes
+        // and cold first runs without burning cycles forever.
+        private const double POLL_WINDOW_SECONDS = 120.0;
+        private const double POLL_INTERVAL_SECONDS = 3.0;
+
+        private static double pollStartTime;
+        private static double nextPollTime;
+        private static bool boundThisSession;
+        private static bool pollingActive;
+
+        static McpAutoBinder()
+        {
+            // Skip batch / headless — those sessions should never overwrite a
+            // human's .mcp.json. Tests and CI invocations land here.
+            if (Application.isBatchMode)
+            {
+                return;
+            }
+
+            if (IsEnabled() == false)
+            {
+                return;
+            }
+
+            // Defer registration to the next editor tick so domain reload
+            // bookkeeping fully settles before we touch IO.
+            EditorApplication.delayCall += BeginPolling;
+        }
+
+        [MenuItem(AUTO_BIND_TOGGLE_MENU)]
+        private static void ToggleAutoBind()
+        {
+            bool newValue = !IsEnabled();
+            EditorPrefs.SetBool(PREF_KEY_ENABLED, newValue);
+            Debug.Log($"[McpAutoBinder] Auto-bind on Editor startup = {newValue}");
+            if (newValue && pollingActive == false)
+            {
+                BeginPolling();
+            }
+        }
+
+        [MenuItem(AUTO_BIND_TOGGLE_MENU, true)]
+        private static bool ToggleAutoBindValidate()
+        {
+            Menu.SetChecked(AUTO_BIND_TOGGLE_MENU, IsEnabled());
+            return true;
+        }
+
+        [MenuItem(RUN_NOW_MENU)]
+        public static void RunAutoBindNow()
+        {
+            BindResult result = TryBindOnce(verbose: true);
+            string body;
+            switch (result.Status)
+            {
+                case BindStatus.Wrote:
+                    body = $"Wrote .mcp.json -> port {result.Port}.";
+                    break;
+                case BindStatus.AlreadyCurrent:
+                    body = $".mcp.json already routes to port {result.Port}. No change.";
+                    break;
+                case BindStatus.NoPort:
+                    body =
+                        "MCP HTTP port not detected. Open Window > MCP for Unity and " +
+                        "ensure HTTP transport is enabled, then try again.";
+                    break;
+                default:
+                    body = $"Auto-bind error: {result.Message}";
+                    break;
+            }
+            EditorUtility.DisplayDialog("MCP Auto-Binder", body, "OK");
+        }
+
+        private static bool IsEnabled()
+        {
+            return EditorPrefs.GetBool(PREF_KEY_ENABLED, true);
+        }
+
+        private static void BeginPolling()
+        {
+            if (pollingActive)
+            {
+                return;
+            }
+
+            pollStartTime = EditorApplication.timeSinceStartup;
+            nextPollTime = pollStartTime;
+            boundThisSession = false;
+            pollingActive = true;
+            EditorApplication.update += OnEditorUpdate;
+        }
+
+        private static void StopPolling()
+        {
+            if (pollingActive == false)
+            {
+                return;
+            }
+            pollingActive = false;
+            EditorApplication.update -= OnEditorUpdate;
+        }
+
+        private static void OnEditorUpdate()
+        {
+            double now = EditorApplication.timeSinceStartup;
+            if (now < nextPollTime)
+            {
+                return;
+            }
+            nextPollTime = now + POLL_INTERVAL_SECONDS;
+
+            BindResult result = TryBindOnce(verbose: false);
+
+            // Successful write: keep polling at the same cadence so a server
+            // restart on a different port still gets picked up automatically
+            // within the polling window. Set the "bound" flag to silence the
+            // log once we're known-good.
+            if (result.Status == BindStatus.Wrote || result.Status == BindStatus.AlreadyCurrent)
+            {
+                boundThisSession = true;
+            }
+
+            if (now - pollStartTime >= POLL_WINDOW_SECONDS)
+            {
+                StopPolling();
+                if (boundThisSession == false)
+                {
+                    Debug.Log(
+                        "[McpAutoBinder] Polling window elapsed without detecting an MCP HTTP server. " +
+                        "If you start the server later, use 'WM > MCP > Run Auto-Bind Now' or click " +
+                        "'WM > MCP > Bind Claude session to this Editor'.");
+                }
+            }
+        }
+
+        private static BindResult TryBindOnce(bool verbose)
+        {
+            try
+            {
+                string projectRoot = McpWorktreeBinder.GetProjectRoot();
+                int port = McpWorktreeBinder.DiscoverHttpPort(projectRoot);
+
+                // DiscoverHttpPort falls back to 8080 by default; treat that
+                // as "no real signal" when no PID file or EditorPrefs URL is
+                // available. We check for an actual PID file first to avoid
+                // writing speculative configs that point at a dead port.
+                if (HasLivePidFile(projectRoot) == false && HasExplicitHttpBaseUrl() == false)
+                {
+                    return new BindResult(BindStatus.NoPort, port, "no live MCP HTTP signal");
+                }
+
+                string mcpJsonPath = Path.Combine(projectRoot, ".mcp.json");
+                int currentPort = ReadExistingPort(mcpJsonPath);
+                if (currentPort == port)
+                {
+                    return new BindResult(BindStatus.AlreadyCurrent, port, mcpJsonPath);
+                }
+
+                WriteMcpJson(mcpJsonPath, port);
+                if (verbose || boundThisSession == false)
+                {
+                    Debug.Log(
+                        $"[McpAutoBinder] Bound this worktree's Claude session to http://127.0.0.1:{port}/mcp " +
+                        $"(previous port {(currentPort > 0 ? currentPort.ToString() : "none")}). " +
+                        $"Wrote {mcpJsonPath}.");
+                }
+                return new BindResult(BindStatus.Wrote, port, mcpJsonPath);
+            }
+            catch (Exception ex)
+            {
+                if (verbose)
+                {
+                    Debug.LogWarning($"[McpAutoBinder] Auto-bind failed: {ex.Message}");
+                }
+                return new BindResult(BindStatus.Error, 0, ex.Message);
+            }
+        }
+
+        private static bool HasLivePidFile(string projectRoot)
+        {
+            string runStateDir = Path.Combine(projectRoot, "Library", "MCPForUnity", "RunState");
+            if (Directory.Exists(runStateDir) == false)
+            {
+                return false;
+            }
+            string[] files = Directory.GetFiles(runStateDir, "mcp_http_*.pid");
+            return files.Length > 0;
+        }
+
+        private static bool HasExplicitHttpBaseUrl()
+        {
+            string value = EditorPrefs.GetString("MCPForUnity.HttpBaseUrl", string.Empty);
+            return string.IsNullOrEmpty(value) == false;
+        }
+
+        private static int ReadExistingPort(string mcpJsonPath)
+        {
+            if (File.Exists(mcpJsonPath) == false)
+            {
+                return 0;
+            }
+            try
+            {
+                string text = File.ReadAllText(mcpJsonPath);
+                int idx = text.IndexOf("127.0.0.1:", StringComparison.Ordinal);
+                if (idx < 0)
+                {
+                    return 0;
+                }
+                int start = idx + "127.0.0.1:".Length;
+                int end = start;
+                while (end < text.Length && char.IsDigit(text[end]))
+                {
+                    end++;
+                }
+                if (end == start)
+                {
+                    return 0;
+                }
+                if (int.TryParse(text.Substring(start, end - start), out int port))
+                {
+                    return port;
+                }
+                return 0;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        private static void WriteMcpJson(string mcpJsonPath, int port)
+        {
+            string url = $"http://127.0.0.1:{port}/mcp";
+            string payload =
+                "{\n" +
+                "  \"mcpServers\": {\n" +
+                "    \"unityMCP\": {\n" +
+                "      \"type\": \"http\",\n" +
+                "      \"url\": \"" + url + "\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n";
+            File.WriteAllText(mcpJsonPath, payload, new UTF8Encoding(false));
+        }
+
+        private enum BindStatus
+        {
+            Wrote,
+            AlreadyCurrent,
+            NoPort,
+            Error
+        }
+
+        private readonly struct BindResult
+        {
+            public readonly BindStatus Status;
+            public readonly int Port;
+            public readonly string Message;
+
+            public BindResult(BindStatus status, int port, string message)
+            {
+                Status = status;
+                Port = port;
+                Message = message;
+            }
+        }
+    }
+}
+#endif

--- a/Assets/_WitchMendokusai/Editor/Infra/MCPRouting/McpAutoBinder.cs.meta
+++ b/Assets/_WitchMendokusai/Editor/Infra/MCPRouting/McpAutoBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b3f1a92c8e64d57a094f283d1b5e6a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Editor/Infra/MCPRouting/McpWorktreeBinder.cs
+++ b/Assets/_WitchMendokusai/Editor/Infra/MCPRouting/McpWorktreeBinder.cs
@@ -162,7 +162,7 @@ namespace WitchMendokusai.Editor.Infra.MCPRouting
             }
         }
 
-        private static string GetProjectRoot()
+        internal static string GetProjectRoot()
         {
             // Application.dataPath = "<root>/Assets"
             return Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
@@ -176,7 +176,10 @@ namespace WitchMendokusai.Editor.Infra.MCPRouting
         //   1. Library/MCPForUnity/RunState/mcp_http_<port>.pid -- filename encodes port.
         //   2. EditorPrefs "MCPForUnity.HttpBaseUrl" -- user-set base URL.
         //   3. Default 8080.
-        private static int DiscoverHttpPort(string projectRoot)
+        //
+        // internal: shared with McpAutoBinder so both menu (explicit) and
+        // auto-bind (background) paths use exactly the same resolution order.
+        internal static int DiscoverHttpPort(string projectRoot)
         {
             const string MCP_HTTP_PREFIX = "mcp_http_";
             string runStateDir = Path.Combine(projectRoot, "Library", "MCPForUnity", "RunState");

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,6 +487,8 @@ EditorSceneManager.SaveOpenScenes();
 - `set_active_instance(instance="...")` 으로 *현재 작업 worktree* 의 Unity 인스턴스 선택
 - Multi-worktree 환경 (TASK-WM-069 인프라) 정합 — 각 worktree Editor 별 MCP routing
 - **자동 라우팅 (TASK-WM-109-G)** — Claude session 시작 시 `.claude/scripts/wm-mcp-route.ps1` 가 현재 worktree 의 `Library/MCPForUnity/RunState/mcp_http_<port>.pid` 를 읽어 worktree-local `.mcp.json` 을 자동 생성. Editor 안에서는 `WM > MCP > Bind Claude session to this Editor` 메뉴 한 클릭. 진단/사용법 = `.claude/scripts/README.md`. `.mcp.json` 은 `.gitignore` 됨 (포트 worktree 별 상이).
+- **Editor-side 자동 바인드 (TASK-WM-109-D)** — `Assets/_WitchMendokusai/Editor/Infra/MCPRouting/McpAutoBinder.cs` 가 `[InitializeOnLoad]` 로 등록, Editor 시작 직후 ~2 분간 ~3 초 간격으로 `mcp_http_*.pid` 폴링 → 발견 즉시 `.mcp.json` 갱신 (idempotent — 포트 동일 시 no-op, batchmode 차단). 메뉴: `WM > MCP > Auto-Bind on Editor Startup` (토글, 기본 ON, `EditorPrefs "WM.MCP.AutoBindEnabled"`) · `WM > MCP > Run Auto-Bind Now` (강제 실행). 109-G 의 수동 경로(스크립트/Bind 메뉴)와 공존 — 자동 경로 = 평시 default, 수동 경로 = 명시 트리거 / 디버그.
+- **Editor.log 폴백 (MCP 미가용 시, TASK-WM-109-D)** — `.claude/scripts/wm-editor-log-tail.ps1` 가 Editor.log 의 마지막 `Reloading assemblies after forced synchronous recompile` 마커 이후 라인만 잘라 `error CS|warning CS` 필터링. append-only 누적 → 옛 컴파일 결과 섞임 문제(§ Editor.log 부정확 사례 TASK-WM-056-A) 해소. *MCP `read_console` 정본은 그대로* — 본 폴백은 MCP 서버 미기동 / 패키지 일시 고장 시만 사용 (CLAUDE.md § Unity-MCP layer Editor.log 의 append-only 한계 정합).
 
 ### 사용자 손 보존 영역 (MCP 도입 후에도)
 


### PR DESCRIPTION
## Summary

Closes TASK-WM-109-D (parent: TASK-WM-109 issue 4).

Two changes close the manual-binding gap that WM-109-G left open and harden the Editor.log fallback against append-only contamination:

- **`McpAutoBinder.cs`** — new `[InitializeOnLoad]` Editor script. Polls `Library/MCPForUnity/RunState/mcp_http_<port>.pid` every ~3s for ~2min after assembly load. When a live MCP HTTP signal appears AND `.mcp.json`'s port doesn't match, writes `<worktree>/.mcp.json` automatically. Idempotent (no-op when port already matches), skipped in batchmode, gated by `EditorPrefs "WM.MCP.AutoBindEnabled"` (default ON). New menu items: ``WM > MCP > Auto-Bind on Editor Startup`` (toggle, validator checkmark reflects state) and ``WM > MCP > Run Auto-Bind Now`` (force one attempt).
- **`McpWorktreeBinder.GetProjectRoot` / `DiscoverHttpPort`** — visibility upgrade to `internal` so the auto-binder reuses the exact resolution order the menu-driven binder uses. No behaviour change for menu users.
- **`.claude/scripts/wm-editor-log-tail.ps1`** — new PowerShell fallback for compile-error inspection when MCP is unavailable. Slices Editor.log at the last `Reloading assemblies after forced synchronous recompile` marker and returns only that session's `error CS|warning CS` lines. Defaults match CLAUDE.md \"Warning 도 무시 X\" (errors + warnings together, max 200 lines, plain stdout). `-Json` emits a structured payload. Exit codes: 0 ok / 2 log missing / 3 no marker.
- **`.claude/scripts/wm-editor-log-tail.tests.ps1`** — 7 fixture cases (no Unity required). Crucially Case 1 builds a synthetic two-session log mirroring the TASK-WM-056-A leak shape (259-vs-6) and asserts session-1 errors do NOT leak into session-2 output.
- **`.claude/scripts/README.md`** — helper table + full `wm-editor-log-tail.ps1` section.
- **`CLAUDE.md § Multi-instance + worktree 정합`** — two new bullets next to the existing WM-109-G manual-routing bullet.

## Why both deliverables, one commit

TASK-WM-109-D enumerated two solution paths (auto-register vs. log fallback improvement) as alternatives. They turn out to be complementary, not redundant: auto-bind eliminates the common case (Editor up → no manual click), and the log fallback covers the residual case (Editor up but MCP server temporarily down / broken). Shipping them together keeps the TASK closed in one bisect-friendly commit.

## Test plan

- [x] `.claude/scripts/wm-editor-log-tail.tests.ps1` — 7/7 PASS
- [x] `.claude/scripts/wm-mcp-route.tests.ps1` — 6/6 PASS (regression check after `McpWorktreeBinder` visibility change)
- [ ] **Reviewer-side Unity compile verification** — this worktree's MCP channel is the very surface this PR fixes (chicken-and-egg), so the agent couldn't run MCP `read_console` locally. After pulling, run `read_console(types=[\"error\", \"warning\"])` once the auto-binder has settled to confirm 0 entries.
- [ ] **Live smoke test** — open a fresh worktree's Editor with `.mcp.json` absent, wait ~5s, confirm `.mcp.json` is written with the correct port, and confirm a Claude session launched from cwd connects.
- [ ] **Toggle smoke test** — uncheck ``WM > MCP > Auto-Bind on Editor Startup``, restart the Editor, confirm `.mcp.json` is NOT touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)