### PR TITLE
feat(TASK-WM-164): SimCity Phase 1 step2 — SimulationTickScheduler fixed-accumulator

### DIFF
--- a/Assets/_WitchMendokusai/DomainSDK/City/SimulationTickScheduler.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/City/SimulationTickScheduler.cs
@@ -1,0 +1,110 @@
+using System;
+
+namespace WitchMendokusai
+{
+	// Fixed-accumulator simulation tick scheduler (SimCity Phase 1 substrate).
+	// TimeManager.UpdateTime(0.05s WaitForSeconds 루프) = *클럭* — Time.timeScale 추종 + render 종속.
+	// SimulationTickScheduler = *스케줄러* — unscaledDeltaTime 입력만 받아 결정적 tick 산출:
+	//
+	//  ① Time.timeScale ⊥ — 일시정지/배속은 SpeedMultiplier 한 곳에서, dt 는 항상 unscaled.
+	//  ② render 프레임율 ⊥ — 느린 프레임 = 다중 catch-up tick, 빠른 프레임 = 0 tick + 누적.
+	//  ③ SpeedMultiplier (SimCity 1/2/3 배속) = dt 곱셈, 결정성 보존.
+	//  ④ Spiral-of-death 캡 (MaxStepsPerAdvance) — 극단 dt 시 잉여 accumulator drop → freeze 후
+	//     catch-up 폭주 차단(사용자 체감 동결 회피).
+	//
+	// 순수 POCO — UnityEngine 무관. 같은 (dt seq, SpeedMultiplier seq) → 결정적 동일 (반환 seq,
+	// Accumulator 종착) — 멀티 클라이언트·재현 디버그 토대 (Phase 4 멀티 seam).
+	//
+	// 사용:
+	//   SimulationTickScheduler scheduler = new(secondsPerTick: 1f / 60f);
+	//   // Update() 안:
+	//   int ticks = scheduler.Advance(Time.unscaledDeltaTime);
+	//   for (int i = 0; i < ticks; i++) { SimStep(); }
+	public sealed class SimulationTickScheduler
+	{
+		public const int DEFAULT_MAX_STEPS_PER_ADVANCE = 8;
+
+		// 한 tick = 시뮬 1 step 의 게임 내 길이 (초). 양수 강제.
+		public float SecondsPerTick { get; }
+
+		// 한 Advance() 호출에서 최대로 실행할 tick 수 (spiral-of-death 캡).
+		// 초과분 dt 는 drop — accumulator 에 누적 X (이후 catch-up 가속 X — 사용자 체감 freeze 회피).
+		public int MaxStepsPerAdvance { get; }
+
+		// 게임 배속 (1 = 실시간, 2 = 2x, 0 = pause). 음수 입력 시 pause 동등 처리(rewind X).
+		public float SpeedMultiplier { get; set; } = 1f;
+
+		// 누적 시뮬 시간 (sub-tick) — 다음 tick fire 까지 남은 잔여분.
+		public float Accumulator { get; private set; }
+
+		// 누적 실행된 tick 수 (모노토닉). 결정적 시드·동기화에 사용 가능.
+		public long TickCount { get; private set; }
+
+		public SimulationTickScheduler(float secondsPerTick, int maxStepsPerAdvance = DEFAULT_MAX_STEPS_PER_ADVANCE)
+		{
+			if (secondsPerTick <= 0f)
+			{
+				throw new ArgumentOutOfRangeException(nameof(secondsPerTick), secondsPerTick, "tick 길이 > 0 필수");
+			}
+
+			if (maxStepsPerAdvance < 1)
+			{
+				throw new ArgumentOutOfRangeException(nameof(maxStepsPerAdvance), maxStepsPerAdvance, "최소 1");
+			}
+
+			SecondsPerTick = secondsPerTick;
+			MaxStepsPerAdvance = maxStepsPerAdvance;
+		}
+
+		// 실시간 dt 를 입력 받아 산출할 sim tick 수 반환 (호출자가 tick 만큼 SimStep 루프).
+		// 결정성: 같은 (dt seq, SpeedMultiplier seq) → 같은 (반환 seq, Accumulator 종착).
+		public int Advance(float unscaledDeltaTime)
+		{
+			if (unscaledDeltaTime <= 0f)
+			{
+				return 0; // 음수/0 dt = 무시 (rewind X, paused frame noop).
+			}
+
+			float speed = SpeedMultiplier;
+			if (speed <= 0f)
+			{
+				return 0; // 일시정지 (배속 ≤ 0). dt 무시 — accumulator 동결.
+			}
+
+			Accumulator += unscaledDeltaTime * speed;
+
+			int steps = 0;
+			while (Accumulator >= SecondsPerTick && steps < MaxStepsPerAdvance)
+			{
+				Accumulator -= SecondsPerTick;
+				steps++;
+			}
+
+			// Spiral-of-death — cap 초과 잔여분 drop. 사용자 freeze 시 다음 Advance 가 폭주 catch-up 안 함.
+			if (Accumulator >= SecondsPerTick)
+			{
+				Accumulator = 0f;
+			}
+
+			TickCount += steps;
+			return steps;
+		}
+
+		// 외부 시점 점프 (저장 로드·디버그) — accumulator/tickCount 초기화.
+		public void Reset(long tickCount = 0L, float accumulator = 0f)
+		{
+			if (tickCount < 0L)
+			{
+				throw new ArgumentOutOfRangeException(nameof(tickCount), tickCount, "tickCount 음수 X");
+			}
+
+			if (accumulator < 0f)
+			{
+				throw new ArgumentOutOfRangeException(nameof(accumulator), accumulator, "accumulator 음수 X");
+			}
+
+			TickCount = tickCount;
+			Accumulator = accumulator;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/City/SimulationTickScheduler.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/City/SimulationTickScheduler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 64fc56dba45f4786bc9740acfbff5dad

--- a/Assets/_WitchMendokusai/Tests/EditMode/SimulationTickSchedulerTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/SimulationTickSchedulerTest.cs
@@ -1,0 +1,185 @@
+using System;
+using NUnit.Framework;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-164 Phase 1 step2 — <see cref="SimulationTickScheduler"/> fixed-accumulator
+	/// 회귀 잠금. RoadGraph 와 형제 — Phase 2 (에이전트·전기 전파) 가 결정적 tick 토대 위에 올라야 한다.
+	///
+	/// 순수 POCO — Time.timeScale ⊥ + render 프레임율 ⊥ 검증 (테스트가 dt 직접 주입).
+	/// RoadGraphTest 패턴 답습 (new() 직접 + Assert.That).
+	///
+	/// 실행: unity -runTests -batchmode -testPlatform EditMode -assemblyNames WM.Tests.EditMode
+	/// </summary>
+	public sealed class SimulationTickSchedulerTest
+	{
+		private const float TICK = 0.05f;
+		private const float EPS = 1e-5f;
+
+		[Test]
+		public void Constructor_RejectsNonPositiveSecondsPerTick()
+		{
+			Assert.Throws<ArgumentOutOfRangeException>(() => new SimulationTickScheduler(0f));
+			Assert.Throws<ArgumentOutOfRangeException>(() => new SimulationTickScheduler(-1f));
+		}
+
+		[Test]
+		public void Constructor_RejectsZeroMaxSteps()
+		{
+			Assert.Throws<ArgumentOutOfRangeException>(() => new SimulationTickScheduler(TICK, maxStepsPerAdvance: 0));
+		}
+
+		[Test]
+		public void Advance_SubTickDt_AccumulatesNoFire()
+		{
+			SimulationTickScheduler scheduler = new(TICK);
+
+			int ticks = scheduler.Advance(TICK * 0.4f);
+
+			Assert.That(ticks, Is.Zero, "sub-tick 단발 fire X");
+			Assert.That(scheduler.TickCount, Is.Zero);
+			Assert.That(scheduler.Accumulator, Is.EqualTo(TICK * 0.4f).Within(EPS), "잔여분 누적");
+		}
+
+		[Test]
+		public void Advance_SubTickDeltasSumToTick_FiresOnce()
+		{
+			SimulationTickScheduler scheduler = new(TICK);
+
+			Assert.That(scheduler.Advance(TICK * 0.4f), Is.Zero);
+			Assert.That(scheduler.Advance(TICK * 0.7f), Is.EqualTo(1), "0.4 + 0.7 = 1.1 tick → 1 fire");
+
+			Assert.That(scheduler.TickCount, Is.EqualTo(1L));
+			Assert.That(scheduler.Accumulator, Is.EqualTo(TICK * 0.1f).Within(EPS), "잔여 0.1 tick 누적");
+		}
+
+		[Test]
+		public void Advance_ExactlyOneTick_FiresOnce_AccumulatorZero()
+		{
+			SimulationTickScheduler scheduler = new(TICK);
+
+			int ticks = scheduler.Advance(TICK);
+
+			Assert.That(ticks, Is.EqualTo(1));
+			Assert.That(scheduler.Accumulator, Is.EqualTo(0f).Within(EPS));
+		}
+
+		[Test]
+		public void Advance_LongDt_FiresMultipleTicks_RemainderAccumulates()
+		{
+			SimulationTickScheduler scheduler = new(TICK);
+
+			int ticks = scheduler.Advance(TICK * 3.5f);
+
+			Assert.That(ticks, Is.EqualTo(3));
+			Assert.That(scheduler.Accumulator, Is.EqualTo(TICK * 0.5f).Within(EPS));
+		}
+
+		[Test]
+		public void Advance_ExcessDt_ClampedByMaxStepsPerAdvance_AccumulatorReset()
+		{
+			SimulationTickScheduler scheduler = new(TICK, maxStepsPerAdvance: 2);
+
+			// 5 tick 분량 입력 but cap=2 → spiral-of-death 차단, 잔여 drop.
+			int ticks = scheduler.Advance(TICK * 5f);
+
+			Assert.That(ticks, Is.EqualTo(2));
+			Assert.That(scheduler.TickCount, Is.EqualTo(2L));
+			Assert.That(scheduler.Accumulator, Is.EqualTo(0f).Within(EPS),
+				"cap 초과분은 drop — 다음 Advance 가 catch-up 가속 안 함");
+		}
+
+		[Test]
+		public void Advance_SpeedMultiplier2x_DoublesEffectiveDt()
+		{
+			SimulationTickScheduler scheduler = new(TICK);
+			scheduler.SpeedMultiplier = 2f;
+
+			int ticks = scheduler.Advance(TICK);
+
+			Assert.That(ticks, Is.EqualTo(2));
+			Assert.That(scheduler.TickCount, Is.EqualTo(2L));
+		}
+
+		[Test]
+		public void Advance_SpeedMultiplierZero_PausesNoFire_AccumulatorUntouched()
+		{
+			SimulationTickScheduler scheduler = new(TICK);
+			scheduler.Advance(TICK * 0.5f);
+			float accBefore = scheduler.Accumulator;
+
+			scheduler.SpeedMultiplier = 0f;
+			int ticks = scheduler.Advance(TICK * 10f);
+
+			Assert.That(ticks, Is.Zero);
+			Assert.That(scheduler.Accumulator, Is.EqualTo(accBefore).Within(EPS),
+				"pause 중 accumulator 동결 (이전 잔여 보존)");
+		}
+
+		[Test]
+		public void Advance_SpeedMultiplierNegative_TreatedAsPause()
+		{
+			SimulationTickScheduler scheduler = new(TICK);
+			scheduler.SpeedMultiplier = -1f;
+
+			int ticks = scheduler.Advance(TICK * 10f);
+
+			Assert.That(ticks, Is.Zero, "음수 배속 = rewind X, pause 동등");
+			Assert.That(scheduler.Accumulator, Is.EqualTo(0f).Within(EPS));
+		}
+
+		[Test]
+		public void Advance_NegativeOrZeroDt_NoEffect()
+		{
+			SimulationTickScheduler scheduler = new(TICK);
+
+			Assert.That(scheduler.Advance(0f), Is.Zero);
+			Assert.That(scheduler.Advance(-1f), Is.Zero);
+			Assert.That(scheduler.Accumulator, Is.EqualTo(0f).Within(EPS));
+			Assert.That(scheduler.TickCount, Is.Zero);
+		}
+
+		[Test]
+		public void Reset_RestoresSnapshotState_PreservesConfig()
+		{
+			SimulationTickScheduler scheduler = new(TICK, maxStepsPerAdvance: 4);
+			scheduler.Advance(TICK * 7f);
+
+			scheduler.Reset(tickCount: 100L, accumulator: TICK * 0.3f);
+
+			Assert.That(scheduler.TickCount, Is.EqualTo(100L));
+			Assert.That(scheduler.Accumulator, Is.EqualTo(TICK * 0.3f).Within(EPS));
+			Assert.That(scheduler.SecondsPerTick, Is.EqualTo(TICK).Within(EPS), "config 보존");
+			Assert.That(scheduler.MaxStepsPerAdvance, Is.EqualTo(4), "config 보존");
+		}
+
+		[Test]
+		public void Reset_NegativeArgs_Throw()
+		{
+			SimulationTickScheduler scheduler = new(TICK);
+
+			Assert.Throws<ArgumentOutOfRangeException>(() => scheduler.Reset(tickCount: -1L));
+			Assert.Throws<ArgumentOutOfRangeException>(() => scheduler.Reset(accumulator: -0.1f));
+		}
+
+		// ★ 결정성 핵심: 같은 누적 dt → 같은 총 tick 수 + 같은 accumulator 종착, 프레임 슬라이싱과 무관.
+		[Test]
+		public void Advance_DeterministicAcrossFrameSlicing_SameTotal()
+		{
+			SimulationTickScheduler one = new(TICK);
+			int oneTicks = one.Advance(TICK * 3.7f);
+
+			SimulationTickScheduler many = new(TICK);
+			int manyTicks = 0;
+			for (int i = 0; i < 10; i++)
+			{
+				manyTicks += many.Advance(TICK * 0.37f);
+			}
+
+			Assert.That(oneTicks, Is.EqualTo(manyTicks), "프레임 슬라이싱과 무관하게 동일 tick 수");
+			Assert.That(many.Accumulator, Is.EqualTo(one.Accumulator).Within(EPS * 10f),
+				"잔여 누적 동일 (float 오차 허용)");
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/SimulationTickSchedulerTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/SimulationTickSchedulerTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 02acbccbc0af436c9a2b199058775519


### PR DESCRIPTION
## 요약

SimCity 도시 시뮬 Phase 1 의 두 번째 substrate. **RoadGraph(step1, da405e99) 와 형제** — TASK 스펙 § "Phase 1 진입 전 박을 것" 양쪽 (도로 그래프 + 시뮬 틱) 완성.

`TimeManager` 의 `0.05s WaitForSeconds` 코루틴은 *클럭* — `Time.timeScale` 추종 + render 종속. `SimulationTickScheduler` 는 *스케줄러* — `unscaledDeltaTime` 입력만 받아 결정적 tick 산출. 두 책임 분리.

## 설계 (POCO, UnityEngine 무관)

- **`Time.timeScale` ⊥** — Pause/배속은 `SpeedMultiplier` 한 곳, dt 는 항상 unscaled.
- **render 프레임율 ⊥** — 느린 프레임 = 다중 catch-up tick / 빠른 프레임 = 0 tick + 누적.
- **`SpeedMultiplier`** (SimCity 1/2/3 배속) = dt 곱셈, 결정성 보존. `<=0` = pause (rewind X).
- **Spiral-of-death 캡** (`MaxStepsPerAdvance`) — 극단 dt 시 잉여 drop → freeze 후 catch-up 폭주 차단.
- 같은 `(dt seq, speed seq)` → 결정적 동일 출력 — 멀티 클라이언트·재현 디버그 토대 (Phase 4 멀티 seam).

## 변경

- `Assets/_WitchMendokusai/DomainSDK/City/SimulationTickScheduler.cs` — 신규 POCO (`RoadGraph` 와 같은 폴더).
- `Assets/_WitchMendokusai/Tests/EditMode/SimulationTickSchedulerTest.cs` — 신규 EditMode 회귀(`RoadGraphTest` 패턴 답습).
- asmdef 변경 0 — DomainSDK 거주, EditMode 가 이미 references.

## 회귀 13 케이스 (NUnit)

- 생성자 검증 (`secondsPerTick > 0`, `maxStepsPerAdvance >= 1`)
- sub-tick 누적 → 합쳐서 1 tick fire / 정확 1 tick / 다중 tick + 잔여 누적
- spiral-of-death cap 초과 → drop, 폭주 catch-up 차단
- `SpeedMultiplier` 2x → 2 tick / 0 = pause / 음수 = pause 동등
- 0/음수 `dt` no-op
- `Reset` 스냅샷 복원 (config 보존) / 음수 인자 throw
- ★ **결정성**: 1 큰 dt vs 10 작은 dt → 동일 tick 수 + 동일 accumulator 종착 (프레임 슬라이싱 무관)

## Test plan

- [ ] Unity MCP `run_tests(EditMode, assemblyNames="WM.Tests.EditMode")` — `RoadGraphTest` 11/11 GREEN 유지 + `SimulationTickSchedulerTest` 13/13 GREEN.
- [ ] `read_console(types=["error","warning"], count=30)` — 0 entries (DomainSDK + Tests).
- [ ] graduate 파이프라인 (`.github/workflows/wm-agent-team-graduate.yml`) 자동 졸업 시 위 검증 실행.

> ⚠ Agent harness 외 Unity 검증: agent 가 Unity Editor MCP 직접 호출 불가 — graduate CI 가 머지 전 실행. POCO + NUnit `new()` 직접 사용이라 Unity 런타임 의존 0.

## 컨텍스트

- Phase 0 잔여(CityView 카메라) = Camera.prefab 안 신규 Cinemachine vcam 필요(binary asset, text 커밋만으로 불완전) → 별도 작업.
- Phase 1 step1 (RoadGraph, `da405e99`) 와 단일 chain — City 폴더 격리로 슬롯 A(WM-163) 와 충돌 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)