### PR TITLE
feat(TASK-WM-173): 마력의 강 Phase 0 — 레이라인 흐름 POCO 코어

### DIFF
--- a/Assets/_WitchMendokusai/DomainSDK/Logistics.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cc0da1ed3c8d417c9191bf824914726c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/Freshness.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/Freshness.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace WitchMendokusai
+{
+	// 마력 신선도 감쇠 모델 — 순수 함수(상태 0). Phase 0 = 거리 기반 선형 감쇠만; 시간 기반은
+	// Phase 2(노화 틱 + TimeManager 연동)에서 별 함수로 first-use 추가 (현재 추가 = 데드 인터페이스).
+	//
+	// 모델: remaining = max(0, 1 - distance × decayRate). 단순하지만 결정적이고 「길수록 줄어든다」
+	// 직관과 정합. exp 모델(e^(-distance×rate))은 부드러우나 0 으로 점근만 해 「완전히 흩어짐」
+	// 표현이 약함 — Phase 0 슬라이스 체감(짧은 직선 vs 긴 우회) 에는 선형이 더 또렷.
+	//
+	// 수치(decayRate) 는 호출자(추후 SO/Variable<float>)가 주입 — CLAUDE.md 「수치 노출 / 런타임
+	// tweak」 룰: 모델은 산술만, 계수는 외부 정본.
+	public static class Freshness
+	{
+		// 거리 distance 만큼 흐른 뒤의 신선도 비율 [0, 1]. 0 = 완전히 흩어짐, 1 = 그대로.
+		// 결정적: 같은 (distance, decayRate) = 같은 출력.
+		public static float DecayByDistance(float distance, float decayRate)
+		{
+			if (distance < 0f)
+			{
+				throw new ArgumentOutOfRangeException(nameof(distance), distance, "거리는 음수일 수 없다");
+			}
+
+			if (decayRate < 0f)
+			{
+				throw new ArgumentOutOfRangeException(nameof(decayRate), decayRate, "감쇠율은 음수일 수 없다");
+			}
+
+			float remaining = 1f - distance * decayRate;
+			if (remaining < 0f)
+			{
+				return 0f;
+			}
+
+			return remaining;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/Freshness.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/Freshness.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 635e5a1a306d4ffb9c3aa0e15defdae4

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineEdge.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineEdge.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace WitchMendokusai
+{
+	// 두 노드를 잇는 배선 한 가닥. RoadGraph 의 4-이웃 인접(엣지=인접 → 길이 항상 1)과 달리,
+	// 레이라인 엣지는 ① 사용자가 명시적으로 깔고 ② Length 가중치를 가진다. Length 가 곧 마력
+	// 노화 거리(Freshness.DecayByDistance) 의 입력이 되어 「긴 우회 vs 짧은 직선」 퍼즐을 만든다.
+	//
+	// Directional — 마계 → 마을 흐름은 한 방향(역방향 흐름은 호출자가 두 엣지로 표현). v1 미스
+	// 큐: 양방향 표현 시 LeylineGraph.AddEdge 호출 2회로 명시 (모델 내부 자동 미러링 X — 의미
+	// 결정을 모델이 추측 안 함).
+	//
+	// Length <= 0 = boundary 위반 → FastFail. 0 길이 엣지는 노화 모델을 망가뜨림(거리 0 = 무손
+	// 텔레포트 vs 의도된 비용이 헷갈림 — 정말 무손이면 별도 TeleportLink 타입을 first-use 에 추가).
+	public sealed class LeylineEdge
+	{
+		public string FromId { get; }
+		public string ToId { get; }
+		public float Length { get; }
+
+		public LeylineEdge(string fromId, string toId, float length)
+		{
+			if (string.IsNullOrEmpty(fromId))
+			{
+				throw new ArgumentException("LeylineEdge.FromId 는 비어있을 수 없다", nameof(fromId));
+			}
+
+			if (string.IsNullOrEmpty(toId))
+			{
+				throw new ArgumentException("LeylineEdge.ToId 는 비어있을 수 없다", nameof(toId));
+			}
+
+			if (length <= 0f)
+			{
+				throw new ArgumentOutOfRangeException(nameof(length), length, "LeylineEdge.Length 는 양수여야 한다");
+			}
+
+			FromId = fromId;
+			ToId = toId;
+			Length = length;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineEdge.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineEdge.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0548b136624348b0971f28218093697e

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineGraph.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineGraph.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+
+namespace WitchMendokusai
+{
+	// 마력 배선 망의 그래프 모델 — 순수 POCO. RoadGraph(격자 셀 dict, 4-이웃 자동 인접) 와 닮은
+	// BFS·연결 컴포넌트 토대를 가지나 데이터 모델이 직교:
+	//   RoadGraph    = Vector3Int 셀 + 4-이웃(엣지 런타임 유도) + 길이 항상 1
+	//   LeylineGraph = string id 노드(임의 위치) + 명시적 엣지 + 가중치 Length
+	// 「격자 위 통근」 vs 「거점 간 가중치 흐름」 의 의미 차이가 자료구조 차이로 그대로 나타난다.
+	//
+	// 향후 공통화 여지: Neighbors/FindShortestPath 추상이 두 그래프에 공통(WM-164 Phase 2 deferred
+	// 의 RoadGraph BFS 중복 추출과 함께 IGraph<T> 로 묶기 가능). 단 Phase 0 = first-use 우선,
+	// 신규 시 선제 추상화 금지 (CLAUDE.md 「데드 인터페이스 방지」).
+	//
+	// 알고리즘: 최단 경로 = Dijkstra(엣지 length 가중치). RoadGraph 의 BFS(균등 가중치) 대신
+	// length 차이를 의미있게 반영 — Phase 0 핵심 퍼즐(「긴 우회 vs 짧은 직선」) 의 모델 기반.
+	public sealed class LeylineGraph
+	{
+		private readonly Dictionary<string, LeylineNode> nodes = new();
+		private readonly List<LeylineEdge> edges = new();
+		private readonly Dictionary<string, List<LeylineEdge>> outgoingByNode = new();
+
+		public IReadOnlyDictionary<string, LeylineNode> Nodes => nodes;
+		public IReadOnlyList<LeylineEdge> Edges => edges;
+
+		// 노드 등록 — 같은 id 재등록은 덮어쓰기(RoadGraph.AddRoad 의 페인트 멱등성 답습 — UGC
+		// 워크플로에서 노드 속성 변경이 자주 일어남).
+		public void AddNode(LeylineNode node)
+		{
+			if (node == null)
+			{
+				throw new ArgumentNullException(nameof(node));
+			}
+
+			nodes[node.Id] = node;
+			if (outgoingByNode.ContainsKey(node.Id) == false)
+			{
+				outgoingByNode[node.Id] = new List<LeylineEdge>();
+			}
+		}
+
+		// 엣지 등록 — 양 끝 노드가 사전 등록돼야 함(FastFail). RoadGraph 가 셀 인접성만 검사하면
+		// 되는 것과 달리, 엣지가 명시적이라 양 끝점 무결성을 그래프가 책임짐.
+		public void AddEdge(LeylineEdge edge)
+		{
+			if (edge == null)
+			{
+				throw new ArgumentNullException(nameof(edge));
+			}
+
+			if (nodes.ContainsKey(edge.FromId) == false)
+			{
+				throw new InvalidOperationException($"LeylineEdge.FromId '{edge.FromId}' 노드가 그래프에 없음 — AddNode 먼저");
+			}
+
+			if (nodes.ContainsKey(edge.ToId) == false)
+			{
+				throw new InvalidOperationException($"LeylineEdge.ToId '{edge.ToId}' 노드가 그래프에 없음 — AddNode 먼저");
+			}
+
+			edges.Add(edge);
+			outgoingByNode[edge.FromId].Add(edge);
+		}
+
+		// 한 노드에서 나가는 엣지들(directional). 미등록 노드면 빈 — FastFail 아닌 정상 질의 결과
+		// (RoadGraph.Neighbors 와 같은 형식).
+		public IEnumerable<LeylineEdge> Outgoing(string nodeId)
+		{
+			if (outgoingByNode.TryGetValue(nodeId, out List<LeylineEdge> outgoing))
+			{
+				return outgoing;
+			}
+
+			return System.Array.Empty<LeylineEdge>();
+		}
+
+		// 최단 경로(엣지 length 합 최소). Dijkstra — 양수 가중치 보장(LeylineEdge.Length > 0).
+		// from→to 노드 id 시퀀스 반환. 미연결이면 빈 리스트(RoadGraph.FindPath 와 동형 — FastFail
+		// 아닌 「경로 없음」 정상 결과). from==to 면 단일 원소.
+		//
+		// O((V+E) log V) 가 정석이나 Phase 0 망 규모(<100 노드 예상)에선 단순 O((V+E) V) 우선순위
+		// 탐색으로 충분 — 노드 수 폭발 시 PriorityQueue<T> (System.Collections.Generic, .NET 6+) 로 격상.
+		public List<string> FindShortestPath(string fromId, string toId)
+		{
+			List<string> path = new();
+
+			if (nodes.ContainsKey(fromId) == false || nodes.ContainsKey(toId) == false)
+			{
+				return path;
+			}
+
+			if (fromId == toId)
+			{
+				path.Add(fromId);
+				return path;
+			}
+
+			Dictionary<string, float> distances = new();
+			Dictionary<string, string> predecessor = new();
+			HashSet<string> visited = new();
+
+			foreach (string nodeId in nodes.Keys)
+			{
+				distances[nodeId] = float.PositiveInfinity;
+			}
+			distances[fromId] = 0f;
+
+			while (true)
+			{
+				// 미방문 노드 중 거리 최소 선택.
+				string current = null;
+				float currentDistance = float.PositiveInfinity;
+				foreach ((string nodeId, float distance) in distances)
+				{
+					if (visited.Contains(nodeId))
+					{
+						continue;
+					}
+
+					if (distance < currentDistance)
+					{
+						currentDistance = distance;
+						current = nodeId;
+					}
+				}
+
+				if (current == null || float.IsPositiveInfinity(currentDistance))
+				{
+					// 도달 가능 노드 소진.
+					break;
+				}
+
+				if (current == toId)
+				{
+					break;
+				}
+
+				visited.Add(current);
+
+				foreach (LeylineEdge edge in outgoingByNode[current])
+				{
+					float candidate = currentDistance + edge.Length;
+					if (candidate < distances[edge.ToId])
+					{
+						distances[edge.ToId] = candidate;
+						predecessor[edge.ToId] = current;
+					}
+				}
+			}
+
+			if (float.IsPositiveInfinity(distances[toId]))
+			{
+				return path;
+			}
+
+			// to → from 역추적 후 뒤집어 from→to 순서로 (RoadGraph.FindPath 패턴 답습).
+			string step = toId;
+			path.Add(step);
+			while (step != fromId)
+			{
+				step = predecessor[step];
+				path.Add(step);
+			}
+			path.Reverse();
+
+			return path;
+		}
+
+		// 노드 id 시퀀스의 총 엣지 길이 합. 인접 노드 쌍에 대응하는 엣지를 outgoing 에서 찾아
+		// 누적 — 같은 from→to 사이에 다중 엣지가 있으면 최단 엣지 채택(망 설계 의도와 일치:
+		// 두 노드를 다중 배선으로 잇는 건 redundancy 표현, 흐름은 짧은 쪽으로).
+		// 경로가 빈/단일 노드면 0 (정상 결과).
+		public float PathLength(List<string> path)
+		{
+			if (path == null || path.Count < 2)
+			{
+				return 0f;
+			}
+
+			float total = 0f;
+			for (int i = 1; i < path.Count; i++)
+			{
+				string from = path[i - 1];
+				string to = path[i];
+				float bestLength = float.PositiveInfinity;
+				foreach (LeylineEdge edge in Outgoing(from))
+				{
+					if (edge.ToId == to && edge.Length < bestLength)
+					{
+						bestLength = edge.Length;
+					}
+				}
+
+				if (float.IsPositiveInfinity(bestLength))
+				{
+					throw new InvalidOperationException($"경로 인접 쌍 '{from}'→'{to}' 에 엣지 없음 — 잘못된 경로");
+				}
+
+				total += bestLength;
+			}
+
+			return total;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineGraph.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineGraph.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a2f22104cea42ea8b665ba6c27c65e1

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineNode.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineNode.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace WitchMendokusai
+{
+	// 레이라인 망의 노드. 격자 셀이 아니라 임의 위치 거점 — RoadGraph(Vector3Int 셀 + 4-이웃)
+	// 와 결정적으로 다른 점: 노드는 id 로 식별되고 인접성은 명시적 엣지로만 정해진다. 그래서
+	// 좌표는 노드 모델에 없음(시각/배치는 별도 layer 책임 — 6 동기 「분리」).
+	//
+	// id 비어있음 = boundary 위반 → FastFail throw. LeylineGraph 가 노드를 id 로 색인하므로
+	// 빈 id 가 들어오면 그래프 무결성이 깨짐(중복 키 / 엣지 미해결).
+	public sealed class LeylineNode
+	{
+		public string Id { get; }
+		public LeylineNodeKind Kind { get; }
+
+		public LeylineNode(string id, LeylineNodeKind kind)
+		{
+			if (string.IsNullOrEmpty(id))
+			{
+				throw new ArgumentException("LeylineNode.Id 는 비어있을 수 없다", nameof(id));
+			}
+
+			Id = id;
+			Kind = kind;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineNode.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineNode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5020587e7a1c47a296b23725f13c7b18

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineNodeKind.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineNodeKind.cs
@@ -1,0 +1,15 @@
+namespace WitchMendokusai
+{
+	// 레이라인 거점의 의미적 역할. 게이트(공급) → 공방(소비) 가 Phase 0 기본 흐름,
+	// Relay 는 중간 환승 (긴 거리를 짧은 엣지로 잘게 나눠 깔 때).
+	// None = sentinel (RoadType 패턴 답습, 데드 인터페이스 0 필드 선제 추가 회피 — 향후
+	// Storage/Junction 등 first-use 시 확장).
+	public enum LeylineNodeKind
+	{
+		None = -1,
+
+		Source = 0,
+		Sink = 1,
+		Relay = 2,
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineNodeKind.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/LeylineNodeKind.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 85fb5e2d8f084fa586bc6942a713d6a5

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/ManaFlow.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/ManaFlow.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace WitchMendokusai
+{
+	// 마력 흐름 계산기 — 보낸 양 × 신선도 = 도착량. 순수 함수(상태 0). Phase 0 슬라이스의 본 의도:
+	//   "두 노드(마계 게이트 → 공방) 흐름 → 거리에 따라 신선도 줄어든 채 도착, 도착량 수치 표시."
+	// 망 위 계산(CalculateOnGraph)은 LeylineGraph 의 최단 경로를 길이로 환산해 Freshness 에 위임.
+	//
+	// 경로 노화의 합성 모델: Phase 0 = 「총 경로 길이를 한 번에 Freshness 에 통과」(엣지별 누적
+	// 곱 아님). 선형 감쇠라 둘이 산술적으로 거의 동치이고, exp 으로 격상 시 「엣지별 곱 vs 총길
+	// 한 번」 의 의미 차이가 생김(엣지별 곱 = 매 홉마다 fresh-clamp, 한 번 = 누적 거리 함수).
+	// Phase 0 = 「한 번」을 정본으로(단순 + Phase 2 시간 노화 합산과 같은 모양).
+	public static class ManaFlow
+	{
+		// 보낸 양 sentAmount 이 길이 pathLength 의 배선을 거쳐 도착한 양. 신선도가 0 이면 0,
+		// 1 이면 그대로. 음수 입력 = boundary 위반 → FastFail.
+		public static float CalculateArrivalAmount(float sentAmount, float pathLength, float decayRate)
+		{
+			if (sentAmount < 0f)
+			{
+				throw new ArgumentOutOfRangeException(nameof(sentAmount), sentAmount, "보낸 양은 음수일 수 없다");
+			}
+
+			float freshness = Freshness.DecayByDistance(pathLength, decayRate);
+			return sentAmount * freshness;
+		}
+
+		// 그래프 위 source→sink 의 도착량. 최단 경로를 찾아 길이를 합쳐 도착량 계산.
+		// 미연결 = 0 (FastFail 아닌 「경로 없음 = 도착 0」 정상 결과 — RoadGraph.FindPath 동형).
+		// 같은 망 입력 = 같은 결과 (Dijkstra + 선형 감쇠 모두 결정적 — 6 동기 「퀄리티」 EditMode 잠금).
+		public static float CalculateOnGraph(LeylineGraph graph, string sourceId, string sinkId, float sentAmount, float decayRate)
+		{
+			if (graph == null)
+			{
+				throw new ArgumentNullException(nameof(graph));
+			}
+
+			List<string> path = graph.FindShortestPath(sourceId, sinkId);
+			if (path.Count == 0)
+			{
+				return 0f;
+			}
+
+			float pathLength = graph.PathLength(path);
+			return CalculateArrivalAmount(sentAmount, pathLength, decayRate);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Logistics/ManaFlow.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Logistics/ManaFlow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: efbd1c0f19bb4c8bafa834c0764a0eb5

--- a/Assets/_WitchMendokusai/Tests/EditMode/FreshnessTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/FreshnessTest.cs
@@ -1,0 +1,74 @@
+using System;
+using NUnit.Framework;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-173 Phase 0 — <see cref="Freshness"/> 거리 기반 선형 감쇠 모델 회귀 잠금.
+	///
+	/// 결정성·경계(거리 0/큰 거리)·음수 입력 boundary 검증. 순수 함수 → EditMode 우선.
+	/// </summary>
+	public sealed class FreshnessTest
+	{
+		[Test]
+		public void DecayByDistance_ZeroDistance_FullFresh()
+		{
+			Assert.That(Freshness.DecayByDistance(0f, 0.1f), Is.EqualTo(1f).Within(0.0001f), "거리 0 = 전혀 흐르지 않음 = 신선도 그대로");
+		}
+
+		[Test]
+		public void DecayByDistance_ZeroRate_NoDecay()
+		{
+			// 노화율 0 = 어떤 거리도 무손 (예: 텔레포트 마법진 톤의 차후 첫 사용 표현).
+			Assert.That(Freshness.DecayByDistance(100f, 0f), Is.EqualTo(1f).Within(0.0001f));
+		}
+
+		[Test]
+		public void DecayByDistance_LinearMidpoint()
+		{
+			// 1 - 5 × 0.1 = 0.5.
+			Assert.That(Freshness.DecayByDistance(5f, 0.1f), Is.EqualTo(0.5f).Within(0.0001f));
+		}
+
+		[Test]
+		public void DecayByDistance_BeyondFullDecay_ClampsToZero()
+		{
+			// 1 - 20 × 0.1 = -1 → 0 (음수 신선도 없음 — 완전히 흩어짐).
+			Assert.That(Freshness.DecayByDistance(20f, 0.1f), Is.Zero);
+		}
+
+		[Test]
+		public void DecayByDistance_Monotonic_LongerDecaysMore()
+		{
+			// 길이 ↑ → 신선도 ↓ (단조 감소). Phase 0 핵심 직관.
+			float shortFresh = Freshness.DecayByDistance(2f, 0.1f);
+			float longFresh = Freshness.DecayByDistance(8f, 0.1f);
+
+			Assert.That(shortFresh, Is.GreaterThan(longFresh), "짧은 거리가 더 신선");
+		}
+
+		[Test]
+		public void DecayByDistance_DeterministicAcrossCalls()
+		{
+			// 6 동기 「퀄리티」 — 같은 입력 = 같은 출력 (1000회).
+			float first = Freshness.DecayByDistance(3.7f, 0.13f);
+			for (int i = 0; i < 1000; i++)
+			{
+				Assert.That(Freshness.DecayByDistance(3.7f, 0.13f), Is.EqualTo(first), "결정성 — 부동소수 같은 입력 = 같은 비트");
+			}
+		}
+
+		[Test]
+		public void DecayByDistance_NegativeDistance_Throws()
+		{
+			// boundary — 음수 거리는 외부 입력 위반(FastFail).
+			Assert.Throws<ArgumentOutOfRangeException>(() => Freshness.DecayByDistance(-1f, 0.1f));
+		}
+
+		[Test]
+		public void DecayByDistance_NegativeRate_Throws()
+		{
+			Assert.Throws<ArgumentOutOfRangeException>(() => Freshness.DecayByDistance(1f, -0.1f));
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/FreshnessTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/FreshnessTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8f00199957724875bf614caad17f1e80

--- a/Assets/_WitchMendokusai/Tests/EditMode/LeylineGraphTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/LeylineGraphTest.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-173 Phase 0 — <see cref="LeylineGraph"/> 명시적 가중치 그래프 회귀 잠금.
+	///
+	/// LeylineGraph 는 마력의 강 Phase 0 흐름 모델의 토대 — RoadGraph 와 구조는 닮았으나
+	/// 데이터 모델이 다름(임의 위치 노드 id + 명시적 가중치 엣지 vs 격자 셀 + 4-이웃). 결정성·경로
+	/// 길이·미연결·자기자신 같은 핵심 불변식을 잠근다. RoadGraphTest 패턴 답습(new() + Assert.That).
+	///
+	/// 순수 POCO — Unity 의존 0.
+	/// </summary>
+	public sealed class LeylineGraphTest
+	{
+		private static LeylineNode N(string id, LeylineNodeKind kind = LeylineNodeKind.Relay)
+		{
+			return new LeylineNode(id, kind);
+		}
+
+		[Test]
+		public void AddNode_RegistersNodeById()
+		{
+			LeylineGraph graph = new();
+			LeylineNode gate = N("gate", LeylineNodeKind.Source);
+
+			graph.AddNode(gate);
+
+			Assert.That(graph.Nodes.ContainsKey("gate"), Is.True);
+			Assert.That(graph.Nodes["gate"].Kind, Is.EqualTo(LeylineNodeKind.Source));
+		}
+
+		[Test]
+		public void AddNode_SameIdOverwrites_KindUpdates()
+		{
+			// RoadGraph.AddRoad 페인트 멱등성과 동형 — UGC 워크플로에서 노드 속성 변경 흔함.
+			LeylineGraph graph = new();
+			graph.AddNode(N("workshop", LeylineNodeKind.Relay));
+			graph.AddNode(N("workshop", LeylineNodeKind.Sink));
+
+			Assert.That(graph.Nodes.Count, Is.EqualTo(1));
+			Assert.That(graph.Nodes["workshop"].Kind, Is.EqualTo(LeylineNodeKind.Sink));
+		}
+
+		[Test]
+		public void AddEdge_UnknownEndpoint_Throws()
+		{
+			// FastFail — 그래프 무결성이 엣지 양 끝점 등록 보장에 달려있음.
+			LeylineGraph graph = new();
+			graph.AddNode(N("a"));
+
+			Assert.Throws<InvalidOperationException>(() => graph.AddEdge(new LeylineEdge("a", "ghost", 1f)));
+			Assert.Throws<InvalidOperationException>(() => graph.AddEdge(new LeylineEdge("ghost", "a", 1f)));
+		}
+
+		[Test]
+		public void Outgoing_OnlyFromEdges_Directional()
+		{
+			LeylineGraph graph = new();
+			graph.AddNode(N("a"));
+			graph.AddNode(N("b"));
+			graph.AddNode(N("c"));
+			graph.AddEdge(new LeylineEdge("a", "b", 1f));
+			graph.AddEdge(new LeylineEdge("a", "c", 2f));
+			graph.AddEdge(new LeylineEdge("b", "a", 5f));
+
+			List<LeylineEdge> aOut = graph.Outgoing("a").ToList();
+
+			Assert.That(aOut.Count, Is.EqualTo(2), "a 에서 나가는 엣지는 a→b, a→c 2개 (b→a 역방향 제외)");
+			Assert.That(aOut.Any(edge => edge.ToId == "b"), Is.True);
+			Assert.That(aOut.Any(edge => edge.ToId == "c"), Is.True);
+		}
+
+		[Test]
+		public void Outgoing_UnknownNode_ReturnsEmpty()
+		{
+			// 미등록 노드 질의는 빈 (RoadGraph.Neighbors 와 같은 형식 — FastFail 아닌 정상 결과).
+			LeylineGraph graph = new();
+			Assert.That(graph.Outgoing("ghost"), Is.Empty);
+		}
+
+		[Test]
+		public void FindShortestPath_DirectEdge_ReturnsTwoNodes()
+		{
+			LeylineGraph graph = new();
+			graph.AddNode(N("gate", LeylineNodeKind.Source));
+			graph.AddNode(N("workshop", LeylineNodeKind.Sink));
+			graph.AddEdge(new LeylineEdge("gate", "workshop", 4f));
+
+			List<string> path = graph.FindShortestPath("gate", "workshop");
+
+			Assert.That(path, Is.EqualTo(new List<string> { "gate", "workshop" }));
+		}
+
+		[Test]
+		public void FindShortestPath_TwoRoutes_PicksShorterByLength()
+		{
+			// 직선 (gate→workshop, 길이 10) vs 우회 (gate→relay→workshop, 1+2=3).
+			// BFS(균등 가중치) 라면 직선(1 hop) 을 고르지만, Dijkstra(가중치) 는 우회(3) 선택.
+			// 이게 RoadGraph.FindPath(BFS) 와의 결정적 차이 — Phase 0 핵심 퍼즐의 모델 기반.
+			LeylineGraph graph = new();
+			graph.AddNode(N("gate", LeylineNodeKind.Source));
+			graph.AddNode(N("relay"));
+			graph.AddNode(N("workshop", LeylineNodeKind.Sink));
+			graph.AddEdge(new LeylineEdge("gate", "workshop", 10f));
+			graph.AddEdge(new LeylineEdge("gate", "relay", 1f));
+			graph.AddEdge(new LeylineEdge("relay", "workshop", 2f));
+
+			List<string> path = graph.FindShortestPath("gate", "workshop");
+
+			Assert.That(path, Is.EqualTo(new List<string> { "gate", "relay", "workshop" }),
+				"가중치 합 작은 우회 경로(3) 가 직선(10) 보다 짧음");
+			Assert.That(graph.PathLength(path), Is.EqualTo(3f).Within(0.0001f));
+		}
+
+		[Test]
+		public void FindShortestPath_Disconnected_ReturnsEmpty()
+		{
+			LeylineGraph graph = new();
+			graph.AddNode(N("a"));
+			graph.AddNode(N("b"));
+			graph.AddNode(N("c"));
+			graph.AddNode(N("d"));
+			graph.AddEdge(new LeylineEdge("a", "b", 1f));
+			graph.AddEdge(new LeylineEdge("c", "d", 1f));
+
+			Assert.That(graph.FindShortestPath("a", "d"), Is.Empty, "분리된 두 망 — 경로 없음 = 빈 (FastFail 아닌 정상 결과)");
+		}
+
+		[Test]
+		public void FindShortestPath_NoOutgoingFromSource_ReturnsEmpty()
+		{
+			// directional — b→a 엣지만 있고 a→b 없으면 a→b 도달 불가.
+			LeylineGraph graph = new();
+			graph.AddNode(N("a"));
+			graph.AddNode(N("b"));
+			graph.AddEdge(new LeylineEdge("b", "a", 1f));
+
+			Assert.That(graph.FindShortestPath("a", "b"), Is.Empty, "directional — 역방향 엣지로는 도달 X");
+		}
+
+		[Test]
+		public void FindShortestPath_SameNode_ReturnsSingle()
+		{
+			LeylineGraph graph = new();
+			graph.AddNode(N("self"));
+
+			Assert.That(graph.FindShortestPath("self", "self"), Is.EqualTo(new List<string> { "self" }));
+		}
+
+		[Test]
+		public void FindShortestPath_UnknownEndpoint_ReturnsEmpty()
+		{
+			LeylineGraph graph = new();
+			graph.AddNode(N("a"));
+
+			Assert.That(graph.FindShortestPath("a", "ghost"), Is.Empty);
+			Assert.That(graph.FindShortestPath("ghost", "a"), Is.Empty);
+		}
+
+		[Test]
+		public void FindShortestPath_DeterministicAcrossRuns()
+		{
+			// 6 동기 「퀄리티」 — 같은 망 = 같은 경로. 같은 망 4번 빌드해 같은 path/length 검증.
+			List<string> reference = null;
+			float referenceLength = -1f;
+			for (int run = 0; run < 4; run++)
+			{
+				LeylineGraph graph = new();
+				graph.AddNode(N("a", LeylineNodeKind.Source));
+				graph.AddNode(N("b"));
+				graph.AddNode(N("c"));
+				graph.AddNode(N("d", LeylineNodeKind.Sink));
+				graph.AddEdge(new LeylineEdge("a", "b", 2f));
+				graph.AddEdge(new LeylineEdge("b", "d", 3f));
+				graph.AddEdge(new LeylineEdge("a", "c", 1f));
+				graph.AddEdge(new LeylineEdge("c", "d", 5f));
+
+				List<string> path = graph.FindShortestPath("a", "d");
+				float length = graph.PathLength(path);
+
+				if (run == 0)
+				{
+					reference = path;
+					referenceLength = length;
+				}
+				else
+				{
+					Assert.That(path, Is.EqualTo(reference), $"run {run} 경로 = run 0 와 같음 (결정성)");
+					Assert.That(length, Is.EqualTo(referenceLength).Within(0.0001f), $"run {run} 길이 = run 0 와 같음");
+				}
+			}
+		}
+
+		[Test]
+		public void PathLength_EmptyOrSingle_ReturnsZero()
+		{
+			LeylineGraph graph = new();
+			graph.AddNode(N("a"));
+
+			Assert.That(graph.PathLength(new List<string>()), Is.Zero);
+			Assert.That(graph.PathLength(new List<string> { "a" }), Is.Zero);
+			Assert.That(graph.PathLength(null), Is.Zero);
+		}
+
+		[Test]
+		public void PathLength_MultiEdgeBetweenSameNodes_PicksShorter()
+		{
+			// a→b 다중 엣지(redundancy 표현). PathLength 는 짧은 쪽 채택.
+			LeylineGraph graph = new();
+			graph.AddNode(N("a"));
+			graph.AddNode(N("b"));
+			graph.AddEdge(new LeylineEdge("a", "b", 7f));
+			graph.AddEdge(new LeylineEdge("a", "b", 2f));
+
+			float length = graph.PathLength(new List<string> { "a", "b" });
+
+			Assert.That(length, Is.EqualTo(2f).Within(0.0001f), "다중 엣지 중 짧은 쪽 채택 (redundancy = 흐름은 짧은 쪽)");
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/LeylineGraphTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/LeylineGraphTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 01ab968612ef4a648c1c02fcdd8160bd

--- a/Assets/_WitchMendokusai/Tests/EditMode/ManaFlowTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/ManaFlowTest.cs
@@ -1,0 +1,138 @@
+using System;
+using NUnit.Framework;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-173 Phase 0 — <see cref="ManaFlow"/> 도착량 계산 회귀 잠금.
+	///
+	/// Phase 0 슬라이스 본 의도("두 노드 → 거리 따라 신선도 줄어든 채 도착, 도착량 수치 표시")
+	/// 의 모델 검증. LeylineGraph + Freshness 합성 — 「짧은 직선 vs 긴 우회 = 도착량 차」 잠금.
+	/// </summary>
+	public sealed class ManaFlowTest
+	{
+		[Test]
+		public void CalculateArrivalAmount_ZeroLength_FullAmount()
+		{
+			Assert.That(ManaFlow.CalculateArrivalAmount(100f, 0f, 0.1f), Is.EqualTo(100f).Within(0.0001f));
+		}
+
+		[Test]
+		public void CalculateArrivalAmount_FullDecay_Zero()
+		{
+			// 길이 20 × 0.1 = 2.0 → 신선도 0 → 도착량 0.
+			Assert.That(ManaFlow.CalculateArrivalAmount(100f, 20f, 0.1f), Is.Zero);
+		}
+
+		[Test]
+		public void CalculateArrivalAmount_LinearMidpoint()
+		{
+			// 길이 5 × 0.1 → 신선도 0.5 → 100 × 0.5 = 50.
+			Assert.That(ManaFlow.CalculateArrivalAmount(100f, 5f, 0.1f), Is.EqualTo(50f).Within(0.0001f));
+		}
+
+		[Test]
+		public void CalculateArrivalAmount_NegativeSent_Throws()
+		{
+			Assert.Throws<ArgumentOutOfRangeException>(() => ManaFlow.CalculateArrivalAmount(-1f, 1f, 0.1f));
+		}
+
+		[Test]
+		public void CalculateOnGraph_TwoNodeSlice_FreshnessApplied()
+		{
+			// Phase 0 슬라이스 본 의도 — 마계 게이트 → 공방 2노드 흐름.
+			LeylineGraph graph = new();
+			graph.AddNode(new LeylineNode("gate", LeylineNodeKind.Source));
+			graph.AddNode(new LeylineNode("workshop", LeylineNodeKind.Sink));
+			graph.AddEdge(new LeylineEdge("gate", "workshop", 4f));
+
+			// 보낸 마력 100, 거리 4, 감쇠율 0.1 → 신선도 0.6 → 60.
+			float arrived = ManaFlow.CalculateOnGraph(graph, "gate", "workshop", 100f, 0.1f);
+
+			Assert.That(arrived, Is.EqualTo(60f).Within(0.0001f));
+		}
+
+		[Test]
+		public void CalculateOnGraph_ShorterRouteArrivesMore()
+		{
+			// 「짧은 직선 vs 긴 우회」 = Phase 0 퍼즐 핵심. Dijkstra 가 짧은 쪽 자동 선택 → 도착량 차.
+			LeylineGraph shortGraph = new();
+			shortGraph.AddNode(new LeylineNode("gate", LeylineNodeKind.Source));
+			shortGraph.AddNode(new LeylineNode("workshop", LeylineNodeKind.Sink));
+			shortGraph.AddEdge(new LeylineEdge("gate", "workshop", 2f));
+
+			LeylineGraph longGraph = new();
+			longGraph.AddNode(new LeylineNode("gate", LeylineNodeKind.Source));
+			longGraph.AddNode(new LeylineNode("workshop", LeylineNodeKind.Sink));
+			longGraph.AddEdge(new LeylineEdge("gate", "workshop", 8f));
+
+			float shortArrived = ManaFlow.CalculateOnGraph(shortGraph, "gate", "workshop", 100f, 0.1f);
+			float longArrived = ManaFlow.CalculateOnGraph(longGraph, "gate", "workshop", 100f, 0.1f);
+
+			Assert.That(shortArrived, Is.GreaterThan(longArrived), "짧은 배선이 더 많이 도착");
+			Assert.That(shortArrived, Is.EqualTo(80f).Within(0.0001f));
+			Assert.That(longArrived, Is.EqualTo(20f).Within(0.0001f));
+		}
+
+		[Test]
+		public void CalculateOnGraph_Disconnected_ReturnsZero()
+		{
+			// 미연결 = 0 도착 (FastFail 아닌 「경로 없음 = 흐름 없음」 정상 결과).
+			LeylineGraph graph = new();
+			graph.AddNode(new LeylineNode("a", LeylineNodeKind.Source));
+			graph.AddNode(new LeylineNode("b", LeylineNodeKind.Sink));
+
+			Assert.That(ManaFlow.CalculateOnGraph(graph, "a", "b", 100f, 0.1f), Is.Zero);
+		}
+
+		[Test]
+		public void CalculateOnGraph_RelayedRoute_AccumulatesLength()
+		{
+			// 우회 (a→relay→b, 1+2=3) 가 직선(a→b, 10) 보다 짧음 → Dijkstra 가 우회 채택.
+			// 우회 누적 길이 3 × 0.1 = 0.3 감쇠 → 신선도 0.7 → 100 × 0.7 = 70.
+			LeylineGraph graph = new();
+			graph.AddNode(new LeylineNode("a", LeylineNodeKind.Source));
+			graph.AddNode(new LeylineNode("relay"));
+			graph.AddNode(new LeylineNode("b", LeylineNodeKind.Sink));
+			graph.AddEdge(new LeylineEdge("a", "b", 10f));
+			graph.AddEdge(new LeylineEdge("a", "relay", 1f));
+			graph.AddEdge(new LeylineEdge("relay", "b", 2f));
+
+			float arrived = ManaFlow.CalculateOnGraph(graph, "a", "b", 100f, 0.1f);
+
+			Assert.That(arrived, Is.EqualTo(70f).Within(0.0001f), "우회(누적 3) 가 선택, 100 × (1 - 0.3) = 70");
+		}
+
+		[Test]
+		public void CalculateOnGraph_DeterministicAcrossRuns()
+		{
+			// 6 동기 「퀄리티」 — 같은 망 = 같은 도착량.
+			float reference = -1f;
+			for (int run = 0; run < 4; run++)
+			{
+				LeylineGraph graph = new();
+				graph.AddNode(new LeylineNode("gate", LeylineNodeKind.Source));
+				graph.AddNode(new LeylineNode("mid"));
+				graph.AddNode(new LeylineNode("workshop", LeylineNodeKind.Sink));
+				graph.AddEdge(new LeylineEdge("gate", "mid", 2f));
+				graph.AddEdge(new LeylineEdge("mid", "workshop", 3f));
+
+				float arrived = ManaFlow.CalculateOnGraph(graph, "gate", "workshop", 100f, 0.05f);
+				if (run == 0)
+				{
+					reference = arrived;
+				}
+				else
+				{
+					Assert.That(arrived, Is.EqualTo(reference), $"run {run} 도착량 = run 0 와 같음 (결정성 — 같은 망 = 같은 흐름)");
+				}
+			}
+		}
+
+		[Test]
+		public void CalculateOnGraph_NullGraph_Throws()
+		{
+			Assert.Throws<ArgumentNullException>(() => ManaFlow.CalculateOnGraph(null, "a", "b", 100f, 0.1f));
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/ManaFlowTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/ManaFlowTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0bf5486cbd234ae7ac71f3ce946859cb


### PR DESCRIPTION
## 요약

TASK-WM-173 「마력의 강」 Phase 0 substrate — 마계 게이트(공급)↔공방(소비)을 가중치 배선으로 잇고 거리에 따라 신선도가 감쇠한 채 도착량을 계산하는 순수 POCO 모델 레이어.

**Phase 0 슬라이스 본 의도** (스펙 발췌): "두 노드(마계 게이트 → 공방)를 레이라인으로 잇고 마력을 흘려보내면, 거리에 따라 신선도가 줄어든 채 도착하고, 도착량이 수치로 표시되는 2노드 흐름 슬라이스."

## 결정 / 설계

**RoadGraph 재활용 vs 신규 판단 — 결론: 신규 LeylineGraph.**
- RoadGraph = `Vector3Int` 격자 셀 dict + 4-이웃 자동 인접 + 길이 항상 1 (BFS).
- LeylineGraph = `string` id 임의 위치 노드 + 명시적 가중치 엣지 + Dijkstra.
- 구조(BFS 토대)는 닮았으나 데이터 모델/의미가 직교 — 직접 재활용 불가. 향후 공통 `IGraph<T>` 추출은 Phase 2+ first-use 시점에 (WM-164 Phase 2 deferred 의 BFS 중복 추출과 함께). 선제 추상화 금지(CLAUDE.md 「데드 인터페이스 방지」) 원칙 따름.

**선형 vs exp 감쇠 모델 — 결론: 선형.**
- 선형: `remaining = max(0, 1 - distance × decayRate)`. 「완전히 흩어짐」 표현이 또렷, 짧은 직선 vs 긴 우회 체감이 강함. Phase 0 슬라이스에 적합.
- exp 으로 격상은 Phase 2 노화 시뮬에서 first-use 판단.

**노화 합성 — 결론: 「총 경로 길이 한 번에 Freshness 통과」.**
- 엣지별 누적 곱 아님. 선형 감쇠라 산술적 거의 동치 + Phase 2 시간 노화와 같은 모양(합성 단순).

## 변경 파일

**DomainSDK/Logistics/** (신규 폴더, 7 파일):
- `LeylineNodeKind.cs` — enum (None/Source/Sink/Relay)
- `LeylineNode.cs` — POCO (Id + Kind, FastFail boundary 검증)
- `LeylineEdge.cs` — POCO directional + 가중치 Length (FastFail)
- `LeylineGraph.cs` — AddNode/AddEdge/Outgoing/FindShortestPath (Dijkstra)/PathLength
- `Freshness.cs` — static DecayByDistance (선형)
- `ManaFlow.cs` — static CalculateArrivalAmount + CalculateOnGraph (합성)

**Tests/EditMode/** (신규 3 파일, 총 32 테스트):
- `LeylineGraphTest.cs` (14) — 노드/엣지 등록 멱등성, Dijkstra 최단(가중치), 미연결·자기자신·미등록 경계, 결정성 4-run, 다중 엣지
- `FreshnessTest.cs` (8) — 거리 0/완전 감쇠/단조성/결정성 1000-run/음수 boundary
- `ManaFlowTest.cs` (10) — Phase 0 슬라이스 본 의도, 짧은 직선 vs 긴 우회 도착량 차, 우회 누적, null 그래프

## 룰 준수 체크

- ✓ POCO 순수성 — Unity Component 의존 0. `WitchMendokusai.DomainSDK` asmdef 안에 추가 (references=[UniTask, MessagePipe] 기존 유지 — 새 references 추가 X).
- ✓ var 금지 / 명시 타입.
- ✓ 변수명 축약 X / 상수 `UPPER_SNAKE_CASE` X (Phase 0 = 0 상수).
- ✓ `== false` (not `!`).
- ✓ Allman 스타일.
- ✓ FastFail — 외부 입력 boundary (string id 빈/엣지 length≤0/음수 거리·감쇠율·송신량·null 그래프) 만 throw, 「경로 없음」 등 정상 결과는 빈/0 반환.
- ✓ 수치 노출 — decayRate 호출자 주입, 모델 내부 하드코딩 X.
- ✓ init-order — Awake/Construct 0, MonoBehaviour 0, lazy Find 0.
- ✓ first-use 우선 — Storage/Junction 같은 가짜 enum 값, IGraph<T> 같은 추상화 선제 추가 X.

## Test plan

- [ ] **MCP 검증 미실행** — 본 worktree (`aw-wm-support-task-wm-173`) 에 Unity Editor 인스턴스 연결 안 됨. MCP `read_console`/`refresh_unity` 가용 X, `wm-editmode-smoke.ps1` / `dotnet-build-wm.ps1` 같은 wrapper 도 cwd 밖. 사용자 측 Editor 에서 reimport 후 컴파일·테스트 확인 필요.
- [ ] Editor reimport 후 `read_console(types=["error","warning"])` 0 entries 확인 (Logistics/ 신규 6 파일 + 테스트 3 파일).
- [ ] EditMode 32 테스트 GREEN — `LeylineGraphTest` 14 + `FreshnessTest` 8 + `ManaFlowTest` 10.
- [ ] (선택) RoadGraph 와 닮은 BFS/연결성 패턴이 의미 차이를 잘 표현하는지 코드리뷰 — 향후 공통 IGraph<T> 추출 시 기준점.

## 다음 단계 (Phase 1~)

- Phase 1: 배선 UI 최소 슬라이스 — 2노드 연결 → 흐름 시각화 (마법진 빛 + 도착량 HUD).
- Phase 2: 노화 시간 차원(TimeManager 연동), 집수 반경.
- Phase 3: 운송 수단(빗자루/텔레포트/소환수 운반대), 병목·대규모 최적화.

## 사용자 대기 컨펌 (디자인 영역, substrate 진행과 별개)

스펙 § 「사용자 컨펌 대기」 의 6 항목 — 마력 정체성/운송 수단 디제틱/SimCity와의 관계/배선 비주얼/자동화 수위/대중성 — 은 Phase 1 UI 슬라이스 진입 전 결정 필요. Phase 0 substrate 는 이들과 독립으로 진행 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)