### PR TITLE
feat(TASK-WM-169): 보관 상자 Phase 1 INC-A — ChestInventory POCO + RuntimeData(JSON) 영속 substrate

### DIFF
--- a/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자.meta
+++ b/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4cefd03619ea4746b0e41df46de9f35a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestBuildingObject.cs
+++ b/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestBuildingObject.cs
@@ -31,7 +31,9 @@ namespace WitchMendokusai
 		private void OnDisable()
 		{
 			if (Chest != null)
+			{
 				Chest.OnDataChanged -= PersistToRuntimeData;
+			}
 			Chest = null;
 			persistOnChange = false;
 		}
@@ -57,7 +59,9 @@ namespace WitchMendokusai
 		private void PersistToRuntimeData()
 		{
 			if (persistOnChange == false || buildingObject == null)
+			{
 				return;
+			}
 			buildingObject.UpdateRuntimeData(ChestSaveData.FromChest(Chest).ToJson());
 		}
 	}

--- a/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestBuildingObject.cs
+++ b/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestBuildingObject.cs
@@ -1,0 +1,64 @@
+using System;
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// TASK-WM-169 Phase 1 — 상자 prefab 의 Model 에 붙는 컴포넌트. ChestInventory POCO 를 보유하고
+	// BuildingObject.SaveData.RuntimeData(string JSON) 슬롯에 직렬화/복원. FarmFieldObject 가 작물
+	// 상태로 동일 RuntimeData bridge 를 쓰는 검증된 패턴(prior art).
+	//
+	// IInteractable.OnInteract — Phase 1 INC-A 는 정적 이벤트만 발화하고 실 UI 패널은 INC-B
+	// 후속(에디터 prefab + UIManager 배선 = 사용자 영역). 게임 코드는 OnChestOpened 구독으로
+	// 자유롭게 UI 를 연결할 수 있다. EditMode 테스트도 이 이벤트로 OnInteract 호출을 관측 가능.
+	public class ChestBuildingObject : MonoBehaviour, IInteractable
+	{
+		public static event Action<ChestBuildingObject> OnChestOpened = delegate { };
+
+		[Header("_" + nameof(ChestBuildingObject))]
+		[SerializeField] private int defaultCapacity = 16;
+
+		public ChestInventory Chest { get; private set; }
+
+		private BuildingObject buildingObject;
+		private bool persistOnChange = false;
+
+		private void OnEnable()
+		{
+			buildingObject = GetComponentInParent<BuildingObject>();
+			LoadChestFromRuntimeData();
+		}
+
+		private void OnDisable()
+		{
+			if (Chest != null)
+				Chest.OnDataChanged -= PersistToRuntimeData;
+			Chest = null;
+			persistOnChange = false;
+		}
+
+		public void OnInteract()
+		{
+			OnChestOpened.Invoke(this);
+		}
+
+		private void LoadChestFromRuntimeData()
+		{
+			string json = buildingObject != null ? buildingObject.SaveData.RuntimeData : string.Empty;
+			ChestSaveData saveData = ChestSaveData.FromJson(json);
+			int capacity = saveData.Capacity > 0 ? saveData.Capacity : defaultCapacity;
+
+			persistOnChange = false;
+			Chest = new ChestInventory(capacity);
+			saveData.ApplyTo(Chest);
+			persistOnChange = true;
+			Chest.OnDataChanged += PersistToRuntimeData;
+		}
+
+		private void PersistToRuntimeData()
+		{
+			if (persistOnChange == false || buildingObject == null)
+				return;
+			buildingObject.UpdateRuntimeData(ChestSaveData.FromChest(Chest).ToJson());
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestBuildingObject.cs.meta
+++ b/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestBuildingObject.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3190ceb492bb4cf6adb5869735dcc819

--- a/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestInventory.cs
+++ b/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestInventory.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+
+namespace WitchMendokusai
+{
+	// TASK-WM-169 Phase 1 — per-Building 보관 인벤토리 POCO. 기존 Inventory(ScriptableObject)는
+	// 공유 자산이라 인스턴스당 한 개만 존재 → 상자별 내용물에는 부적합. ChestInventory 는 IInventory
+	// 정본 surface 만 구현하는 평범 객체로, ChestBuildingObject 가 BuildingObject.RuntimeData(JSON)
+	// 슬롯에 직렬화·복원한다(FarmRuntimeData 와 같은 RuntimeData bridge 패턴).
+	//
+	// Inventory.Add 의 countable/non-countable 알고리즘 동일 의미로 옮긴다(둘이 의미 다르면 상자가
+	// 메인 인벤과 다르게 동작 = 사용자 혼란). 미래 두 구현 합치려면 static 헬퍼로 추출 가능.
+	public class ChestInventory : IInventory
+	{
+		private const int NONE = -1;
+
+		public int Capacity { get; }
+		public List<Item> Slots { get; }
+
+		public event Action OnDataChanged = delegate { };
+
+		public ChestInventory(int capacity)
+		{
+			Capacity = capacity;
+			Slots = new List<Item>(capacity);
+			for (int i = 0; i < capacity; i++)
+				Slots.Add(null);
+		}
+
+		private int FindEmptySlotIndex(int startIndex = 0)
+		{
+			for (int i = startIndex; i < Capacity; i++)
+			{
+				if (Slots[i] == null)
+					return i;
+			}
+			return NONE;
+		}
+
+		public int FindItemIndex(int targetID, int startIndex = 0)
+		{
+			for (int i = startIndex; i < Capacity; i++)
+			{
+				Item current = Slots[i];
+				if (current == null)
+					continue;
+				if (current.Data.ID == targetID)
+					return i;
+			}
+			return NONE;
+		}
+
+		public int FindItemIndex(IItemData target, int startIndex = 0)
+		{
+			for (int i = startIndex; i < Capacity; i++)
+			{
+				Item current = Slots[i];
+				if (current == null)
+					continue;
+				if (current.Data == target)
+					return i;
+			}
+			return NONE;
+		}
+
+		public int Add(IItemData itemData, int amount = 1)
+		{
+			if (itemData.IsCountable)
+			{
+				bool findNextCountable = true;
+				int index = -1;
+
+				while (amount > 0)
+				{
+					if (findNextCountable)
+					{
+						index = FindItemIndex(itemData, index + 1);
+
+						if (index != NONE)
+						{
+							if (Slots[index].IsMax)
+							{
+								continue;
+							}
+							else
+							{
+								amount = Slots[index].AddAmountAndGetExcess(amount);
+							}
+						}
+						else
+						{
+							findNextCountable = false;
+						}
+					}
+					else
+					{
+						index = FindEmptySlotIndex(index + 1);
+						if (index == NONE)
+							break;
+
+						Item newItem = itemData.CreateItem();
+						newItem.SetAmount(amount);
+						Slots[index] = newItem;
+						amount = (amount > itemData.MaxAmount) ? (amount - itemData.MaxAmount) : 0;
+					}
+				}
+			}
+			else
+			{
+				int index;
+
+				if (amount == 1)
+				{
+					index = FindEmptySlotIndex();
+					if (index != NONE)
+					{
+						Slots[index] = itemData.CreateItem();
+						amount = 0;
+					}
+				}
+
+				index = -1;
+				for (; amount > 0; amount--)
+				{
+					index = FindEmptySlotIndex(index + 1);
+					if (index == NONE)
+						break;
+
+					Slots[index] = itemData.CreateItem();
+				}
+			}
+
+			OnDataChanged.Invoke();
+			return amount;
+		}
+
+		public void Remove(int index, int amount = 1)
+		{
+			if (IsValidIndex(index) == false)
+				return;
+
+			Item item = Slots[index];
+			if (item == null)
+				return;
+
+			if (item.Data.IsCountable)
+			{
+				item.SetAmount(item.Amount - amount);
+				if (item.IsEmpty)
+					Slots[index] = null;
+			}
+			else
+			{
+				Slots[index] = null;
+			}
+
+			OnDataChanged.Invoke();
+		}
+
+		public Item GetItem(int index)
+		{
+			if (IsValidIndex(index) == false)
+				return null;
+			return Slots[index];
+		}
+
+		public Item GetItem(Guid? guid)
+		{
+			if (guid == null)
+				return null;
+
+			foreach (Item item in Slots)
+			{
+				if (item == null)
+					continue;
+				if (item.Guid == guid)
+					return item;
+			}
+			return null;
+		}
+
+		public void SetItem(int index, Item item)
+		{
+			if (IsValidIndex(index) == false)
+				return;
+			Slots[index] = item;
+			OnDataChanged.Invoke();
+		}
+
+		public void SetItemAmount(int index, int amount)
+		{
+			if (IsValidIndex(index) == false)
+				return;
+			if (Slots[index] != null)
+				Slots[index].SetAmount(amount);
+			OnDataChanged.Invoke();
+		}
+
+		public int GetItemAmount(int itemID)
+		{
+			int amount = 0;
+			foreach (Item item in Slots)
+			{
+				if (item == null)
+					continue;
+				if (item.Data.ID == itemID)
+					amount += item.Amount;
+			}
+			return amount;
+		}
+
+		public IItemData GetItemData(int index)
+		{
+			if (IsValidIndex(index) == false)
+				return null;
+			return Slots[index]?.Data;
+		}
+
+		private bool IsValidIndex(int index) => index >= 0 && index < Capacity;
+	}
+}

--- a/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestInventory.cs
+++ b/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestInventory.cs
@@ -24,7 +24,9 @@ namespace WitchMendokusai
 			Capacity = capacity;
 			Slots = new List<Item>(capacity);
 			for (int i = 0; i < capacity; i++)
+			{
 				Slots.Add(null);
+			}
 		}
 
 		private int FindEmptySlotIndex(int startIndex = 0)
@@ -32,7 +34,9 @@ namespace WitchMendokusai
 			for (int i = startIndex; i < Capacity; i++)
 			{
 				if (Slots[i] == null)
+				{
 					return i;
+				}
 			}
 			return NONE;
 		}
