### PR TITLE
feat(TASK-WM-170): 「낮의 마계, 밤의 공방」 듀얼루프 자원 브리지 Phase 0

### DIFF
--- a/Assets/_WitchMendokusai/DomainSDK/Workshop.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f9c97bd9d81412dbbc4147c9fc6db7e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/DayEfficiencyCoefficients.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/DayEfficiencyCoefficients.cs
@@ -1,0 +1,31 @@
+namespace WitchMendokusai.DomainSDK.Workshop
+{
+	/// <summary>
+	/// TASK-WM-170 Phase 0 — 듀얼루프 브리지 계수: "밤 골드 → 다음 낮 채집 효율 증대" 환산식.
+	/// 순수 값(POCO) — <see cref="DayEfficiencyModel"/> 가 주입받아 평가. 게임 배선에선 SO 가 공급.
+	///
+	/// 디폴트값 없음 — 공급자가 명시(하드코딩 회피, 같은 수치 두 곳 박기 X). City RciDemandCoefficients 동형.
+	/// </summary>
+	public readonly struct DayEfficiencyCoefficients
+	{
+		/// <summary>투자 0 일 때 기준 효율 (보통 1.0 — 채집 베이스 그대로).</summary>
+		public readonly float BaseEfficiency;
+
+		/// <summary>1 step 효율 증가에 필요한 골드 (낮을수록 빠른 성장 — 시드라 매끄러운 curve 아니어도 OK).</summary>
+		public readonly float GoldPerEfficiencyStep;
+
+		/// <summary>1 step 당 효율에 더해지는 양 (0.2 = 매 step 마다 +20%).</summary>
+		public readonly float EfficiencyPerStep;
+
+		/// <summary>효율 상한 — 무한 인플레 차단. 가격·재료 밸런스 깨짐 방지.</summary>
+		public readonly float MaxEfficiency;
+
+		public DayEfficiencyCoefficients(float baseEfficiency, float goldPerEfficiencyStep, float efficiencyPerStep, float maxEfficiency)
+		{
+			BaseEfficiency = baseEfficiency;
+			GoldPerEfficiencyStep = goldPerEfficiencyStep;
+			EfficiencyPerStep = efficiencyPerStep;
+			MaxEfficiency = maxEfficiency;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/DayEfficiencyCoefficients.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/DayEfficiencyCoefficients.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 30a84eb4134e4a74b6b4b3188f628c0b

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/DayEfficiencyModel.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/DayEfficiencyModel.cs
@@ -1,0 +1,45 @@
+namespace WitchMendokusai.DomainSDK.Workshop
+{
+	/// <summary>
+	/// TASK-WM-170 Phase 0 — 듀얼루프 브리지 코어: "골드 누계 투자량 → 낮 채집 효율" 순수 함수.
+	/// MonoBehaviour/VContainer/PlayMode 0 — new() 직접. <see cref="WorkshopLedger"/> 가 호출.
+	///
+	/// 식: efficiency = clamp(base + floor(invested / goldPerStep) * efficiencyPerStep, .., maxEfficiency)
+	/// floor 로 step 화 → 정수 산술 결정성 + UI 에서 "n step 도달" 표현 직관.
+	/// </summary>
+	public static class DayEfficiencyModel
+	{
+		public static float Evaluate(int goldInvested, DayEfficiencyCoefficients coefficients)
+		{
+			if (goldInvested <= 0 || coefficients.GoldPerEfficiencyStep <= 0f)
+			{
+				return Clamp(coefficients.BaseEfficiency, coefficients);
+			}
+
+			int steps = (int)(goldInvested / coefficients.GoldPerEfficiencyStep);
+			float raw = coefficients.BaseEfficiency + steps * coefficients.EfficiencyPerStep;
+			return Clamp(raw, coefficients);
+		}
+
+		/// <summary>base 채집량 × 효율 → 실제 수확량(정수, 내림). 음수 효율은 0 처리.</summary>
+		public static int ScaleCollection(int baseAmount, float efficiency)
+		{
+			if (baseAmount <= 0 || efficiency <= 0f)
+			{
+				return 0;
+			}
+
+			return (int)(baseAmount * efficiency);
+		}
+
+		private static float Clamp(float value, DayEfficiencyCoefficients coefficients)
+		{
+			if (value > coefficients.MaxEfficiency)
+			{
+				return coefficients.MaxEfficiency;
+			}
+
+			return value;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/DayEfficiencyModel.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/DayEfficiencyModel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1788076a558a42adbfc2a3518189c33e

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/DayNightCycle.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/DayNightCycle.cs
@@ -1,0 +1,41 @@
+namespace WitchMendokusai.DomainSDK.Workshop
+{
+	/// <summary>
+	/// TASK-WM-170 Phase 0 — 듀얼루프 단계 전환 상태. 순수 POCO (DomainSDK, MonoBehaviour 무관).
+	/// Phase 전환 = Day → Night → Day(다음날 인덱스+1). Dave the Diver 공식의 낮↔밤 교대를 추상화.
+	///
+	/// 본격 슬라이스에선 TimeManager.OnTimeOfDayChanged 같은 기존 시간 시스템이 Advance() 호출.
+	/// 여긴 순수 상태기 — 트리거(누가 Advance 호출하는가)는 Domain/Core 책임.
+	/// </summary>
+	public sealed class DayNightCycle
+	{
+		public DayNightPhase Phase { get; private set; }
+
+		/// <summary>0-based 누계 일수. 매 Night→Day 전환 시 +1 (1사이클 닫힘 카운터).</summary>
+		public int DayIndex { get; private set; }
+
+		public DayNightCycle()
+			: this(DayNightPhase.Day, 0)
+		{
+		}
+
+		public DayNightCycle(DayNightPhase startPhase, int startDayIndex)
+		{
+			Phase = startPhase;
+			DayIndex = startDayIndex;
+		}
+
+		public void Advance()
+		{
+			if (Phase == DayNightPhase.Day)
+			{
+				Phase = DayNightPhase.Night;
+			}
+			else
+			{
+				Phase = DayNightPhase.Day;
+				DayIndex = DayIndex + 1;
+			}
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/DayNightCycle.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/DayNightCycle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a8e2e7feab12412381b01553b69023a2

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/DayNightPhase.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/DayNightPhase.cs
@@ -1,0 +1,13 @@
+namespace WitchMendokusai.DomainSDK.Workshop
+{
+	/// <summary>
+	/// TASK-WM-170 Phase 0 — 듀얼루프(낮 마계 / 밤 공방)의 현재 단계. 순수 enum (DomainSDK).
+	/// 낮 = 채집·전투(WM-165 투기장/탐험 재활용 입력원), 밤 = 공방 운영(제조·판매).
+	/// 본격 슬라이스에선 TimeManager / WorldClock 의 시각이 이쪽으로 매핑.
+	/// </summary>
+	public enum DayNightPhase
+	{
+		Day = 0,
+		Night = 1,
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/DayNightPhase.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/DayNightPhase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8274f68609d346679c88b1939bac4399

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/MaterialCost.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/MaterialCost.cs
@@ -1,0 +1,18 @@
+namespace WitchMendokusai.DomainSDK.Workshop
+{
+	/// <summary>
+	/// TASK-WM-170 Phase 0 — 상품 1개 제조에 필요한 재료 종류·수량. <see cref="WorkshopProduct"/> 의 레시피 원소.
+	/// 순수 readonly struct — 비교·전송 가벼움.
+	/// </summary>
+	public readonly struct MaterialCost
+	{
+		public readonly MaterialId Material;
+		public readonly int Amount;
+
+		public MaterialCost(MaterialId material, int amount)
+		{
+			Material = material;
+			Amount = amount;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/MaterialCost.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/MaterialCost.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7ad24e4c708e418f9b06df96aad03e2a

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/MaterialId.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/MaterialId.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace WitchMendokusai.DomainSDK.Workshop
+{
+	/// <summary>
+	/// TASK-WM-170 Phase 0 — 공방 재료 식별자(데이터주도). 마계 전리품·재배·구매 등 어떤 입력원이든
+	/// 동일한 정수 키로 다룬다. 모드/UGC 가 정의한 새 재료도 그대로 흐름 (6 동기 모딩/UGC).
+	///
+	/// City.ResourceId 와 같은 패턴 — 다만 City 경제와 공방 경제는 의도적으로 분리(스케일 다름).
+	/// 본격 슬라이스에서 ItemData 와 매핑 SO 가 추가될 수 있음.
+	/// </summary>
+	public readonly struct MaterialId : IEquatable<MaterialId>
+	{
+		public readonly int Value;
+
+		public MaterialId(int value)
+		{
+			Value = value;
+		}
+
+		public bool Equals(MaterialId other) => Value == other.Value;
+
+		public override bool Equals(object obj) => obj is MaterialId other && Equals(other);
+
+		public override int GetHashCode() => Value;
+
+		public override string ToString() => $"Material({Value})";
+
+		public static bool operator ==(MaterialId left, MaterialId right) => left.Equals(right);
+
+		public static bool operator !=(MaterialId left, MaterialId right) => left.Equals(right) == false;
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/MaterialId.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/MaterialId.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d7044a3a12cf484c88ae795567711e15

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/ProductSale.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/ProductSale.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace WitchMendokusai.DomainSDK.Workshop
+{
+	/// <summary>
+	/// TASK-WM-170 Phase 0 — 공방 상품 제조/판매 순수 함수. 상태 0, MonoBehaviour 무관, EditMode 직접.
+	/// 재고 충분성 판정 + 매출 환산을 분리해 두면 <see cref="WorkshopLedger"/> 외 다른 사용처(시뮬레이션,
+	/// 가격 미리보기 UI 등)에서도 같은 식을 빌려 쓸 수 있다.
+	/// </summary>
+	public static class ProductSale
+	{
+		/// <summary>주어진 재고로 상품 1개를 제조할 수 있는가 — 모든 재료가 요구량 이상이면 true.</summary>
+		public static bool CanProduce(IReadOnlyDictionary<MaterialId, int> stock, WorkshopProduct product)
+		{
+			foreach (MaterialCost cost in product.Materials)
+			{
+				if (stock.TryGetValue(cost.Material, out int available) == false)
+				{
+					return false;
+				}
+
+				if (available < cost.Amount)
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		/// <summary>주어진 판매 수량의 총 매출(골드). 음수 수량은 0 으로 환산(외부 호출자 보호).</summary>
+		public static int Revenue(WorkshopProduct product, int unitsSold)
+		{
+			if (unitsSold <= 0)
+			{
+				return 0;
+			}
+
+			return product.SalePrice * unitsSold;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/ProductSale.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/ProductSale.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 37fe6809b7214ce7934b6bf48ff1188b

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/WorkshopLedger.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/WorkshopLedger.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+
+namespace WitchMendokusai.DomainSDK.Workshop
+{
+	/// <summary>
+	/// TASK-WM-170 Phase 0 — 듀얼루프(낮 마계 / 밤 공방) 자원 수지 원장. 순수 POCO (DomainSDK).
+	/// 낮 산출(채집) → 재료 재고 → 밤 제조(재료 차감) → 판매(골드 +) → 다음 낮 효율 투자(골드 -) 1사이클 닫힘.
+	///
+	/// City CityEconomy 와 같은 "누계 재고 원장" 패턴(데이터주도 키, 음수 방지는 호출자/메서드 자체 책임).
+	/// 차이: 공방은 단일 가게 미시 운영이라 골드 + 효율 누계까지 한 곳에서 묶는다.
+	///
+	/// 본격 슬라이스에선 ISavable 직렬화 + EventBus 이벤트 발행이 위에 얹힘 — Phase 0 은 순수 산술만.
+	/// </summary>
+	public sealed class WorkshopLedger
+	{
+		private readonly Dictionary<MaterialId, int> stock = new();
+
+		public IReadOnlyDictionary<MaterialId, int> Stock => stock;
+
+		/// <summary>판매로 누적된 골드. 효율 투자로 차감.</summary>
+		public int Gold { get; private set; }
+
+		/// <summary>지금까지 다음 낮 채집 효율에 투자한 누계 골드. <see cref="DayEfficiencyModel"/> 입력.</summary>
+		public int GoldInvestedInDayEfficiency { get; private set; }
+
+		public int GetStock(MaterialId material)
+		{
+			return stock.TryGetValue(material, out int amount) ? amount : 0;
+		}
+
+		/// <summary>낮 루프(마계 채집) 결과 — 재료 재고에 추가. 0/음수는 무효.</summary>
+		public void CollectMaterial(MaterialId material, int amount)
+		{
+			if (amount <= 0)
+			{
+				return;
+			}
+
+			stock[material] = GetStock(material) + amount;
+		}
+
+		/// <summary>밤 루프(공방 제조) — 재료 충분하면 차감하고 true. 부족하면 재고 불변 + false.</summary>
+		public bool TryManufacture(WorkshopProduct product)
+		{
+			if (ProductSale.CanProduce(stock, product) == false)
+			{
+				return false;
+			}
+
+			foreach (MaterialCost cost in product.Materials)
+			{
+				stock[cost.Material] = stock[cost.Material] - cost.Amount;
+			}
+
+			return true;
+		}
+
+		/// <summary>밤 루프 — 판매 매출을 골드에 누적. 음수 수량은 무효(외부 호출자 보호).</summary>
+		public void SellProduct(WorkshopProduct product, int unitsSold)
+		{
+			Gold = Gold + ProductSale.Revenue(product, unitsSold);
+		}
+
+		/// <summary>다음 낮 채집 효율 강화 — 골드 부족 시 false (트랜잭션 보존).</summary>
+		public bool InvestInDayEfficiency(int goldAmount)
+		{
+			if (goldAmount <= 0)
+			{
+				return false;
+			}
+
+			if (Gold < goldAmount)
+			{
+				return false;
+			}
+
+			Gold = Gold - goldAmount;
+			GoldInvestedInDayEfficiency = GoldInvestedInDayEfficiency + goldAmount;
+			return true;
+		}
+
+		/// <summary>현재 누적 투자에 따른 채집 효율 (호출자가 ScaleCollection 으로 base 채집량에 적용).</summary>
+		public float CurrentDayEfficiency(DayEfficiencyCoefficients coefficients)
+		{
+			return DayEfficiencyModel.Evaluate(GoldInvestedInDayEfficiency, coefficients);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/WorkshopLedger.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/WorkshopLedger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c6a7c8f431c94b6084cf7628bfb7fad4

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/WorkshopProduct.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/WorkshopProduct.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace WitchMendokusai.DomainSDK.Workshop
+{
+	/// <summary>
+	/// TASK-WM-170 Phase 0 — 공방 상품 정의(레시피 + 판매가). 순수 POCO (DomainSDK).
+	/// 본격 슬라이스에선 WorkshopProductSO(Domain) 가 공급원, 모드가 새 상품 주입.
+	///
+	/// 가격은 정수 골드 — 정수 산술 결정성. 부동소수 가격이 필요하면 별도 모델로 분리(EditMode 잠금 깨짐 회피).
+	/// </summary>
+	public sealed class WorkshopProduct
+	{
+		public int ProductId { get; }
+		public IReadOnlyList<MaterialCost> Materials { get; }
+		public int SalePrice { get; }
+
+		public WorkshopProduct(int productId, IReadOnlyList<MaterialCost> materials, int salePrice)
+		{
+			ProductId = productId;
+			Materials = materials;
+			SalePrice = salePrice;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Workshop/WorkshopProduct.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Workshop/WorkshopProduct.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4187cb83170543c3ab35f2a843c2f1ea

--- a/Assets/_WitchMendokusai/Tests/EditMode/Workshop.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/Workshop.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e5d9600fc924b3da36b390c80c21348
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Tests/EditMode/Workshop/WorkshopLedgerTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/Workshop/WorkshopLedgerTest.cs
@@ -1,0 +1,248 @@
+using NUnit.Framework;
+using WitchMendokusai.DomainSDK.Workshop;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-170 Phase 0 — 「낮의 마계, 밤의 공방」 듀얼루프 자원 브리지 회귀 잠금.
+	///
+	/// 검증 축:
+	///  - DayNightCycle 단계 전환 + 일수 카운터 결정성.
+	///  - 채집 → 재고 누적 / 제조 가능·불가 판정 / 판매 → 골드.
+	///  - 효율 투자 트랜잭션(부족 시 보존) + 효율 step 함수 단조·clamp.
+	///  - "1사이클 닫힘": 낮 채집 → 밤 제조·판매 → 효율 투자 → 다음 낮 채집량 증가.
+	///
+	/// 순수 — MonoBehaviour/VContainer/PlayMode 0. new() 직접.
+	/// 실행: unity -runTests -batchmode -testPlatform EditMode -assemblyNames WM.Tests.EditMode
+	/// </summary>
+	public sealed class WorkshopLedgerTest
+	{
+		private static readonly MaterialId MagicHerb = new(1);
+		private static readonly MaterialId DemonBone = new(2);
+
+		private static WorkshopProduct MakePotion(int salePrice = 30)
+		{
+			return new WorkshopProduct(
+				productId: 1,
+				materials: new[]
+				{
+					new MaterialCost(MagicHerb, 2),
+					new MaterialCost(DemonBone, 1),
+				},
+				salePrice: salePrice);
+		}
+
+		private static DayEfficiencyCoefficients Coeffs()
+		{
+			return new DayEfficiencyCoefficients(
+				baseEfficiency: 1f,
+				goldPerEfficiencyStep: 50f,
+				efficiencyPerStep: 0.2f,
+				maxEfficiency: 3f);
+		}
+
+		[Test]
+		public void DayNightCycle_Advance_DayToNight_PreservesDayIndex()
+		{
+			DayNightCycle cycle = new(DayNightPhase.Day, 0);
+
+			cycle.Advance();
+
+			Assert.That(cycle.Phase, Is.EqualTo(DayNightPhase.Night), "낮 → 밤");
+			Assert.That(cycle.DayIndex, Is.EqualTo(0), "낮→밤 전환은 일수 증가 X(아직 1일 안 끝남)");
+		}
+
+		[Test]
+		public void DayNightCycle_Advance_NightToDay_IncrementsDayIndex()
+		{
+			DayNightCycle cycle = new(DayNightPhase.Night, 0);
+
+			cycle.Advance();
+
+			Assert.That(cycle.Phase, Is.EqualTo(DayNightPhase.Day), "밤 → 다음 날 아침");
+			Assert.That(cycle.DayIndex, Is.EqualTo(1), "밤→낮 = 1사이클 닫힘 → 일수 +1");
+		}
+
+		[Test]
+		public void CollectMaterial_AccumulatesStock()
+		{
+			WorkshopLedger ledger = new();
+
+			ledger.CollectMaterial(MagicHerb, 5);
+			ledger.CollectMaterial(MagicHerb, 3);
+
+			Assert.That(ledger.GetStock(MagicHerb), Is.EqualTo(8));
+		}
+
+		[Test]
+		public void CollectMaterial_NonPositive_Ignored()
+		{
+			WorkshopLedger ledger = new();
+
+			ledger.CollectMaterial(MagicHerb, 0);
+			ledger.CollectMaterial(MagicHerb, -5);
+
+			Assert.That(ledger.GetStock(MagicHerb), Is.EqualTo(0), "0/음수 채집은 무효");
+		}
+
+		[Test]
+		public void TryManufacture_StockInsufficient_FalseAndStockPreserved()
+		{
+			WorkshopLedger ledger = new();
+			ledger.CollectMaterial(MagicHerb, 1);
+
+			bool produced = ledger.TryManufacture(MakePotion());
+
+			Assert.That(produced, Is.False, "재료 부족 → 제조 불가");
+			Assert.That(ledger.GetStock(MagicHerb), Is.EqualTo(1), "실패는 재고 소비 X (트랜잭션 보존)");
+			Assert.That(ledger.GetStock(DemonBone), Is.EqualTo(0));
+		}
+
+		[Test]
+		public void TryManufacture_StockSufficient_TrueAndMaterialsConsumed()
+		{
+			WorkshopLedger ledger = new();
+			ledger.CollectMaterial(MagicHerb, 5);
+			ledger.CollectMaterial(DemonBone, 3);
+
+			bool produced = ledger.TryManufacture(MakePotion());
+
+			Assert.That(produced, Is.True);
+			Assert.That(ledger.GetStock(MagicHerb), Is.EqualTo(3), "Herb 2 차감");
+			Assert.That(ledger.GetStock(DemonBone), Is.EqualTo(2), "Bone 1 차감");
+		}
+
+		[Test]
+		public void SellProduct_AccumulatesGold()
+		{
+			WorkshopLedger ledger = new();
+
+			ledger.SellProduct(MakePotion(salePrice: 30), unitsSold: 4);
+
+			Assert.That(ledger.Gold, Is.EqualTo(120));
+		}
+
+		[Test]
+		public void SellProduct_NonPositiveUnits_NoOp()
+		{
+			WorkshopLedger ledger = new();
+
+			ledger.SellProduct(MakePotion(salePrice: 30), unitsSold: 0);
+			ledger.SellProduct(MakePotion(salePrice: 30), unitsSold: -2);
+
+			Assert.That(ledger.Gold, Is.EqualTo(0), "0/음수 판매는 골드 변화 X");
+		}
+
+		[Test]
+		public void InvestInDayEfficiency_GoldSufficient_DeductsAndAccumulatesInvestment()
+		{
+			WorkshopLedger ledger = new();
+			ledger.SellProduct(MakePotion(salePrice: 100), unitsSold: 2); // gold 200
+
+			bool invested = ledger.InvestInDayEfficiency(150);
+
+			Assert.That(invested, Is.True);
+			Assert.That(ledger.Gold, Is.EqualTo(50));
+			Assert.That(ledger.GoldInvestedInDayEfficiency, Is.EqualTo(150));
+		}
+
+		[Test]
+		public void InvestInDayEfficiency_GoldInsufficient_FalseAndStatePreserved()
+		{
+			WorkshopLedger ledger = new();
+			ledger.SellProduct(MakePotion(salePrice: 10), unitsSold: 1); // gold 10
+
+			bool invested = ledger.InvestInDayEfficiency(50);
+
+			Assert.That(invested, Is.False, "골드 부족 → 투자 거부");
+			Assert.That(ledger.Gold, Is.EqualTo(10), "실패는 골드 보존");
+			Assert.That(ledger.GoldInvestedInDayEfficiency, Is.EqualTo(0));
+		}
+
+		[Test]
+		public void DayEfficiencyModel_ZeroInvestment_ReturnsBaseEfficiency()
+		{
+			float efficiency = DayEfficiencyModel.Evaluate(0, Coeffs());
+
+			Assert.That(efficiency, Is.EqualTo(1f), "투자 0 = baseEfficiency");
+		}
+
+		[Test]
+		public void DayEfficiencyModel_OneStep_AddsEfficiencyPerStep()
+		{
+			float oneStep = DayEfficiencyModel.Evaluate(50, Coeffs());
+
+			Assert.That(oneStep, Is.EqualTo(1.2f).Within(0.001f), "1 step = base + perStep");
+		}
+
+		[Test]
+		public void DayEfficiencyModel_AboveCeiling_ClampedToMax()
+		{
+			float efficiency = DayEfficiencyModel.Evaluate(10_000, Coeffs());
+
+			Assert.That(efficiency, Is.EqualTo(3f), "ceiling 너머 invest 해도 maxEfficiency");
+		}
+
+		[Test]
+		public void DayEfficiencyModel_MonotonicallyNonDecreasing()
+		{
+			DayEfficiencyCoefficients coeffs = Coeffs();
+
+			// 같은 step 안에선 평탄, step 경계 넘으면 +. 절대 감소 X.
+			float prev = DayEfficiencyModel.Evaluate(0, coeffs);
+			for (int gold = 1; gold <= 500; gold += 1)
+			{
+				float current = DayEfficiencyModel.Evaluate(gold, coeffs);
+				Assert.That(current, Is.GreaterThanOrEqualTo(prev), $"투자 {gold} 에서 효율 감소 발견");
+				prev = current;
+			}
+		}
+
+		[Test]
+		public void DualLoop_SingleCycle_Closes_NextDayCollectsMore()
+		{
+			// 1사이클 수치 닫힘 — Phase 0 검수 메인.
+			// 낮1(eff 1.0) → 채집 → 밤1 → 제조·판매 → 골드 → 효율 투자 → 낮2(eff > 1.0)
+			DayEfficiencyCoefficients coeffs = Coeffs();
+			WorkshopLedger ledger = new();
+			DayNightCycle cycle = new();
+
+			// --- 낮 1 ---
+			Assert.That(cycle.Phase, Is.EqualTo(DayNightPhase.Day));
+			float dayOneEff = ledger.CurrentDayEfficiency(coeffs);
+			Assert.That(dayOneEff, Is.EqualTo(1f), "첫 낮은 baseline");
+
+			int dayOneHerbs = DayEfficiencyModel.ScaleCollection(10, dayOneEff);
+			int dayOneBones = DayEfficiencyModel.ScaleCollection(5, dayOneEff);
+			ledger.CollectMaterial(MagicHerb, dayOneHerbs);
+			ledger.CollectMaterial(DemonBone, dayOneBones);
+			cycle.Advance(); // → Night
+
+			// --- 밤 1 ---
+			Assert.That(cycle.Phase, Is.EqualTo(DayNightPhase.Night));
+			WorkshopProduct potion = MakePotion(salePrice: 50);
+			int produced = 0;
+			while (ledger.TryManufacture(potion))
+			{
+				produced = produced + 1;
+			}
+			ledger.SellProduct(potion, produced);
+			int goldAfterNight = ledger.Gold;
+			cycle.Advance(); // → Day, DayIndex +1
+
+			Assert.That(produced, Is.GreaterThan(0), "낮 채집분으로 최소 1개 제조 가능");
+			Assert.That(goldAfterNight, Is.GreaterThan(0), "판매 → 골드 +");
+			Assert.That(cycle.DayIndex, Is.EqualTo(1), "1사이클 닫힘 → DayIndex +1");
+
+			// --- 다음 낮 시작 — 효율 투자로 다음 낮 채집량 증가 검수 ---
+			bool invested = ledger.InvestInDayEfficiency(50);
+			Assert.That(invested, Is.True);
+			float dayTwoEff = ledger.CurrentDayEfficiency(coeffs);
+
+			Assert.That(dayTwoEff, Is.GreaterThan(dayOneEff), "투자 후 다음 낮 효율 상승");
+
+			int dayTwoHerbs = DayEfficiencyModel.ScaleCollection(10, dayTwoEff);
+			Assert.That(dayTwoHerbs, Is.GreaterThan(dayOneHerbs), "같은 base 채집량으로도 다음 낮은 더 많이 수확 (브리지 닫힘)");
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/Workshop/WorkshopLedgerTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/Workshop/WorkshopLedgerTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 14467f56139549c4a32f86fe60ec26ea


### PR DESCRIPTION
## TASK
TASK-WM-170 — 「낮의 마계, 밤의 공방」 (Dave the Diver 식 듀얼루프 타이쿤) **Phase 0**.
시장조사 워크플로 `wf_ebd5ec41` 의 5종 시드 중 *운영 타이쿤 축* (사용자 픽 2026-05-31).

## Phase 0 슬라이스 — "1사이클 수치 닫힘"
> 낮에 마계에서 재료 N개 → 밤에 공방에서 그 재료로 상품 제조 → 판매로 골드 → 다음 낮 채집 효율을 올리는 1사이클을 *수치로 닫는다*.

순수 POCO 만 — `DomainSDK/Workshop/` (references=[], MonoBehaviour/PlayMode 무관). City `RciDemandModel` / `CityEconomy` POCO 선례 동형.

## 신규 (8 src + 1 test)

**Workshop substrate (`Assets/_WitchMendokusai/DomainSDK/Workshop/`)**
- `DayNightPhase` (enum) + `DayNightCycle` — 단계 + 일수 카운터 (낮→밤 / 밤→낮+1)
- `MaterialId` (readonly struct) + `MaterialCost` + `WorkshopProduct` — 데이터주도 재료·레시피 (모드/UGC)
- `ProductSale` (static) — 재고 충분성 + 매출 환산 순수 함수
- `DayEfficiencyCoefficients` + `DayEfficiencyModel` — 골드 누계 → 채집 효율 step 함수 (브리지 코어)
- `WorkshopLedger` — 재고/골드/효율투자 누계 + 트랜잭션 메서드 (`CollectMaterial` / `TryManufacture` / `SellProduct` / `InvestInDayEfficiency`)

**EditMode 테스트 (`Assets/_WitchMendokusai/Tests/EditMode/Workshop/`)**
- `WorkshopLedgerTest` — 14 케이스: 단계 전환·재고·제조 가능/불가·판매·투자 트랜잭션·step 함수 단조성·clamp + **DualLoop 1사이클 닫힘** (낮1 채집 → 밤1 제조·판매 → 효율 투자 → 낮2 *더 많은* 채집 검수)

## 비전 정합
- **이중 무대 직접 매핑**: WM 의 마을(낮 재건) ↔ 마계(밤 전투/채집) 구조에 Dave 공식 그대로 — 신규 무대 0
- **재활용 65~70%**: 낮 루프(WM-165 투기장/탐험) + TimeManager + ItemData + UI Toolkit + Actor/Unit(인형 직원) 전부 기존
- **6 동기**: 퀄리티(EditMode 결정성) · 미래/모딩/UGC(`MaterialId` 정수 키 + `WorkshopProduct` POCO 데이터주도) · 분리(DomainSDK references=[])
- **수치 노출**: 모든 계수가 POCO 디폴트 없이 명시 주입 — 본격 슬라이스에서 `WorkshopProductSO` / `DayEfficiencySO` (Domain) 가 공급원이 됨

## Test plan
- [x] **Static review**: 새 `.cs` 8 + 테스트 1 — `var` 0 / 부정 `== false` 사용 / Allman / `init-order` 안전(MonoBehaviour 0)
- [x] **POCO 격리**: 새 파일 모두 `WitchMendokusai.DomainSDK.Workshop` 네임스페이스 + DomainSDK 어셈블리 (references=`[UniTask, MessagePipe]`)
- [x] **수치 결정성**: 정수 골드 / `int` step 함수 (`(int)(gold/stepGold)`) — float 누적 회피
- [x] **메타 GUID**: 모든 신규 폴더 + `.cs` 에 UUID v4 .meta 추가 (Unity 임포트 시 충돌 방지)
- [ ] **Unity MCP EditMode**: `run_tests(EditMode, assemblyNames=["WM.Tests.EditMode"])` 로 `WorkshopLedgerTest` 14/14 GREEN 확인 (이 agent context 에서 MCP 미가용 → 사람 리뷰어가 worktree 에서 Editor 열고 확인 필요)
- [ ] **컴파일 클린**: `read_console(types=["error","warning"], count=30)` 0 entries (위와 동일 — Editor MCP 필요)

## 다음 슬라이스 (Phase 1 — 별도 PR)
- `WorkshopProductSO` (Domain) + `WorkshopLedger` 의 `ISavable<WorkshopLedgerSaveData>` 격상
- EventBus `ProductSoldEvent` / `MaterialCollectedEvent` (DomainSDK/Workshop/Events)
- 공방 운영 UI 최소 슬라이스 (UI Toolkit) — 상품 진열·가격·재고
- TimeManager 의 `OnTimeOfDayChanged` → `DayNightCycle.Advance()` 바인딩

## 사용자 컨펌 대기 (디자인 영역 — 본 PR 영향 X)
스펙 § "사용자 컨펌 대기" 의 6개 디자인 결정 (공방 정체성 / 단골 구성 / 낮 루프 출처 / 손맛 수위 / 욘 위임 정도 / WM-165 통합 시점) 은 substrate 와 직교 — Phase 1 진입 그릴 게이트 시점에 묻는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)