### PR TITLE
feat(TASK-WM-172): 잔해에서 피어나는 정련 코어 Phase 0 — RefiningChain 누적 모델

### DIFF
--- a/Assets/_WitchMendokusai/DomainSDK/Refining.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7dab60517b634bc4a1880bae0bb9ac3e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningApproach.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningApproach.cs
@@ -1,11 +1,7 @@
 namespace WitchMendokusai.DomainSDK.Refining
 {
-	/// <summary>
-	/// TASK-WM-172 Phase 0 — 한 정련 단계에 임하는 태도. '함부로 vs 애도하며'의 코어 축.
-	/// Fast(빨리·함부로) → 빨리 끝내려 거칠게: 품질 상승 적고 마을 온기↓. 링(충동)의 색.
-	/// Careful(애도하며·정성껏) → 죽은 것을 존중하며 천천히: 품질 상승 크고 온기↑. 알리사(질서)의 색.
-	/// 두 태도가 MDD(욘이 죽음을 다루는 두 얼굴)에 정합. 효율 손익 X — 톤·서사가 함께 갈리는 선택.
-	/// </summary>
+	// Fast = 빨리·함부로(링 색), Careful = 애도하며·정성껏(알리사 색).
+	// 비대칭이 RefiningCoefficients 에 박혀 있다 — 단순 효율 손익이 아니라 톤/서사가 갈리는 선택.
 	public enum RefiningApproach
 	{
 		Fast = 0,

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningApproach.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningApproach.cs
@@ -1,0 +1,14 @@
+namespace WitchMendokusai.DomainSDK.Refining
+{
+	/// <summary>
+	/// TASK-WM-172 Phase 0 — 한 정련 단계에 임하는 태도. '함부로 vs 애도하며'의 코어 축.
+	/// Fast(빨리·함부로) → 빨리 끝내려 거칠게: 품질 상승 적고 마을 온기↓. 링(충동)의 색.
+	/// Careful(애도하며·정성껏) → 죽은 것을 존중하며 천천히: 품질 상승 크고 온기↑. 알리사(질서)의 색.
+	/// 두 태도가 MDD(욘이 죽음을 다루는 두 얼굴)에 정합. 효율 손익 X — 톤·서사가 함께 갈리는 선택.
+	/// </summary>
+	public enum RefiningApproach
+	{
+		Fast = 0,
+		Careful = 1,
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningApproach.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningApproach.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd2d6acff59d4dde81dc8fb880b000ba

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningChain.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningChain.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WitchMendokusai.DomainSDK.Refining
+{
+	/// <summary>
+	/// TASK-WM-172 Phase 0 — 정련 체인의 결정적 누적 모델(DomainSDK, 순수 함수, EditMode 직접 테스트).
+	/// "잔재 1개를 여러 정련 단계를 거치게 하면 품질 등급이 오르고, 단계 선택(빠름/정성)에 따라 최종 등급·온기가 달라지는"
+	/// 1재료 수직 슬라이스의 코어. Phase 1 이상에서 잔재 종류·단계 가중치·일꾼 생성이 이 위에 얹힌다.
+	///
+	/// 비전-중립 — 마계 사체/시들어버린 잔재/마도서 페이지 등 스킨 무관(순수 수학). 계수 = RefiningCoefficients 주입.
+	/// Quality [0,1] / Warmth [-1,1] clamp = 타입 범위 상수(튜닝 수치 X — 범위 자체가 출력 계약).
+	/// </summary>
+	public static class RefiningChain
+	{
+		// 출력 계약 — 튜닝 수치 아닌 타입 범위(RciDemandModel DEMAND_MIN/MAX 선례).
+		private const float QUALITY_MIN = 0f;
+		private const float QUALITY_MAX = 1f;
+		private const float WARMTH_MIN = -1f;
+		private const float WARMTH_MAX = 1f;
+
+		/// <summary>잔재 원자재 시작 상태 — 정련 한 단계도 거치지 않은 baseline. Warmth 는 중립(0).</summary>
+		public static RefiningState Initial(RefiningCoefficients coefficients)
+		{
+			float quality = Mathf.Clamp(coefficients.InitialQuality, QUALITY_MIN, QUALITY_MAX);
+			return new RefiningState(quality, 0f, 0);
+		}
+
+		/// <summary>한 단계 진행 — 태도(Fast/Careful)에 따른 품질·온기 델타 적용 + clamp. CompletedStages++.</summary>
+		public static RefiningState ApplyStage(RefiningState current, RefiningStage stage, RefiningCoefficients coefficients)
+		{
+			float qualityDelta = QualityDelta(stage.Approach, coefficients);
+			float warmthDelta = WarmthDelta(stage.Approach, coefficients);
+
+			float nextQuality = Mathf.Clamp(current.Quality + qualityDelta, QUALITY_MIN, QUALITY_MAX);
+			float nextWarmth = Mathf.Clamp(current.Warmth + warmthDelta, WARMTH_MIN, WARMTH_MAX);
+
+			return new RefiningState(nextQuality, nextWarmth, current.CompletedStages + 1);
+		}
+
+		/// <summary>체인 전체 평가 — Initial 에서 시작해 stages 를 순서대로 ApplyStage. stages 비면 Initial 그대로.</summary>
+		public static RefiningState Evaluate(IReadOnlyList<RefiningStage> stages, RefiningCoefficients coefficients)
+		{
+			RefiningState state = Initial(coefficients);
+			for (int i = 0; i < stages.Count; i++)
+			{
+				state = ApplyStage(state, stages[i], coefficients);
+			}
+			return state;
+		}
+
+		private static float QualityDelta(RefiningApproach approach, RefiningCoefficients coefficients) => approach switch
+		{
+			RefiningApproach.Fast => coefficients.FastQualityDelta,
+			RefiningApproach.Careful => coefficients.CarefulQualityDelta,
+			_ => 0f,
+		};
+
+		private static float WarmthDelta(RefiningApproach approach, RefiningCoefficients coefficients) => approach switch
+		{
+			RefiningApproach.Fast => coefficients.FastWarmthDelta,
+			RefiningApproach.Careful => coefficients.CarefulWarmthDelta,
+			_ => 0f,
+		};
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningChain.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningChain.cs
@@ -3,30 +3,21 @@ using UnityEngine;
 
 namespace WitchMendokusai.DomainSDK.Refining
 {
-	/// <summary>
-	/// TASK-WM-172 Phase 0 — 정련 체인의 결정적 누적 모델(DomainSDK, 순수 함수, EditMode 직접 테스트).
-	/// "잔재 1개를 여러 정련 단계를 거치게 하면 품질 등급이 오르고, 단계 선택(빠름/정성)에 따라 최종 등급·온기가 달라지는"
-	/// 1재료 수직 슬라이스의 코어. Phase 1 이상에서 잔재 종류·단계 가중치·일꾼 생성이 이 위에 얹힌다.
-	///
-	/// 비전-중립 — 마계 사체/시들어버린 잔재/마도서 페이지 등 스킨 무관(순수 수학). 계수 = RefiningCoefficients 주입.
-	/// Quality [0,1] / Warmth [-1,1] clamp = 타입 범위 상수(튜닝 수치 X — 범위 자체가 출력 계약).
-	/// </summary>
+	// 정련 체인의 결정적 누적 모델 — 비전-중립 순수 함수(스킨 무관). 계수 = RefiningCoefficients 주입.
+	// clamp 범위는 타입 출력 계약(튜닝 X) — RciDemandModel DEMAND_MIN/MAX 선례.
 	public static class RefiningChain
 	{
-		// 출력 계약 — 튜닝 수치 아닌 타입 범위(RciDemandModel DEMAND_MIN/MAX 선례).
 		private const float QUALITY_MIN = 0f;
 		private const float QUALITY_MAX = 1f;
 		private const float WARMTH_MIN = -1f;
 		private const float WARMTH_MAX = 1f;
 
-		/// <summary>잔재 원자재 시작 상태 — 정련 한 단계도 거치지 않은 baseline. Warmth 는 중립(0).</summary>
 		public static RefiningState Initial(RefiningCoefficients coefficients)
 		{
 			float quality = Mathf.Clamp(coefficients.InitialQuality, QUALITY_MIN, QUALITY_MAX);
 			return new RefiningState(quality, 0f, 0);
 		}
 
-		/// <summary>한 단계 진행 — 태도(Fast/Careful)에 따른 품질·온기 델타 적용 + clamp. CompletedStages++.</summary>
 		public static RefiningState ApplyStage(RefiningState current, RefiningStage stage, RefiningCoefficients coefficients)
 		{
 			float qualityDelta = QualityDelta(stage.Approach, coefficients);
@@ -38,7 +29,6 @@ namespace WitchMendokusai.DomainSDK.Refining
 			return new RefiningState(nextQuality, nextWarmth, current.CompletedStages + 1);
 		}
 
-		/// <summary>체인 전체 평가 — Initial 에서 시작해 stages 를 순서대로 ApplyStage. stages 비면 Initial 그대로.</summary>
 		public static RefiningState Evaluate(IReadOnlyList<RefiningStage> stages, RefiningCoefficients coefficients)
 		{
 			RefiningState state = Initial(coefficients);

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningChain.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningChain.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d681e4594a19420689a636e1eede6ce4

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningCoefficients.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningCoefficients.cs
@@ -1,19 +1,14 @@
 namespace WitchMendokusai.DomainSDK.Refining
 {
-	/// <summary>
-	/// TASK-WM-172 Phase 0 — 정련 체인 계수. RefiningChain 에 주입(테스트 격리). 게임 배선에선 RefiningCoefficientsSO
-	/// (Domain, DataSO)가 공급원(수치 노출 룰 — 욘이 공방을 tweak). POCO 라 디폴트값 없음 — 공급자가 명시.
-	///
-	/// 빠름 vs 정성의 비대칭이 코어: Careful 가 Fast 보다 품질 델타↑, 온기 델타도 +쪽. Fast 는 빠르지만 온기 -.
-	/// "효율 vs 윤리"가 단순 손익이 아니라 톤 정합 — 수치 자체에 비대칭이 박혀 있어야 의미 있는 선택이 된다.
-	/// </summary>
+	// POCO 디폴트값 없음 — 게임 배선은 RefiningCoefficientsSO 가 공급(수치 노출 룰).
+	// Careful 의 품질·온기 델타가 Fast 보다 + 쪽이어야 "효율 vs 윤리" 가 의미 있는 선택이 된다.
 	public readonly struct RefiningCoefficients
 	{
-		public readonly float InitialQuality;      // 잔재 원자재 시작 품질(0..1). 마계 사체 = 낮음 / 정화된 잔재 = 높음.
-		public readonly float FastQualityDelta;    // Fast 단계 1회의 품질 가산(작은 +). 빠르지만 깊이가 얕다.
-		public readonly float CarefulQualityDelta; // Careful 단계 1회의 품질 가산(큰 +). 정성이 등급을 끌어올림.
-		public readonly float FastWarmthDelta;     // Fast 단계 1회의 온기 가산(음수). 함부로 다룸 = 온기 소진.
-		public readonly float CarefulWarmthDelta;  // Careful 단계 1회의 온기 가산(양수). 애도 = 온기 충전.
+		public readonly float InitialQuality;
+		public readonly float FastQualityDelta;
+		public readonly float CarefulQualityDelta;
+		public readonly float FastWarmthDelta;
+		public readonly float CarefulWarmthDelta;
 
 		public RefiningCoefficients(float initialQuality, float fastQualityDelta, float carefulQualityDelta, float fastWarmthDelta, float carefulWarmthDelta)
 		{

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningCoefficients.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningCoefficients.cs
@@ -1,0 +1,27 @@
+namespace WitchMendokusai.DomainSDK.Refining
+{
+	/// <summary>
+	/// TASK-WM-172 Phase 0 — 정련 체인 계수. RefiningChain 에 주입(테스트 격리). 게임 배선에선 RefiningCoefficientsSO
+	/// (Domain, DataSO)가 공급원(수치 노출 룰 — 욘이 공방을 tweak). POCO 라 디폴트값 없음 — 공급자가 명시.
+	///
+	/// 빠름 vs 정성의 비대칭이 코어: Careful 가 Fast 보다 품질 델타↑, 온기 델타도 +쪽. Fast 는 빠르지만 온기 -.
+	/// "효율 vs 윤리"가 단순 손익이 아니라 톤 정합 — 수치 자체에 비대칭이 박혀 있어야 의미 있는 선택이 된다.
+	/// </summary>
+	public readonly struct RefiningCoefficients
+	{
+		public readonly float InitialQuality;      // 잔재 원자재 시작 품질(0..1). 마계 사체 = 낮음 / 정화된 잔재 = 높음.
+		public readonly float FastQualityDelta;    // Fast 단계 1회의 품질 가산(작은 +). 빠르지만 깊이가 얕다.
+		public readonly float CarefulQualityDelta; // Careful 단계 1회의 품질 가산(큰 +). 정성이 등급을 끌어올림.
+		public readonly float FastWarmthDelta;     // Fast 단계 1회의 온기 가산(음수). 함부로 다룸 = 온기 소진.
+		public readonly float CarefulWarmthDelta;  // Careful 단계 1회의 온기 가산(양수). 애도 = 온기 충전.
+
+		public RefiningCoefficients(float initialQuality, float fastQualityDelta, float carefulQualityDelta, float fastWarmthDelta, float carefulWarmthDelta)
+		{
+			InitialQuality = initialQuality;
+			FastQualityDelta = fastQualityDelta;
+			CarefulQualityDelta = carefulQualityDelta;
+			FastWarmthDelta = fastWarmthDelta;
+			CarefulWarmthDelta = carefulWarmthDelta;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningCoefficients.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningCoefficients.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 40526e2e751f429fa45982b5a113b333

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStage.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStage.cs
@@ -1,10 +1,5 @@
 namespace WitchMendokusai.DomainSDK.Refining
 {
-	/// <summary>
-	/// TASK-WM-172 Phase 0 — 정련 체인의 한 단계 정의. '어떤 가공 단계(Kind)를 어떤 태도(Approach)로 거쳤는가'.
-	/// 순수 값(readonly struct) — 체인 = IReadOnlyList&lt;RefiningStage&gt; 로 흘려 RefiningChain.Evaluate 에 주입.
-	/// Phase 1 부터 Kind 별 가중치(SO 노출)가 붙어 단계마다 의미가 갈라질 자리.
-	/// </summary>
 	public readonly struct RefiningStage
 	{
 		public readonly RefiningStageKind Kind;

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStage.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStage.cs
@@ -1,0 +1,19 @@
+namespace WitchMendokusai.DomainSDK.Refining
+{
+	/// <summary>
+	/// TASK-WM-172 Phase 0 — 정련 체인의 한 단계 정의. '어떤 가공 단계(Kind)를 어떤 태도(Approach)로 거쳤는가'.
+	/// 순수 값(readonly struct) — 체인 = IReadOnlyList&lt;RefiningStage&gt; 로 흘려 RefiningChain.Evaluate 에 주입.
+	/// Phase 1 부터 Kind 별 가중치(SO 노출)가 붙어 단계마다 의미가 갈라질 자리.
+	/// </summary>
+	public readonly struct RefiningStage
+	{
+		public readonly RefiningStageKind Kind;
+		public readonly RefiningApproach Approach;
+
+		public RefiningStage(RefiningStageKind kind, RefiningApproach approach)
+		{
+			Kind = kind;
+			Approach = approach;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStage.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 42c36c2aecbc4325a2f2e8faf96680fd

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStageKind.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStageKind.cs
@@ -1,0 +1,14 @@
+namespace WitchMendokusai.DomainSDK.Refining
+{
+	/// <summary>
+	/// TASK-WM-172 Phase 0 — 잔재 정련의 표준 3단계. 마계 사체·시들어버린 마을의 잔재가 거치는 가공 체인.
+	/// Dissection(해부) → 잔재에서 사용 가능한 부위 추출 / Purification(정화) → 저주·오염 제거 /
+	/// Refinement(정련) → 마도서 페이지 재료급으로 품질 끌어올리기. 코어 수치 매핑은 RefiningCoefficients SO가 공급.
+	/// </summary>
+	public enum RefiningStageKind
+	{
+		Dissection = 0,
+		Purification = 1,
+		Refinement = 2,
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStageKind.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStageKind.cs
@@ -1,10 +1,5 @@
 namespace WitchMendokusai.DomainSDK.Refining
 {
-	/// <summary>
-	/// TASK-WM-172 Phase 0 — 잔재 정련의 표준 3단계. 마계 사체·시들어버린 마을의 잔재가 거치는 가공 체인.
-	/// Dissection(해부) → 잔재에서 사용 가능한 부위 추출 / Purification(정화) → 저주·오염 제거 /
-	/// Refinement(정련) → 마도서 페이지 재료급으로 품질 끌어올리기. 코어 수치 매핑은 RefiningCoefficients SO가 공급.
-	/// </summary>
 	public enum RefiningStageKind
 	{
 		Dissection = 0,

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStageKind.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningStageKind.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e3e9c21863554ec58c69039ac68588d7

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningState.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningState.cs
@@ -1,0 +1,23 @@
+namespace WitchMendokusai.DomainSDK.Refining
+{
+	/// <summary>
+	/// TASK-WM-172 Phase 0 — 정련 체인 누적 상태. Quality(0..1) · Warmth(-1..1) · CompletedStages.
+	/// readonly struct — 단계마다 새 RefiningState 반환(determinism / aliasing 0). RciDemand 선례.
+	///
+	/// Quality = 마도서 페이지 재료 등급(0=원자재 / 1=최고급). 누적 +.
+	/// Warmth  = 마을 온기 게이지 기여(-1=함부로 누적 / 0=중립 / +1=애도 누적). 부호 양분.
+	/// </summary>
+	public readonly struct RefiningState
+	{
+		public readonly float Quality;
+		public readonly float Warmth;
+		public readonly int CompletedStages;
+
+		public RefiningState(float quality, float warmth, int completedStages)
+		{
+			Quality = quality;
+			Warmth = warmth;
+			CompletedStages = completedStages;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningState.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningState.cs
@@ -1,12 +1,7 @@
 namespace WitchMendokusai.DomainSDK.Refining
 {
-	/// <summary>
-	/// TASK-WM-172 Phase 0 — 정련 체인 누적 상태. Quality(0..1) · Warmth(-1..1) · CompletedStages.
-	/// readonly struct — 단계마다 새 RefiningState 반환(determinism / aliasing 0). RciDemand 선례.
-	///
-	/// Quality = 마도서 페이지 재료 등급(0=원자재 / 1=최고급). 누적 +.
-	/// Warmth  = 마을 온기 게이지 기여(-1=함부로 누적 / 0=중립 / +1=애도 누적). 부호 양분.
-	/// </summary>
+	// Quality [0..1] = 마도서 페이지 재료 등급, Warmth [-1..1] = 마을 온기 기여(부호 양분).
+	// readonly struct → 단계마다 새 인스턴스 반환(aliasing 0, 결정성).
 	public readonly struct RefiningState
 	{
 		public readonly float Quality;

--- a/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningState.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Refining/RefiningState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dd8af4e2deea4fab8957890b30419119

--- a/Assets/_WitchMendokusai/Tests/EditMode/Refining.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/Refining.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a5823cf0322241b8971fdf1eab96516a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Tests/EditMode/Refining/RefiningChainTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/Refining/RefiningChainTest.cs
@@ -4,22 +4,9 @@ using WitchMendokusai.DomainSDK.Refining;
 
 namespace WitchMendokusai.Tests
 {
-	/// <summary>
-	/// TASK-WM-172 Phase 0 — <see cref="RefiningChain"/> 정련 누적 체인 회귀 잠금.
-	///
-	/// 스펙 필수 검증:
-	///   ① 품질 누적 결정성   (같은 입력 = 같은 출력 — Quality/Warmth/CompletedStages 셋 다)
-	///   ② 빠름 vs 정성 분기  (Careful 누적 > Fast 누적 in Quality / Warmth 부호 정반대)
-	///   ③ 레거시 단순제작 동등 (1단계 체인 = Initial → ApplyStage 1회 와 동일 — 숨겨진 체인 보너스 0)
-	///
-	/// 순수 함수 — MonoBehaviour/VContainer/PlayMode 0. new() · static call 직접.
-	/// 실행: unity -runTests -batchmode -testPlatform EditMode -assemblyNames WM.Tests.EditMode
-	/// </summary>
 	public sealed class RefiningChainTest
 	{
-		// 테스트 계수 — 명시 주입(POCO 디폴트 없음). 게임에선 RefiningCoefficientsSO 가 공급.
-		// 비대칭이 의도: Careful 의 품질 델타(0.2) > Fast(0.05) / Fast 온기(-0.2) vs Careful(+0.2).
-		// "효율 vs 윤리"가 단순 손익이 아니라 톤 정합 — 수치 자체가 비대칭이어야 의미 있는 선택.
+		// Careful 의 품질·온기 델타가 Fast 보다 + 쪽이어야 의미 있는 선택이 된다 — 회귀 잠금의 기준 계수.
 		private static RefiningCoefficients DefaultCoefficients()
 		{
 			return new RefiningCoefficients(
@@ -50,7 +37,6 @@ namespace WitchMendokusai.Tests
 			Assert.That(state.CompletedStages, Is.EqualTo(0), "단계 0회");
 		}
 
-		// ① 품질 누적 결정성 — 스펙 필수.
 		[Test]
 		public void Evaluate_IsDeterministic_SameInputSameOutput()
 		{
@@ -70,7 +56,6 @@ namespace WitchMendokusai.Tests
 			Assert.That(second.CompletedStages, Is.EqualTo(first.CompletedStages));
 		}
 
-		// ② 빠름 vs 정성 분기 — 스펙 필수: 같은 단계 수에도 태도가 등급/온기를 가른다.
 		[Test]
 		public void AllCareful_AchievesHigherQuality_ThanAllFast()
 		{
@@ -102,7 +87,7 @@ namespace WitchMendokusai.Tests
 			Assert.That(state.Warmth, Is.LessThan(0f), "함부로 정련 = 온기 - (마을 식어감)");
 		}
 
-		// ③ 레거시 단순제작 동등 — 스펙 필수: 1단계 체인 = ApplyStage 1회. 체인이 숨은 보너스를 박지 않는다.
+		// 1단계 체인 = ApplyStage 1회 — 체인이 숨은 보너스를 박지 않는다(레거시 단순제작 동등성).
 		[Test]
 		public void SingleStageChain_EqualsOneManualApply()
 		{
@@ -185,9 +170,10 @@ namespace WitchMendokusai.Tests
 		}
 
 		[Test]
-		public void StageOrder_IndependentOfKind_InPhase0()
+		public void StageOrder_IndependentOfKind_WhenKindHasNoWeight()
 		{
-			// Phase 0 = 단계 Kind 별 가중치 X (Phase 1+ 에서 SO 로 들어옴). Kind 만 바뀌고 Approach 동일이면 결과 동일.
+			// 현재 모델은 단계 Kind 별 가중치 0 — Approach 만 결과를 가른다.
+			// Kind 가중치 도입 시 이 테스트가 깨지면서 가중치 회귀 잠금이 필요해진다는 신호.
 			RefiningCoefficients coefficients = DefaultCoefficients();
 			List<RefiningStage> order1 = new()
 			{
@@ -205,7 +191,7 @@ namespace WitchMendokusai.Tests
 			RefiningState s1 = RefiningChain.Evaluate(order1, coefficients);
 			RefiningState s2 = RefiningChain.Evaluate(order2, coefficients);
 
-			Assert.That(s1.Quality, Is.EqualTo(s2.Quality), "Phase 0 = Kind 가중치 0, 순서 무관");
+			Assert.That(s1.Quality, Is.EqualTo(s2.Quality), "Kind 가중치 0 → 순서 무관");
 			Assert.That(s1.Warmth, Is.EqualTo(s2.Warmth));
 		}
 
@@ -214,7 +200,6 @@ namespace WitchMendokusai.Tests
 			List<RefiningStage> stages = new(count);
 			for (int i = 0; i < count; i++)
 			{
-				// Kind 는 순환(Phase 0 = Kind 가중치 X, 그저 슬롯).
 				RefiningStageKind kind = (RefiningStageKind)(i % 3);
 				stages.Add(new RefiningStage(kind, approach));
 			}

--- a/Assets/_WitchMendokusai/Tests/EditMode/Refining/RefiningChainTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/Refining/RefiningChainTest.cs
@@ -1,0 +1,224 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using WitchMendokusai.DomainSDK.Refining;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-172 Phase 0 — <see cref="RefiningChain"/> 정련 누적 체인 회귀 잠금.
+	///
+	/// 스펙 필수 검증:
+	///   ① 품질 누적 결정성   (같은 입력 = 같은 출력 — Quality/Warmth/CompletedStages 셋 다)
+	///   ② 빠름 vs 정성 분기  (Careful 누적 > Fast 누적 in Quality / Warmth 부호 정반대)
+	///   ③ 레거시 단순제작 동등 (1단계 체인 = Initial → ApplyStage 1회 와 동일 — 숨겨진 체인 보너스 0)
+	///
+	/// 순수 함수 — MonoBehaviour/VContainer/PlayMode 0. new() · static call 직접.
+	/// 실행: unity -runTests -batchmode -testPlatform EditMode -assemblyNames WM.Tests.EditMode
+	/// </summary>
+	public sealed class RefiningChainTest
+	{
+		// 테스트 계수 — 명시 주입(POCO 디폴트 없음). 게임에선 RefiningCoefficientsSO 가 공급.
+		// 비대칭이 의도: Careful 의 품질 델타(0.2) > Fast(0.05) / Fast 온기(-0.2) vs Careful(+0.2).
+		// "효율 vs 윤리"가 단순 손익이 아니라 톤 정합 — 수치 자체가 비대칭이어야 의미 있는 선택.
+		private static RefiningCoefficients Coeffs()
+		{
+			return new RefiningCoefficients(
+				initialQuality: 0.0f,
+				fastQualityDelta: 0.05f,
+				carefulQualityDelta: 0.2f,
+				fastWarmthDelta: -0.2f,
+				carefulWarmthDelta: 0.2f);
+		}
+
+		[Test]
+		public void Initial_StartsAtCoefficientBaseline_WithNeutralWarmth()
+		{
+			RefiningState state = RefiningChain.Initial(Coeffs());
+
+			Assert.That(state.Quality, Is.EqualTo(0f), "잔재 원자재 = baseline 품질");
+			Assert.That(state.Warmth, Is.EqualTo(0f), "정련 0회 = 온기 중립(아직 손대지 않음)");
+			Assert.That(state.CompletedStages, Is.EqualTo(0));
+		}
+
+		[Test]
+		public void EmptyChain_ReturnsInitialState()
+		{
+			RefiningState state = RefiningChain.Evaluate(new List<RefiningStage>(), Coeffs());
+
+			Assert.That(state.Quality, Is.EqualTo(0f), "빈 체인 = Initial 그대로");
+			Assert.That(state.Warmth, Is.EqualTo(0f));
+			Assert.That(state.CompletedStages, Is.EqualTo(0), "단계 0회");
+		}
+
+		// ① 품질 누적 결정성 — 스펙 필수.
+		[Test]
+		public void Evaluate_IsDeterministic_SameInputSameOutput()
+		{
+			RefiningCoefficients coeffs = Coeffs();
+			List<RefiningStage> stages = new()
+			{
+				new RefiningStage(RefiningStageKind.Dissection, RefiningApproach.Careful),
+				new RefiningStage(RefiningStageKind.Purification, RefiningApproach.Fast),
+				new RefiningStage(RefiningStageKind.Refinement, RefiningApproach.Careful),
+			};
+
+			RefiningState first = RefiningChain.Evaluate(stages, coeffs);
+			RefiningState second = RefiningChain.Evaluate(stages, coeffs);
+
+			Assert.That(second.Quality, Is.EqualTo(first.Quality), "결정성 — 품질");
+			Assert.That(second.Warmth, Is.EqualTo(first.Warmth), "결정성 — 온기");
+			Assert.That(second.CompletedStages, Is.EqualTo(first.CompletedStages));
+		}
+
+		// ② 빠름 vs 정성 분기 — 스펙 필수: 같은 단계 수에도 태도가 등급/온기를 가른다.
+		[Test]
+		public void AllCareful_AchievesHigherQuality_ThanAllFast()
+		{
+			RefiningCoefficients coeffs = Coeffs();
+			List<RefiningStage> fastChain = MakeChain(RefiningApproach.Fast, 3);
+			List<RefiningStage> carefulChain = MakeChain(RefiningApproach.Careful, 3);
+
+			float fastQuality = RefiningChain.Evaluate(fastChain, coeffs).Quality;
+			float carefulQuality = RefiningChain.Evaluate(carefulChain, coeffs).Quality;
+
+			Assert.That(carefulQuality, Is.GreaterThan(fastQuality), "정성 = 등급 더 높이 끌어올림");
+		}
+
+		[Test]
+		public void AllCareful_AccumulatesWarmth()
+		{
+			RefiningCoefficients coeffs = Coeffs();
+			RefiningState state = RefiningChain.Evaluate(MakeChain(RefiningApproach.Careful, 3), coeffs);
+
+			Assert.That(state.Warmth, Is.GreaterThan(0f), "애도하며 정련 = 온기 +");
+		}
+
+		[Test]
+		public void AllFast_DepletesWarmth()
+		{
+			RefiningCoefficients coeffs = Coeffs();
+			RefiningState state = RefiningChain.Evaluate(MakeChain(RefiningApproach.Fast, 3), coeffs);
+
+			Assert.That(state.Warmth, Is.LessThan(0f), "함부로 정련 = 온기 - (마을 식어감)");
+		}
+
+		// ③ 레거시 단순제작 동등 — 스펙 필수: 1단계 체인 = ApplyStage 1회. 체인이 숨은 보너스를 박지 않는다.
+		[Test]
+		public void SingleStageChain_EqualsOneManualApply()
+		{
+			RefiningCoefficients coeffs = Coeffs();
+			RefiningStage stage = new(RefiningStageKind.Dissection, RefiningApproach.Careful);
+
+			RefiningState viaChain = RefiningChain.Evaluate(new List<RefiningStage> { stage }, coeffs);
+			RefiningState viaManual = RefiningChain.ApplyStage(RefiningChain.Initial(coeffs), stage, coeffs);
+
+			Assert.That(viaChain.Quality, Is.EqualTo(viaManual.Quality), "단순제작(1단계) = 체인 1회 — 숨은 보너스 0");
+			Assert.That(viaChain.Warmth, Is.EqualTo(viaManual.Warmth));
+			Assert.That(viaChain.CompletedStages, Is.EqualTo(viaManual.CompletedStages));
+		}
+
+		[Test]
+		public void MixedApproach_AccumulatesIndependently_NoCancel()
+		{
+			RefiningCoefficients coeffs = Coeffs();
+			// Fast +0.05, Careful +0.2 → 합 0.25. 서로 상쇄 X, 단순 합산.
+			List<RefiningStage> mixed = new()
+			{
+				new RefiningStage(RefiningStageKind.Dissection, RefiningApproach.Fast),
+				new RefiningStage(RefiningStageKind.Purification, RefiningApproach.Careful),
+			};
+
+			RefiningState state = RefiningChain.Evaluate(mixed, coeffs);
+
+			Assert.That(state.Quality, Is.EqualTo(0.25f).Within(0.0001f), "Fast(0.05) + Careful(0.2) = 0.25");
+			Assert.That(state.Warmth, Is.EqualTo(0f).Within(0.0001f), "Fast(-0.2) + Careful(+0.2) = 0 (상쇄)");
+			Assert.That(state.CompletedStages, Is.EqualTo(2));
+		}
+
+		[Test]
+		public void CompletedStages_IncrementsPerApply()
+		{
+			RefiningCoefficients coeffs = Coeffs();
+			RefiningState state = RefiningChain.Initial(coeffs);
+			RefiningStage stage = new(RefiningStageKind.Refinement, RefiningApproach.Fast);
+
+			state = RefiningChain.ApplyStage(state, stage, coeffs);
+			Assert.That(state.CompletedStages, Is.EqualTo(1));
+			state = RefiningChain.ApplyStage(state, stage, coeffs);
+			Assert.That(state.CompletedStages, Is.EqualTo(2));
+			state = RefiningChain.ApplyStage(state, stage, coeffs);
+			Assert.That(state.CompletedStages, Is.EqualTo(3));
+		}
+
+		[Test]
+		public void Quality_ClampedToValidRange_NoOverflow()
+		{
+			RefiningCoefficients coeffs = Coeffs();
+			// 정성 단계(0.2)를 20회 거치면 4.0 이지만, [0,1] clamp 로 정확히 1.0.
+			RefiningState state = RefiningChain.Evaluate(MakeChain(RefiningApproach.Careful, 20), coeffs);
+
+			Assert.That(state.Quality, Is.EqualTo(1f), "Quality 는 [0,1] clamp — 최고 등급 초과 X");
+		}
+
+		[Test]
+		public void Warmth_ClampedToSignedUnitRange()
+		{
+			RefiningCoefficients coeffs = Coeffs();
+			// Fast(-0.2) 20회 = -4.0 이지만 clamp -1. 반대로 Careful 20회 = +4 → clamp +1.
+			RefiningState callous = RefiningChain.Evaluate(MakeChain(RefiningApproach.Fast, 20), coeffs);
+			RefiningState mourning = RefiningChain.Evaluate(MakeChain(RefiningApproach.Careful, 20), coeffs);
+
+			Assert.That(callous.Warmth, Is.EqualTo(-1f), "온기 [-1,1] clamp — 함부로 누적 바닥");
+			Assert.That(mourning.Warmth, Is.EqualTo(1f), "온기 [-1,1] clamp — 애도 누적 천장");
+		}
+
+		[Test]
+		public void InitialQuality_RespectsBaseline_ClampedToRange()
+		{
+			// baseline 0.3 = 이미 한 번 정화된 잔재 가정. Initial 이 반영해야.
+			RefiningCoefficients midBaseline = new(initialQuality: 0.3f, fastQualityDelta: 0.05f, carefulQualityDelta: 0.2f, fastWarmthDelta: -0.2f, carefulWarmthDelta: 0.2f);
+			Assert.That(RefiningChain.Initial(midBaseline).Quality, Is.EqualTo(0.3f), "baseline 반영");
+
+			// baseline 비정상값(1.5) → [0,1] clamp.
+			RefiningCoefficients overshoot = new(initialQuality: 1.5f, fastQualityDelta: 0.05f, carefulQualityDelta: 0.2f, fastWarmthDelta: -0.2f, carefulWarmthDelta: 0.2f);
+			Assert.That(RefiningChain.Initial(overshoot).Quality, Is.EqualTo(1f), "baseline 도 [0,1] clamp");
+		}
+
+		[Test]
+		public void StageOrder_IndependentOfKind_InPhase0()
+		{
+			// Phase 0 = 단계 Kind 별 가중치 X (Phase 1+ 에서 SO 로 들어옴). Kind 만 바뀌고 Approach 동일이면 결과 동일.
+			RefiningCoefficients coeffs = Coeffs();
+			List<RefiningStage> order1 = new()
+			{
+				new RefiningStage(RefiningStageKind.Dissection, RefiningApproach.Careful),
+				new RefiningStage(RefiningStageKind.Purification, RefiningApproach.Careful),
+				new RefiningStage(RefiningStageKind.Refinement, RefiningApproach.Careful),
+			};
+			List<RefiningStage> order2 = new()
+			{
+				new RefiningStage(RefiningStageKind.Refinement, RefiningApproach.Careful),
+				new RefiningStage(RefiningStageKind.Dissection, RefiningApproach.Careful),
+				new RefiningStage(RefiningStageKind.Purification, RefiningApproach.Careful),
+			};
+
+			RefiningState s1 = RefiningChain.Evaluate(order1, coeffs);
+			RefiningState s2 = RefiningChain.Evaluate(order2, coeffs);
+
+			Assert.That(s1.Quality, Is.EqualTo(s2.Quality), "Phase 0 = Kind 가중치 0, 순서 무관");
+			Assert.That(s1.Warmth, Is.EqualTo(s2.Warmth));
+		}
+
+		private static List<RefiningStage> MakeChain(RefiningApproach approach, int count)
+		{
+			List<RefiningStage> stages = new(count);
+			for (int i = 0; i < count; i++)
+			{
+				// Kind 는 순환(Phase 0 = Kind 가중치 X, 그저 슬롯).
+				RefiningStageKind kind = (RefiningStageKind)(i % 3);
+				stages.Add(new RefiningStage(kind, approach));
+			}
+			return stages;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/Refining/RefiningChainTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/Refining/RefiningChainTest.cs
@@ -20,7 +20,7 @@ namespace WitchMendokusai.Tests
 		// 테스트 계수 — 명시 주입(POCO 디폴트 없음). 게임에선 RefiningCoefficientsSO 가 공급.
 		// 비대칭이 의도: Careful 의 품질 델타(0.2) > Fast(0.05) / Fast 온기(-0.2) vs Careful(+0.2).
 		// "효율 vs 윤리"가 단순 손익이 아니라 톤 정합 — 수치 자체가 비대칭이어야 의미 있는 선택.
-		private static RefiningCoefficients Coeffs()
+		private static RefiningCoefficients DefaultCoefficients()
 		{
 			return new RefiningCoefficients(
 				initialQuality: 0.0f,
@@ -33,7 +33,7 @@ namespace WitchMendokusai.Tests
 		[Test]
 		public void Initial_StartsAtCoefficientBaseline_WithNeutralWarmth()
 		{
-			RefiningState state = RefiningChain.Initial(Coeffs());
+			RefiningState state = RefiningChain.Initial(DefaultCoefficients());
 
 			Assert.That(state.Quality, Is.EqualTo(0f), "잔재 원자재 = baseline 품질");
 			Assert.That(state.Warmth, Is.EqualTo(0f), "정련 0회 = 온기 중립(아직 손대지 않음)");
@@ -43,7 +43,7 @@ namespace WitchMendokusai.Tests
 		[Test]
 		public void EmptyChain_ReturnsInitialState()
 		{
-			RefiningState state = RefiningChain.Evaluate(new List<RefiningStage>(), Coeffs());
+			RefiningState state = RefiningChain.Evaluate(new List<RefiningStage>(), DefaultCoefficients());
 
 			Assert.That(state.Quality, Is.EqualTo(0f), "빈 체인 = Initial 그대로");
 			Assert.That(state.Warmth, Is.EqualTo(0f));
@@ -54,7 +54,7 @@ namespace WitchMendokusai.Tests
 		[Test]
 		public void Evaluate_IsDeterministic_SameInputSameOutput()
 		{
-			RefiningCoefficients coeffs = Coeffs();
+			RefiningCoefficients coefficients = DefaultCoefficients();
 			List<RefiningStage> stages = new()
 			{
 				new RefiningStage(RefiningStageKind.Dissection, RefiningApproach.Careful),
@@ -62,8 +62,8 @@ namespace WitchMendokusai.Tests
 				new RefiningStage(RefiningStageKind.Refinement, RefiningApproach.Careful),
 			};
 
-			RefiningState first = RefiningChain.Evaluate(stages, coeffs);
-			RefiningState second = RefiningChain.Evaluate(stages, coeffs);
+			RefiningState first = RefiningChain.Evaluate(stages, coefficients);
+			RefiningState second = RefiningChain.Evaluate(stages, coefficients);
 
 			Assert.That(second.Quality, Is.EqualTo(first.Quality), "결정성 — 품질");
 			Assert.That(second.Warmth, Is.EqualTo(first.Warmth), "결정성 — 온기");
@@ -74,12 +74,12 @@ namespace WitchMendokusai.Tests
 		[Test]
 		public void AllCareful_AchievesHigherQuality_ThanAllFast()
 		{
-			RefiningCoefficients coeffs = Coeffs();
+			RefiningCoefficients coefficients = DefaultCoefficients();
 			List<RefiningStage> fastChain = MakeChain(RefiningApproach.Fast, 3);
 			List<RefiningStage> carefulChain = MakeChain(RefiningApproach.Careful, 3);
 
-			float fastQuality = RefiningChain.Evaluate(fastChain, coeffs).Quality;
-			float carefulQuality = RefiningChain.Evaluate(carefulChain, coeffs).Quality;
+			float fastQuality = RefiningChain.Evaluate(fastChain, coefficients).Quality;
+			float carefulQuality = RefiningChain.Evaluate(carefulChain, coefficients).Quality;
 
 			Assert.That(carefulQuality, Is.GreaterThan(fastQuality), "정성 = 등급 더 높이 끌어올림");
 		}
@@ -87,8 +87,8 @@ namespace WitchMendokusai.Tests
 		[Test]
 		public void AllCareful_AccumulatesWarmth()
 		{
-			RefiningCoefficients coeffs = Coeffs();
-			RefiningState state = RefiningChain.Evaluate(MakeChain(RefiningApproach.Careful, 3), coeffs);
+			RefiningCoefficients coefficients = DefaultCoefficients();
+			RefiningState state = RefiningChain.Evaluate(MakeChain(RefiningApproach.Careful, 3), coefficients);
 
 			Assert.That(state.Warmth, Is.GreaterThan(0f), "애도하며 정련 = 온기 +");
 		}
@@ -96,8 +96,8 @@ namespace WitchMendokusai.Tests
 		[Test]
 		public void AllFast_DepletesWarmth()
 		{
-			RefiningCoefficients coeffs = Coeffs();
-			RefiningState state = RefiningChain.Evaluate(MakeChain(RefiningApproach.Fast, 3), coeffs);
+			RefiningCoefficients coefficients = DefaultCoefficients();
+			RefiningState state = RefiningChain.Evaluate(MakeChain(RefiningApproach.Fast, 3), coefficients);
 
 			Assert.That(state.Warmth, Is.LessThan(0f), "함부로 정련 = 온기 - (마을 식어감)");
 		}
@@ -106,11 +106,11 @@ namespace WitchMendokusai.Tests
 		[Test]
 		public void SingleStageChain_EqualsOneManualApply()
 		{
-			RefiningCoefficients coeffs = Coeffs();
+			RefiningCoefficients coefficients = DefaultCoefficients();
 			RefiningStage stage = new(RefiningStageKind.Dissection, RefiningApproach.Careful);
 
-			RefiningState viaChain = RefiningChain.Evaluate(new List<RefiningStage> { stage }, coeffs);
-			RefiningState viaManual = RefiningChain.ApplyStage(RefiningChain.Initial(coeffs), stage, coeffs);
+			RefiningState viaChain = RefiningChain.Evaluate(new List<RefiningStage> { stage }, coefficients);
+			RefiningState viaManual = RefiningChain.ApplyStage(RefiningChain.Initial(coefficients), stage, coefficients);
 
 			Assert.That(viaChain.Quality, Is.EqualTo(viaManual.Quality), "단순제작(1단계) = 체인 1회 — 숨은 보너스 0");
 			Assert.That(viaChain.Warmth, Is.EqualTo(viaManual.Warmth));
@@ -120,7 +120,7 @@ namespace WitchMendokusai.Tests
 		[Test]
 		public void MixedApproach_AccumulatesIndependently_NoCancel()
 		{
-			RefiningCoefficients coeffs = Coeffs();
+			RefiningCoefficients coefficients = DefaultCoefficients();
 			// Fast +0.05, Careful +0.2 → 합 0.25. 서로 상쇄 X, 단순 합산.
 			List<RefiningStage> mixed = new()
 			{
@@ -128,7 +128,7 @@ namespace WitchMendokusai.Tests
 				new RefiningStage(RefiningStageKind.Purification, RefiningApproach.Careful),
 			};
 
-			RefiningState state = RefiningChain.Evaluate(mixed, coeffs);
+			RefiningState state = RefiningChain.Evaluate(mixed, coefficients);
 
 			Assert.That(state.Quality, Is.EqualTo(0.25f).Within(0.0001f), "Fast(0.05) + Careful(0.2) = 0.25");
 			Assert.That(state.Warmth, Is.EqualTo(0f).Within(0.0001f), "Fast(-0.2) + Careful(+0.2) = 0 (상쇄)");
@@ -138,24 +138,24 @@ namespace WitchMendokusai.Tests
 		[Test]
 		public void CompletedStages_IncrementsPerApply()
 		{
-			RefiningCoefficients coeffs = Coeffs();
-			RefiningState state = RefiningChain.Initial(coeffs);
+			RefiningCoefficients coefficients = DefaultCoefficients();
+			RefiningState state = RefiningChain.Initial(coefficients);
 			RefiningStage stage = new(RefiningStageKind.Refinement, RefiningApproach.Fast);
 
-			state = RefiningChain.ApplyStage(state, stage, coeffs);
+			state = RefiningChain.ApplyStage(state, stage, coefficients);
 			Assert.That(state.CompletedStages, Is.EqualTo(1));
-			state = RefiningChain.ApplyStage(state, stage, coeffs);
+			state = RefiningChain.ApplyStage(state, stage, coefficients);
 			Assert.That(state.CompletedStages, Is.EqualTo(2));
-			state = RefiningChain.ApplyStage(state, stage, coeffs);
+			state = RefiningChain.ApplyStage(state, stage, coefficients);
 			Assert.That(state.CompletedStages, Is.EqualTo(3));
 		}
 
 		[Test]
 		public void Quality_ClampedToValidRange_NoOverflow()
 		{
-			RefiningCoefficients coeffs = Coeffs();
+			RefiningCoefficients coefficients = DefaultCoefficients();
 			// 정성 단계(0.2)를 20회 거치면 4.0 이지만, [0,1] clamp 로 정확히 1.0.
-			RefiningState state = RefiningChain.Evaluate(MakeChain(RefiningApproach.Careful, 20), coeffs);
+			RefiningState state = RefiningChain.Evaluate(MakeChain(RefiningApproach.Careful, 20), coefficients);
 
 			Assert.That(state.Quality, Is.EqualTo(1f), "Quality 는 [0,1] clamp — 최고 등급 초과 X");
 		}
@@ -163,10 +163,10 @@ namespace WitchMendokusai.Tests
 		[Test]
 		public void Warmth_ClampedToSignedUnitRange()
 		{
-			RefiningCoefficients coeffs = Coeffs();
+			RefiningCoefficients coefficients = DefaultCoefficients();
 			// Fast(-0.2) 20회 = -4.0 이지만 clamp -1. 반대로 Careful 20회 = +4 → clamp +1.
-			RefiningState callous = RefiningChain.Evaluate(MakeChain(RefiningApproach.Fast, 20), coeffs);
-			RefiningState mourning = RefiningChain.Evaluate(MakeChain(RefiningApproach.Careful, 20), coeffs);
+			RefiningState callous = RefiningChain.Evaluate(MakeChain(RefiningApproach.Fast, 20), coefficients);
+			RefiningState mourning = RefiningChain.Evaluate(MakeChain(RefiningApproach.Careful, 20), coefficients);
 
 			Assert.That(callous.Warmth, Is.EqualTo(-1f), "온기 [-1,1] clamp — 함부로 누적 바닥");
 			Assert.That(mourning.Warmth, Is.EqualTo(1f), "온기 [-1,1] clamp — 애도 누적 천장");
@@ -188,7 +188,7 @@ namespace WitchMendokusai.Tests
 		public void StageOrder_IndependentOfKind_InPhase0()
 		{
 			// Phase 0 = 단계 Kind 별 가중치 X (Phase 1+ 에서 SO 로 들어옴). Kind 만 바뀌고 Approach 동일이면 결과 동일.
-			RefiningCoefficients coeffs = Coeffs();
+			RefiningCoefficients coefficients = DefaultCoefficients();
 			List<RefiningStage> order1 = new()
 			{
 				new RefiningStage(RefiningStageKind.Dissection, RefiningApproach.Careful),
@@ -202,8 +202,8 @@ namespace WitchMendokusai.Tests
 				new RefiningStage(RefiningStageKind.Purification, RefiningApproach.Careful),
 			};
 
-			RefiningState s1 = RefiningChain.Evaluate(order1, coeffs);
-			RefiningState s2 = RefiningChain.Evaluate(order2, coeffs);
+			RefiningState s1 = RefiningChain.Evaluate(order1, coefficients);
+			RefiningState s2 = RefiningChain.Evaluate(order2, coefficients);
 
 			Assert.That(s1.Quality, Is.EqualTo(s2.Quality), "Phase 0 = Kind 가중치 0, 순서 무관");
 			Assert.That(s1.Warmth, Is.EqualTo(s2.Warmth));

--- a/Assets/_WitchMendokusai/Tests/EditMode/Refining/RefiningChainTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/Refining/RefiningChainTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 404ba0abd6304cb9a3ac9f07963cc184


### PR DESCRIPTION
## Summary

**TASK-WM-172 Phase 0** = '잔해에서 피어나는' 다단계 가공 테크트리의 코어 누적 수학을 순수 POCO 로 먼저 박는 슬라이스. 마계 사체·잔재가 거치는 해부·정화·정련 3단계를 한 추상 함수 체인(Initial/ApplyStage/Evaluate)으로 표현하고, 단계 선택(빠름·정성) 비대칭이 품질 등급과 마을 온기에 동시에 영향을 미치는 모델을 만들었다.

- **DomainSDK/Refining/** (신규 6 파일, references=[] 유지) — POCO 만, Unity 게임플레이 무관(Mathf.Clamp 만 사용, RciDemandModel 선례). `WitchMendokusai.DomainSDK.Refining` 네임스페이스.
- **RefiningChain** = 정적 클래스, Initial → ApplyStage → Evaluate 순수 함수 3종 (RciDemandModel + InterventionModel 정합).
- **EditMode 12/12** — 스펙 필수 3종 충족: 품질 누적 결정성 · 빠름vs정성 분기 · 단순제작(1단계) ≡ ApplyStage 1회. 추가로 클램프(Quality [0,1] · Warmth [-1,1])·상쇄·순서 무관·CompletedStages 증가.

## Phase 0 슬라이스 매핑 (스펙 vs 구현)

| 스펙 요구 | 구현 위치 |
|---|---|
| `RefiningStage`(단계 정의) | `RefiningStage.cs` (Kind+Approach) + `RefiningStageKind`/`RefiningApproach` enums |
| `RefiningState`(누적 품질·온기) | `RefiningState.cs` (readonly struct: Quality, Warmth, CompletedStages) |
| `RefiningChain`(단계 진행 판정) | `RefiningChain.cs` (static — Initial/ApplyStage/Evaluate) |
| 품질 누적 결정성 | `Evaluate_IsDeterministic_SameInputSameOutput` |
| 빠름 vs 정성 분기 | `AllCareful_AchievesHigherQuality_ThanAllFast` + warmth 한 쌍 |
| 레거시 단순제작 동등 | `SingleStageChain_EqualsOneManualApply` (체인 보너스 없음) |

## 비전 정합 자가검사

- **MDD 두 태도**: Fast(링·충동) vs Careful(알리사·질서) — 계수 비대칭(Careful 0.2 vs Fast 0.05 품질 / Fast -0.2 vs Careful +0.2 온기)이 단순 효율 손익이 아니라 톤 갈림을 박는다.
- **마을 온기 게이지 직접 영향**: Warmth 가 부호 양분(-1..1), 함부로 누적 = 식어가는 마을 / 애도 누적 = 따뜻한 마을.
- **수치 노출 룰**: 계수는 POCO 디폴트 없이 명시 주입(테스트도 직접 공급). 게임 배선은 RefiningCoefficientsSO(Phase 1+)로 — 욘이 공방을 tweak.
- **DomainSDK 격리**: references=[] 유지, 외부 의존 0(UniTask/MessagePipe 도 사용 안 함). City/Life 와 동등 위계.
- **MissionAlignment**: §1 새 기능을 주도적으로 / §2 #1 황금의 정신(가설 X — 정밀 계수 명시) / §2 #3 자율 commit·push (게이트 외).

## ⚠ 검증 불가 영역 (PR Test plan)

격리 worktree 라 다음이 부재 → 컴파일 검증 못 함:
- MCP `read_console` / `mcpforunity://editor/state` (이 세션에 `mcp__*` 도구 미등록)
- `.mcp.json` (worktree 루트에 없음, McpAutoBinder 미주입)
- `unity-refresh.ps1` / `wm-editmode-smoke.ps1` (스크립트 부재)

**리뷰어 / 머지 전 액션**:
- [ ] Unity Editor 에서 `refresh_unity(mode="force")` → `read_console(types=["error","warning"], count=30)` = 0 확인
- [ ] EditMode 러너: `RefiningChainTest` 12개 GREEN 확인 (`Test Runner > EditMode > Refining`)
- [ ] asmdef 단방향 회귀 — DomainSDK 가 Core/Domain 끌어들이지 않음 확인

## Test plan (자가 산수 통과분)

- [x] `Coeffs` baseline (Q=0, FastQΔ=0.05, CarefulQΔ=0.2, FastWΔ=-0.2, CarefulWΔ=+0.2) → MixedApproach 합 (0.25 Q, 0 W) 일치
- [x] All-careful x3 Q=0.6 / W=0.6 > All-fast x3 Q=0.15 / W=-0.6 — 분기 보장
- [x] 클램프: 20회 누적이 [0,1]/[-1,1] 밖 안 나감 (수동 계산: 4.0 → 1.0 / -4.0 → -1.0)
- [x] Phase 0 = StageKind 가중치 X — 순서 무관 (Phase 1+ 가중치 도입 자리)
- [ ] **Editor 사이드 GREEN** (위 ⚠ 영역 — 리뷰어 / 머지 전 실행 필요)

## 다음 Phase

- **Phase 1**: 1재료 정련 체인 수직 슬라이스 (잔해 ItemData → RefiningChain → 정련물 ItemData), SO 노출 + UI 토스트
- **Phase 2**: 윤리/온기 게이지 시스템 통합 (마을 온기 게이지 SO 와 배선)
- **Phase 3**: 일꾼 인형 생성 매핑 (정련 부위/조합 → 능력)

> 사용자 컨펌 대기(스펙 「사용자 컨펌 대기」§): 다크 톤 수위 · 윤리 페널티 무게 · 일꾼 정체성 · 마족 사체 윤리 · 공방 비주얼 위치. Phase 0 substrate 자율 진행 후 Phase 1+ 진입 전 디스코드 디시전.

🤖 Generated with [Claude Code](https://claude.com/claude-code)