@@ -43,9 +47,13 @@ namespace WitchMendokusai
 			{
 				Item current = Slots[i];
 				if (current == null)
+				{
 					continue;
+				}
 				if (current.Data.ID == targetID)
+				{
 					return i;
+				}
 			}
 			return NONE;
 		}
@@ -56,9 +64,13 @@ namespace WitchMendokusai
 			{
 				Item current = Slots[i];
 				if (current == null)
+				{
 					continue;
+				}
 				if (current.Data == target)
+				{
 					return i;
+				}
 			}
 			return NONE;
 		}
@@ -96,7 +108,9 @@ namespace WitchMendokusai
 					{
 						index = FindEmptySlotIndex(index + 1);
 						if (index == NONE)
+						{
 							break;
+						}
 
 						Item newItem = itemData.CreateItem();
 						newItem.SetAmount(amount);
@@ -124,7 +138,9 @@ namespace WitchMendokusai
 				{
 					index = FindEmptySlotIndex(index + 1);
 					if (index == NONE)
+					{
 						break;
+					}
 
 					Slots[index] = itemData.CreateItem();
 				}
@@ -137,17 +153,23 @@ namespace WitchMendokusai
 		public void Remove(int index, int amount = 1)
 		{
 			if (IsValidIndex(index) == false)
+			{
 				return;
+			}
 
 			Item item = Slots[index];
 			if (item == null)
+			{
 				return;
+			}
 
 			if (item.Data.IsCountable)
 			{
 				item.SetAmount(item.Amount - amount);
 				if (item.IsEmpty)
+				{
 					Slots[index] = null;
+				}
 			}
 			else
 			{
@@ -160,21 +182,29 @@ namespace WitchMendokusai
 		public Item GetItem(int index)
 		{
 			if (IsValidIndex(index) == false)
+			{
 				return null;
+			}
 			return Slots[index];
 		}
 
 		public Item GetItem(Guid? guid)
 		{
 			if (guid == null)
+			{
 				return null;
+			}
 
 			foreach (Item item in Slots)
 			{
 				if (item == null)
+				{
 					continue;
+				}
 				if (item.Guid == guid)
+				{
 					return item;
+				}
 			}
 			return null;
 		}
@@ -182,7 +212,9 @@ namespace WitchMendokusai
 		public void SetItem(int index, Item item)
 		{
 			if (IsValidIndex(index) == false)
+			{
 				return;
+			}
 			Slots[index] = item;
 			OnDataChanged.Invoke();
 		}
@@ -190,9 +222,13 @@ namespace WitchMendokusai
 		public void SetItemAmount(int index, int amount)
 		{
 			if (IsValidIndex(index) == false)
+			{
 				return;
+			}
 			if (Slots[index] != null)
+			{
 				Slots[index].SetAmount(amount);
+			}
 			OnDataChanged.Invoke();
 		}
 
@@ -202,9 +238,13 @@ namespace WitchMendokusai
 			foreach (Item item in Slots)
 			{
 				if (item == null)
+				{
 					continue;
+				}
 				if (item.Data.ID == itemID)
+				{
 					amount += item.Amount;
+				}
 			}
 			return amount;
 		}
@@ -212,7 +252,9 @@ namespace WitchMendokusai
 		public IItemData GetItemData(int index)
 		{
 			if (IsValidIndex(index) == false)
+			{
 				return null;
+			}
 			return Slots[index]?.Data;
 		}
 

--- a/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestInventory.cs.meta
+++ b/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestInventory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 609f3067767a4f0994972cb5db56ca91

--- a/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestSaveData.cs
+++ b/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestSaveData.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using static WitchMendokusai.SOHelper;
+
+namespace WitchMendokusai
+{
+	// TASK-WM-169 Phase 1 — ChestInventory 의 JsonUtility 친화 직렬화 DTO. BuildingInstanceData
+	// RuntimeData(string) 슬롯에 저장되어 GridData.Save/Load 와 함께 영속된다(FarmRuntimeData 패턴).
+	//
+	// 왜 InventorySlotSaveData 재사용 안 하나: 그 struct 는 Guid? 필드를 가지는데 JsonUtility 가
+	// Nullable<T> 직렬화를 지원하지 않음. 여기서는 Guid 를 string 으로 평탄화(빈 문자열 = 신규 GUID).
+	[Serializable]
+	public struct ChestSlotSaveData
+	{
+		public int SlotIndex;
+		public string GuidString;
+		public int ItemID;
+		public int Amount;
+
+		public ChestSlotSaveData(int slotIndex, Item item)
+		{
+			SlotIndex = slotIndex;
+			GuidString = item.Guid.HasValue ? item.Guid.Value.ToString() : string.Empty;
+			ItemID = item.Data.ID;
+			Amount = item.Amount;
+		}
+
+		public Item ToItem()
+		{
+			Guid? guid = string.IsNullOrEmpty(GuidString) ? null : Guid.Parse(GuidString);
+			return new Item(guid, GetItemData(ItemID), Amount);
+		}
+	}
+
+	[Serializable]
+	public struct ChestSaveData
+	{
+		public int Capacity;
+		public List<ChestSlotSaveData> Slots;
+
+		public static ChestSaveData FromChest(ChestInventory chest)
+		{
+			List<ChestSlotSaveData> slots = new();
+			for (int i = 0; i < chest.Slots.Count; i++)
+			{
+				Item item = chest.Slots[i];
+				if (item == null)
+					continue;
+				slots.Add(new ChestSlotSaveData(i, item));
+			}
+			return new ChestSaveData
+			{
+				Capacity = chest.Capacity,
+				Slots = slots
+			};
+		}
+
+		public void ApplyTo(ChestInventory chest)
+		{
+			for (int i = 0; i < chest.Capacity; i++)
+				chest.Slots[i] = null;
+
+			if (Slots == null)
+				return;
+
+			foreach (ChestSlotSaveData slot in Slots)
+			{
+				if (slot.SlotIndex < 0 || slot.SlotIndex >= chest.Capacity)
+					continue;
+				chest.Slots[slot.SlotIndex] = slot.ToItem();
+			}
+		}
+
+		public string ToJson() => JsonUtility.ToJson(this);
+
+		public static ChestSaveData FromJson(string json)
+		{
+			if (string.IsNullOrEmpty(json))
+				return new ChestSaveData { Capacity = 0, Slots = new List<ChestSlotSaveData>() };
+			return JsonUtility.FromJson<ChestSaveData>(json);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestSaveData.cs
+++ b/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestSaveData.cs
@@ -46,7 +46,9 @@ namespace WitchMendokusai
 			{
 				Item item = chest.Slots[i];
 				if (item == null)
+				{
 					continue;
+				}
 				slots.Add(new ChestSlotSaveData(i, item));
 			}
 			return new ChestSaveData
@@ -59,15 +61,21 @@ namespace WitchMendokusai
 		public void ApplyTo(ChestInventory chest)
 		{
 			for (int i = 0; i < chest.Capacity; i++)
+			{
 				chest.Slots[i] = null;
+			}
 
 			if (Slots == null)
+			{
 				return;
+			}
 
 			foreach (ChestSlotSaveData slot in Slots)
 			{
 				if (slot.SlotIndex < 0 || slot.SlotIndex >= chest.Capacity)
+				{
 					continue;
+				}
 				chest.Slots[slot.SlotIndex] = slot.ToItem();
 			}
 		}
@@ -77,7 +85,9 @@ namespace WitchMendokusai
 		public static ChestSaveData FromJson(string json)
 		{
 			if (string.IsNullOrEmpty(json))
+			{
 				return new ChestSaveData { Capacity = 0, Slots = new List<ChestSlotSaveData>() };
+			}
 			return JsonUtility.FromJson<ChestSaveData>(json);
 		}
 	}

--- a/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestSaveData.cs.meta
+++ b/Assets/_WitchMendokusai/Domain/Building/Building/4005_보관상자/ChestSaveData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 665ffbb39eb142d092b82a2548fde0fe

--- a/Assets/_WitchMendokusai/Tests/EditMode/ChestInventoryTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/ChestInventoryTest.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-169 Phase 1 INC-A — 보관 상자 데이터 substrate 잠금.
+	///
+	/// 핵심 3가지:
+	/// (1) ChestInventory(POCO IInventory) 의 Add/Remove/Find 의미가 메인 Inventory 와 동일,
+	/// (2) ChestSaveData JSON round-trip 이 capacity + 슬롯(인덱스/ID/수량/Guid) 보존,
+	/// (3) BuildingInstanceData.RuntimeData(string) 슬롯 ↔ GridData.Save/Load 와 함께 영속 — 즉
+	///     상자 배치 → 아이템 입출 → save → load → 내용물 유지 (behavior-verify 의 EditMode 등가).
+	///
+	/// SOManager bootstrap 없이 돌아가도록 TestItemData fake 사용(WorldStageCitySaveTest 동일
+	/// 정책 — 구조적 round-trip 만 검증, SO 해석 분리). Item.ToItem 의 SOHelper 호출 검증은 INC-B
+	/// 의 실 ItemData asset 통합에서.
+	/// </summary>
+	public sealed class ChestInventoryTest
+	{
+		private sealed class TestItemData : IItemData
+		{
+			public int ID { get; }
+			public int MaxAmount { get; }
+			public ItemType Type => ItemType.None;
+			public ItemGrade Grade => default;
+			public bool IsCountable => MaxAmount != 1;
+
+			public TestItemData(int id, int maxAmount)
+			{
+				ID = id;
+				MaxAmount = maxAmount;
+			}
+
+			public Item CreateItem() => new(Guid.NewGuid(), this, 1);
+		}
+
+		[Test]
+		public void Add_Countable_FillsExistingSlotThenOverflowsToEmpty()
+		{
+			ChestInventory chest = new(capacity: 4);
+			TestItemData seed = new(id: 101, maxAmount: 10);
+
+			int remaining = chest.Add(seed, 7);
+			Assert.That(remaining, Is.Zero, "용량 충분 — 잉여 0");
+			Assert.That(chest.GetItemAmount(101), Is.EqualTo(7));
+
+			remaining = chest.Add(seed, 5);
+			Assert.That(remaining, Is.Zero, "기존 슬롯 max=10 까지 채우고 빈 슬롯에 2 — 잉여 0");
+			Assert.That(chest.GetItemAmount(101), Is.EqualTo(12));
+			Assert.That(chest.GetItem(0).Amount, Is.EqualTo(10), "첫 슬롯 max");
+			Assert.That(chest.GetItem(1).Amount, Is.EqualTo(2), "둘째 슬롯 잉여분");
+		}
+
+		[Test]
+		public void Add_ExceedsCapacity_ReturnsRemainder()
+		{
+			ChestInventory chest = new(capacity: 2);
+			TestItemData seed = new(id: 200, maxAmount: 5);
+
+			int remaining = chest.Add(seed, 12);
+			Assert.That(remaining, Is.EqualTo(2), "용량 2 슬롯 × max 5 = 10 수용 → 12 중 2 잉여");
+			Assert.That(chest.GetItemAmount(200), Is.EqualTo(10));
+		}
+
+		[Test]
+		public void Remove_DecrementsThenClearsEmptySlot()
+		{
+			ChestInventory chest = new(capacity: 4);
+			TestItemData seed = new(id: 300, maxAmount: 10);
+			chest.Add(seed, 5);
+
+			chest.Remove(0, 2);
+			Assert.That(chest.GetItem(0).Amount, Is.EqualTo(3));
+
+			chest.Remove(0, 3);
+			Assert.That(chest.GetItem(0), Is.Null, "0 도달 시 슬롯 클리어");
+		}
+
+		[Test]
+		public void SaveData_RoundTrip_PreservesCapacityAndSlots()
+		{
+			ChestInventory original = new(capacity: 5);
+			TestItemData seedA = new(id: 401, maxAmount: 99);
+			TestItemData seedB = new(id: 402, maxAmount: 99);
+			original.Add(seedA, 12);
+			original.Add(seedB, 7);
+
+			ChestSaveData saved = ChestSaveData.FromChest(original);
+			string json = saved.ToJson();
+			ChestSaveData reloaded = ChestSaveData.FromJson(json);
+
+			Assert.That(reloaded.Capacity, Is.EqualTo(5), "용량 보존");
+			Assert.That(reloaded.Slots, Has.Count.EqualTo(2), "비는 슬롯 제외 2 개만");
+
+			ChestSlotSaveData slot0 = reloaded.Slots.First(s => s.SlotIndex == 0);
+			Assert.That(slot0.ItemID, Is.EqualTo(401));
+			Assert.That(slot0.Amount, Is.EqualTo(12));
+			Assert.That(slot0.GuidString, Is.Not.Empty, "Guid 보존(string 평탄화)");
+
+			ChestSlotSaveData slot1 = reloaded.Slots.First(s => s.SlotIndex == 1);
+			Assert.That(slot1.ItemID, Is.EqualTo(402));
+			Assert.That(slot1.Amount, Is.EqualTo(7));
+		}
+
+		[Test]
+		public void SaveData_FromJson_EmptyOrNull_ReturnsEmptySafely()
+		{
+			ChestSaveData fromEmpty = ChestSaveData.FromJson(string.Empty);
+			Assert.That(fromEmpty.Slots, Is.Not.Null, "빈 JSON → 빈 슬롯 리스트(NRE 금지)");
+			Assert.That(fromEmpty.Capacity, Is.Zero);
+
+			ChestSaveData fromNull = ChestSaveData.FromJson(null);
+			Assert.That(fromNull.Slots, Is.Not.Null);
+		}
+
+		[Test]
+		public void GridDataRoundTrip_PreservesChestRuntimeData()
+		{
+			// 핵심 영속 시나리오 — 상자 배치 → 인벤 채움 → GridData Save → Load → 내용물 유지.
+			// BuildingInstanceData.RuntimeData(string) 가 GridData 와 함께 직렬화되는 단일 채널.
+			//
+			// 복원 측은 ChestSaveData 구조만 검증한다. Item 으로의 재구성(ApplyTo)은 SOHelper 를
+			// 거쳐 실 ItemData asset 을 해석하므로 SOManager bootstrap 이 필요 — 그 부분은 PlayMode/
+			// integration 영역. 여기서는 RuntimeData 가 그대로 살아남아 같은 슬롯/ID/수량으로 디코딩
+			// 됨을 보장하면 충분(WorldStageCitySaveTest 가 BuildingID 만 보는 정책과 정합).
+			ChestInventory chestA = new(capacity: 3);
+			TestItemData seed = new(id: 500, maxAmount: 99);
+			chestA.Add(seed, 8);
+			string chestJsonA = ChestSaveData.FromChest(chestA).ToJson();
+
+			GridData original = new();
+			Vector3Int pivot = new(2, 3, 0);
+			original.AddBuildingAt(pivot, new BuildingInstanceData(
+				buildingID: 4005,
+				state: BuildingState.Placed,
+				level: 1,
+				runtimeData: chestJsonA));
+
+			List<KeyValuePair<Vector3Int, BuildingInstanceData>> serialized = original.Save();
+
+			GridData restored = new();
+			restored.Load(serialized);
+
+			Assert.That(restored.HasBuildingAt(pivot), Is.True, "건물 복원");
+			Assert.That(restored.TryGetBuildingAt(pivot, out BuildingInstanceData data), Is.True);
+			Assert.That(data.RuntimeData, Is.Not.Empty, "RuntimeData 유지");
+
+			ChestSaveData decoded = ChestSaveData.FromJson(data.RuntimeData);
+			Assert.That(decoded.Capacity, Is.EqualTo(3));
+			Assert.That(decoded.Slots, Has.Count.EqualTo(1));
+			Assert.That(decoded.Slots[0].ItemID, Is.EqualTo(500), "상자 내용물(아이템 500)");
+			Assert.That(decoded.Slots[0].Amount, Is.EqualTo(8), "수량 8 유지");
+		}
+
+		[Test]
+		public void OnDataChanged_FiresOnAddAndRemove()
+		{
+			ChestInventory chest = new(capacity: 4);
+			TestItemData seed = new(id: 700, maxAmount: 10);
+			int callCount = 0;
+			chest.OnDataChanged += () => callCount++;
+
+			chest.Add(seed, 3);
+			Assert.That(callCount, Is.EqualTo(1), "Add 시 발화");
+
+			chest.Remove(0, 1);
+			Assert.That(callCount, Is.EqualTo(2), "Remove 시 발화");
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/ChestInventoryTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/ChestInventoryTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 01a3c1375ea840c5b3e549e8f8475ef4


### PR DESCRIPTION
## Summary

TASK-WM-169 Phase 1 INC-A — 거점 건설 심화의 첫 증분 **보관 상자** 데이터 substrate.

생존/크래프팅 갭(`memo/wm/design/systems/survival-crafting-gap.md`)에서 **near-universal 인데 코드 전무**로 확정된 `보관 상자/컨테이너`. 기존 Building / GridData / Inventory / Save full 시스템 위에 **새 레이어 0** 으로 조립 — substrate-first(평행표면 회피).

- **`ChestInventory`** — POCO `IInventory` 구현. 메인 `Inventory`(ScriptableObject 공유 자산)와 별개로 Building 인스턴스당 한 개. Add/Remove/Find 의미는 메인 Inventory 와 동일(둘이 다르면 UX 혼란).
- **`ChestSaveData`** — `JsonUtility` 친화 DTO. Capacity + 평탄화된 슬롯(Guid string). `InventorySlotSaveData` 재사용 안 한 이유 = `Guid?` 가 `JsonUtility` 지원 밖.
- **`ChestBuildingObject`** — MonoBehaviour, `IInteractable`. `BuildingObject.RuntimeData(string)` 슬롯에 직렬화/복원. `FarmFieldObject` 의 RuntimeData bridge prior art 그대로. `OnInteract` 는 정적 이벤트 `OnChestOpened` 발화만 — UI 패널 배선은 **INC-B**(에디터 prefab + UIManager = 사용자 영역).
- **EditMode 테스트 7 케이스** (`ChestInventoryTest.cs`):
  Add countable/overflow/cap, Remove 슬롯 클리어, JSON round-trip, 빈 JSON 안전(NRE 금지), GridData round-trip 영속, OnDataChanged 발화.

## INC-A 미포함 — INC-B 후속 (에디터·시각 영역, 사용자 컨펌 필요)

- [ ] `BD_4005_보관상자.asset` (Building SO, Type=Util) — `WM/Variable/Building` 메뉴로 생성
- [ ] 상자 모델 prefab + Collider (`Building.Prefab` 슬롯)
- [ ] 상자 prefab 에 `ChestBuildingObject` + `InteractiveObject` 컴포넌트 부착
- [ ] `ChestPanel` UI prefab (기존 UIItemGrid 파생 또는 신규 — IInventory 직접 타깃)
- [ ] `UIManager` 에 `ChestPanel` 등록 + `ChestBuildingObject.OnChestOpened` 구독
- [ ] 실 PlayMode behavior-verify: 상자 배치 → 아이템 넣기 → 씬/게임 리로드 → 내용물 유지

## 룰 정합

- **6 동기 매핑** 우선그룹 1(분리·미래·퀄리티) 충족 — `BuildingInstanceData.RuntimeData` 슬롯이 이미 존재해 데이터 모델 변경 0(옛 세이브 호환 자동).
- **수치 노출** — `defaultCapacity = 16` `[SerializeField]` 로 노출, prefab 단위 override 가능. 하드코딩 없음.
- **FastFail 유지** — defensive try/catch 없음. `IInventory` contract 위반(범위 밖 인덱스 등)은 조용한 no-op(메인 Inventory 와 동일 의미).
- **InputManager 룰** — 본 PR 입력 이벤트 추가 없음 (chest interaction = 기존 `InteractiveObject` 경유).
- **DomainSDK asmdef** — chest 코드 전부 Domain 층(`WitchMendokusai` 네임스페이스 공유). DomainSDK 신규 타입 0 (격상 안 함 — 6 동기 LAST step 정책).

## 의존 / 조율

- ⚠ **slot B (TASK-WM-166 City / WorldStage)** 영역 일부 침범 — `GridData.AddBuildingAt` 의 `BuildingInstanceData.runtimeData` 슬롯 사용. 데이터 모델 자체는 변경 안 함(슬롯 활용만). 회귀 없음.

## Test plan

- [ ] **MCP `read_console(types=["error","warning"], count=30)` 0 entries** — autopilot 환경 미실행(Unity Editor 미가동). **Editor 재가동 후 필수 검증.**
- [ ] `WM.Tests.EditMode` 실행 — `ChestInventoryTest` 7 케이스 + 기존 회귀 GREEN
- [ ] 기존 건물(BD_0~5000) 배치/제거/세이브 회귀 0 (`BuildingInstanceData` 데이터 변경 없음 — 자동)
- [ ] **INC-B 진입 시**: 실 chest prefab/UI 후 Play 모드 behavior-verify(상자 → 아이템 → 리로드)

## cross-link

- 조사 정본: `memo/wm/design/systems/survival-crafting-gap.md` §3.1(보관상자/조각세트/토대 = 코드 전무), §6(방향 후보 B)
- 현황 인덱스: `memo/wm/design/systems/status.md` § 건설
- prior art: `Assets/_WitchMendokusai/Domain/Farming/Scripts/FarmRuntimeData.cs` + `FarmFieldObject.cs` — RuntimeData(JSON) bridge 패턴
- TASK 스펙: `memo/wm/tasks/TASK-WM-169-거점-건설-심화.md` (cwd 밖 — 봇이 별도 반영)

---

⚠ **autopilot 환경 노트**: 본 세션 worktree 가 `git-hygiene-scheduled` 18:00 실행으로 부분 삭제됨 → recovery worktree(`-recover` suffix)에서 작업 재개. 브랜치/커밋 무결성 유지, 새 worktree 는 git worktree list 에 정상 등록됨. PR 머지/squash 후 양쪽 worktree 정리 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
