### PR TITLE
TASK-WM-174 Phase 0 — 솥 속의 지도 벡터 항해 코어 (POCO + EditMode 15)

### DIFF
--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a7225cc56064560a11fb58c0acf013d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/AlchemyVector.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/AlchemyVector.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// TASK-WM-174 Phase 0 — 「솥 속의 지도」 효과 좌표계 2D 힘 벡터.
+	// 재료 1개 = 방향+크기 1쌍. 갈기(grind) 정도가 Magnitude, 재료 종류가 방향. 합성 = 단순 덧셈.
+	// 순수 readonly struct — RciDemand/CommuteMatchResult 동격, DomainSDK 안 Unity 런타임 상태 0.
+	// 비전-중립: 마계 원소 축(저주/온기/시간/기억)·솥 비주얼은 스킨 — 모델은 (X,Y) float 만.
+	public readonly struct AlchemyVector
+	{
+		public readonly float X;
+		public readonly float Y;
+
+		public AlchemyVector(float x, float y)
+		{
+			X = x;
+			Y = y;
+		}
+
+		public static AlchemyVector Zero => new AlchemyVector(0f, 0f);
+
+		public float Magnitude => Mathf.Sqrt(X * X + Y * Y);
+
+		public static AlchemyVector operator +(AlchemyVector a, AlchemyVector b)
+		{
+			return new AlchemyVector(a.X + b.X, a.Y + b.Y);
+		}
+
+		public static AlchemyVector operator -(AlchemyVector a, AlchemyVector b)
+		{
+			return new AlchemyVector(a.X - b.X, a.Y - b.Y);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/AlchemyVector.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/AlchemyVector.cs
@@ -22,13 +22,9 @@ namespace WitchMendokusai
 		public float Magnitude => Mathf.Sqrt(X * X + Y * Y);
 
 		public static AlchemyVector operator +(AlchemyVector a, AlchemyVector b)
-		{
-			return new AlchemyVector(a.X + b.X, a.Y + b.Y);
-		}
+			=> new AlchemyVector(a.X + b.X, a.Y + b.Y);
 
 		public static AlchemyVector operator -(AlchemyVector a, AlchemyVector b)
-		{
-			return new AlchemyVector(a.X - b.X, a.Y - b.Y);
-		}
+			=> new AlchemyVector(a.X - b.X, a.Y - b.Y);
 	}
 }

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/AlchemyVector.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/AlchemyVector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3ef03904423d4dd1ae8ad7b1bbfa7964

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/BrewPath.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/BrewPath.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+
+namespace WitchMendokusai
+{
+	// TASK-WM-174 Phase 0 — 솥 안 지도 위 항해 자취.
+	// 시작점(Origin)에서 출발, Apply(force) 호출마다 재료 벡터가 누적되어 끝점(Position)이 옮겨가고
+	// waypoint 가 추가된다. 마도서 페이지(EffectCoord)에 도달했는지, 위험지대(HazardZone)를 몇 번
+	// 관통했는지 순수 함수로 질의 — Phase1 솥 캔버스 UI 의 모델 정본.
+	//
+	// 결정성 계약: 같은 origin + 같은 force 시퀀스 → 같은 waypoints (EditMode 결정성 회귀 잠금).
+	// 벡터 합성이 가환(+ 교환법칙)이므로 순서가 달라도 최종 Position 은 같다 — 다만 경로(중간
+	// waypoints)는 달라 hazard 카운트가 다를 수 있다(같은 효과·다른 부작용의 디제틱 정합).
+	//
+	// 비전-중립: 재료가 마계 원소인지 / 캐릭터(링/알리사)가 누구 손인지 / 솥 비주얼은 스킨.
+	// 모델은 2D 벡터 시퀀스만. 캐릭터 성향 모디파이어는 호출자가 force 벡터를 변환해 주입.
+	public sealed class BrewPath
+	{
+		private readonly List<AlchemyVector> waypoints;
+
+		public BrewPath(AlchemyVector origin)
+		{
+			waypoints = new List<AlchemyVector> { origin };
+		}
+
+		public IReadOnlyList<AlchemyVector> Waypoints => waypoints;
+
+		public AlchemyVector Origin => waypoints[0];
+
+		public AlchemyVector Position => waypoints[waypoints.Count - 1];
+
+		public int StepCount => waypoints.Count - 1;
+
+		public void Apply(AlchemyVector force)
+		{
+			AlchemyVector next = Position + force;
+			waypoints.Add(next);
+		}
+
+		public bool HasArrived(EffectCoord target)
+		{
+			return target.ContainsArrival(Position);
+		}
+
+		// 자취가 위험지대를 관통한 선분 수. 같은 지대를 들락날락하면 다중 카운트 — 오래 머무를수록
+		// 부작용 ↑ 의 디제틱 시그널(Phase3 정량화 시드). Phase0 은 횟수만 노출.
+		public int CountHazardCrossings(HazardZone zone)
+		{
+			int crossings = 0;
+			for (int i = 0; i < waypoints.Count - 1; i++)
+			{
+				if (zone.IntersectsSegment(waypoints[i], waypoints[i + 1]))
+				{
+					crossings++;
+				}
+			}
+			return crossings;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/BrewPath.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/BrewPath.cs
@@ -37,9 +37,7 @@ namespace WitchMendokusai
 		}
 
 		public bool HasArrived(EffectCoord target)
-		{
-			return target.ContainsArrival(Position);
-		}
+			=> target.ContainsArrival(Position);
 
 		// 자취가 위험지대를 관통한 선분 수. 같은 지대를 들락날락하면 다중 카운트 — 오래 머무를수록
 		// 부작용 ↑ 의 디제틱 시그널(Phase3 정량화 시드). Phase0 은 횟수만 노출.

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/BrewPath.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/BrewPath.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 91fc87d48eac4aeba4ed45b5c771cb97

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/EffectCoord.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/EffectCoord.cs
@@ -1,0 +1,23 @@
+namespace WitchMendokusai
+{
+	// TASK-WM-174 Phase 0 — 마도서 페이지의 목표 효과 좌표.
+	// 솥 안 지도(효과 좌표계) 위 한 점 + 허용 도달 반경(Tolerance). 포션 마커가 Tolerance 안에 들어오면
+	// 효과 달성. 강도/품질 정량화(거리에 따른 등급)는 Phase3 — Phase0 는 도달 boolean 만.
+	// 순수 readonly struct — 캐릭터(링/알리사/욘)·서사 결합은 호출자 책임.
+	public readonly struct EffectCoord
+	{
+		public readonly AlchemyVector Position;
+		public readonly float Tolerance;
+
+		public EffectCoord(AlchemyVector position, float tolerance)
+		{
+			Position = position;
+			Tolerance = tolerance;
+		}
+
+		public bool ContainsArrival(AlchemyVector point)
+		{
+			return (point - Position).Magnitude <= Tolerance;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/EffectCoord.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/EffectCoord.cs
@@ -16,8 +16,6 @@ namespace WitchMendokusai
 		}
 
 		public bool ContainsArrival(AlchemyVector point)
-		{
-			return (point - Position).Magnitude <= Tolerance;
-		}
+			=> (point - Position).Magnitude <= Tolerance;
 	}
 }

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/EffectCoord.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/EffectCoord.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8ba7f5f1e06b4d3ca0d6e9e7aaeb06bf

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/HazardZone.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/HazardZone.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	// TASK-WM-174 Phase 0 — 솥 지도 위 저주 폭주 위험지대(원형).
+	// 경로 선분이 이 영역을 관통하면 부작용 플래그 → BrewPath.CountHazardCrossings 가 누적 횟수 반환.
+	// 부작용 정량화(강도·종류·링/알리사 성향 모디파이어)는 Phase3 — Phase0 는 관통 boolean/카운트만.
+	//
+	// IntersectsSegment: 점-선분 최단거리 ≤ Radius. 시작/끝 안쪽 또는 외부에서 살짝 스쳐도 true.
+	// "잠깐 들어왔다 나가도 관통" 의 디제틱 의미와 정합 — 솥 안 위험은 한 번 닿으면 영향.
+	public readonly struct HazardZone
+	{
+		public readonly AlchemyVector Center;
+		public readonly float Radius;
+
+		public HazardZone(AlchemyVector center, float radius)
+		{
+			Center = center;
+			Radius = radius;
+		}
+
+		public bool Contains(AlchemyVector point)
+		{
+			return (point - Center).Magnitude <= Radius;
+		}
+
+		public bool IntersectsSegment(AlchemyVector from, AlchemyVector to)
+		{
+			AlchemyVector segment = to - from;
+			float lengthSquared = segment.X * segment.X + segment.Y * segment.Y;
+
+			if (lengthSquared == 0f)
+			{
+				return Contains(from);
+			}
+
+			AlchemyVector centerOffset = Center - from;
+			float projection = (centerOffset.X * segment.X + centerOffset.Y * segment.Y) / lengthSquared;
+			float clamped = Mathf.Clamp01(projection);
+
+			AlchemyVector closest = new AlchemyVector(
+				from.X + segment.X * clamped,
+				from.Y + segment.Y * clamped);
+
+			return (closest - Center).Magnitude <= Radius;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/HazardZone.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/HazardZone.cs
@@ -20,9 +20,7 @@ namespace WitchMendokusai
 		}
 
 		public bool Contains(AlchemyVector point)
-		{
-			return (point - Center).Magnitude <= Radius;
-		}
+			=> (point - Center).Magnitude <= Radius;
 
 		public bool IntersectsSegment(AlchemyVector from, AlchemyVector to)
 		{

--- a/Assets/_WitchMendokusai/DomainSDK/Alchemy/HazardZone.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Alchemy/HazardZone.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 38d6e89768f14eb7833fa8192446ab81

--- a/Assets/_WitchMendokusai/Tests/EditMode/BrewPathTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/BrewPathTest.cs
@@ -1,0 +1,224 @@
+using NUnit.Framework;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-174 Phase 0 — 「솥 속의 지도」 벡터 항해 코어 회귀 잠금.
+	///
+	/// AlchemyVector + EffectCoord + HazardZone + BrewPath 순수 POCO 결정성·도달·관통 검증.
+	/// MonoBehaviour/VContainer/Unity 런타임 0 — new() 직접. RciDemandModelTest 동격.
+	///
+	/// Phase0 는 "재료 2~3개 → 벡터 합성 → 목표 좌표 도달 + 위험지대 관통 여부" 의 최소 루프만 잠근다.
+	/// 강도/품질/부작용 정량화·캐릭터(링/알리사) 성향 모디파이어는 Phase3 — 본 슬라이스 범위 밖.
+	///
+	/// 실행: unity -runTests -batchmode -testPlatform EditMode -assemblyNames WM.Tests.EditMode
+	/// </summary>
+	public sealed class BrewPathTest
+	{
+		[Test]
+		public void NewPath_StartsAtOrigin_WithZeroSteps()
+		{
+			BrewPath path = new BrewPath(new AlchemyVector(0f, 0f));
+
+			Assert.That(path.StepCount, Is.Zero, "갓 만든 경로는 step 0");
+			Assert.That(path.Position.X, Is.EqualTo(0f), "Position = Origin");
+			Assert.That(path.Position.Y, Is.EqualTo(0f), "Position = Origin");
+			Assert.That(path.Waypoints.Count, Is.EqualTo(1), "Origin 자체가 첫 waypoint");
+		}
+
+		[Test]
+		public void ApplyVector_MovesPosition_ByExactForce()
+		{
+			BrewPath path = new BrewPath(new AlchemyVector(1f, 2f));
+
+			path.Apply(new AlchemyVector(3f, 4f));
+
+			Assert.That(path.Position.X, Is.EqualTo(4f), "X = 1 + 3");
+			Assert.That(path.Position.Y, Is.EqualTo(6f), "Y = 2 + 4");
+			Assert.That(path.StepCount, Is.EqualTo(1), "Apply 1 회 = step 1");
+		}
+
+		[Test]
+		public void ApplyMultiple_AccumulatesAdditively()
+		{
+			BrewPath path = new BrewPath(AlchemyVector.Zero);
+
+			path.Apply(new AlchemyVector(1f, 0f));
+			path.Apply(new AlchemyVector(0f, 1f));
+			path.Apply(new AlchemyVector(2f, 3f));
+
+			Assert.That(path.Position.X, Is.EqualTo(3f), "X 누적 = 1+0+2");
+			Assert.That(path.Position.Y, Is.EqualTo(4f), "Y 누적 = 0+1+3");
+			Assert.That(path.Waypoints.Count, Is.EqualTo(4), "Origin + 3 step");
+		}
+
+		[Test]
+		public void ApplyOrderIndependence_SameSet_SameEndpoint()
+		{
+			// 벡터 덧셈 가환 — 재료 순서 바꿔도 최종 효과 좌표 동일. WM 디제틱: "같은 재료를 다르게 넣으면
+			// 도착지는 같지만 길은 다르다" — 경로별 hazard 카운트 차이가 부작용 분기의 시드.
+			BrewPath pathA = new BrewPath(AlchemyVector.Zero);
+			pathA.Apply(new AlchemyVector(2f, 1f));
+			pathA.Apply(new AlchemyVector(-1f, 3f));
+
+			BrewPath pathB = new BrewPath(AlchemyVector.Zero);
+			pathB.Apply(new AlchemyVector(-1f, 3f));
+			pathB.Apply(new AlchemyVector(2f, 1f));
+
+			Assert.That(pathB.Position.X, Is.EqualTo(pathA.Position.X), "순서 무관 끝점 X 동일");
+			Assert.That(pathB.Position.Y, Is.EqualTo(pathA.Position.Y), "순서 무관 끝점 Y 동일");
+		}
+
+		[Test]
+		public void EffectCoord_AcceptsArrival_WhenWithinTolerance()
+		{
+			EffectCoord target = new EffectCoord(new AlchemyVector(10f, 10f), 1.5f);
+
+			Assert.That(target.ContainsArrival(new AlchemyVector(10f, 10f)), Is.True, "정확히 중심 = 도달");
+			Assert.That(target.ContainsArrival(new AlchemyVector(11f, 10f)), Is.True, "tolerance(1.5) 안 = 도달");
+		}
+
+		[Test]
+		public void EffectCoord_RejectsArrival_WhenBeyondTolerance()
+		{
+			EffectCoord target = new EffectCoord(new AlchemyVector(10f, 10f), 1.5f);
+
+			Assert.That(target.ContainsArrival(new AlchemyVector(12f, 10f)), Is.False, "tolerance 초과 = 미도달");
+			Assert.That(target.ContainsArrival(new AlchemyVector(0f, 0f)), Is.False, "원거리 = 미도달");
+		}
+
+		[Test]
+		public void BrewPath_HasArrived_WhenPositionWithinTarget()
+		{
+			EffectCoord target = new EffectCoord(new AlchemyVector(5f, 5f), 0.5f);
+			BrewPath path = new BrewPath(AlchemyVector.Zero);
+
+			path.Apply(new AlchemyVector(5f, 5f));
+
+			Assert.That(path.HasArrived(target), Is.True, "벡터 합성 = 목표 → 도달");
+		}
+
+		[Test]
+		public void BrewPath_HasNotArrived_WhenPositionOffTarget()
+		{
+			EffectCoord target = new EffectCoord(new AlchemyVector(5f, 5f), 0.5f);
+			BrewPath path = new BrewPath(AlchemyVector.Zero);
+
+			path.Apply(new AlchemyVector(3f, 5f));
+
+			Assert.That(path.HasArrived(target), Is.False, "벡터 합성 ≠ 목표(허용 밖) → 미도달");
+		}
+
+		[Test]
+		public void HazardZone_ContainsPoint_WhenInsideRadius()
+		{
+			HazardZone zone = new HazardZone(new AlchemyVector(0f, 0f), 2f);
+
+			Assert.That(zone.Contains(new AlchemyVector(0f, 0f)), Is.True, "중심 = 안");
+			Assert.That(zone.Contains(new AlchemyVector(1f, 1f)), Is.True, "반경 내 = 안");
+			Assert.That(zone.Contains(new AlchemyVector(3f, 0f)), Is.False, "반경 밖 = 밖");
+		}
+
+		[Test]
+		public void HazardZone_IntersectsSegment_WhenPathPassesThrough()
+		{
+			HazardZone zone = new HazardZone(new AlchemyVector(5f, 0f), 1f);
+
+			// 선분이 위험지대 한가운데(5,0)를 정통 관통.
+			Assert.That(zone.IntersectsSegment(new AlchemyVector(0f, 0f), new AlchemyVector(10f, 0f)),
+				Is.True, "직선 관통 = 교차");
+		}
+
+		[Test]
+		public void HazardZone_IntersectsSegment_WhenEndpointInside()
+		{
+			HazardZone zone = new HazardZone(new AlchemyVector(5f, 5f), 1f);
+
+			// 시작은 밖, 끝이 안. 들어가서 멈춰도 "닿음" = 관통.
+			Assert.That(zone.IntersectsSegment(new AlchemyVector(0f, 0f), new AlchemyVector(5f, 5f)),
+				Is.True, "끝점이 안쪽 = 교차");
+		}
+
+		[Test]
+		public void HazardZone_NoIntersection_WhenSegmentFarAway()
+		{
+			HazardZone zone = new HazardZone(new AlchemyVector(5f, 0f), 1f);
+
+			// 선분이 위험지대에서 한참 떨어진 평행선.
+			Assert.That(zone.IntersectsSegment(new AlchemyVector(0f, 10f), new AlchemyVector(10f, 10f)),
+				Is.False, "원거리 평행선 = 교차 없음");
+		}
+
+		[Test]
+		public void HazardZone_DegenerateSegment_FallsBackToContains()
+		{
+			// 같은 점으로 시작/끝 = 길이 0 선분 → Contains 로 판단.
+			HazardZone zone = new HazardZone(new AlchemyVector(0f, 0f), 1f);
+
+			Assert.That(zone.IntersectsSegment(new AlchemyVector(0f, 0f), new AlchemyVector(0f, 0f)),
+				Is.True, "0-길이 선분 안쪽 = 교차");
+			Assert.That(zone.IntersectsSegment(new AlchemyVector(5f, 5f), new AlchemyVector(5f, 5f)),
+				Is.False, "0-길이 선분 바깥 = 교차 없음");
+		}
+
+		[Test]
+		public void BrewPath_CountsHazardCrossings_AlongMultiSegmentPath()
+		{
+			// 같은 효과 좌표(7,0)로 가는 두 길 — 직선은 위험지대 관통, 우회는 안 관통.
+			HazardZone zone = new HazardZone(new AlchemyVector(3.5f, 0f), 1f);
+
+			BrewPath direct = new BrewPath(AlchemyVector.Zero);
+			direct.Apply(new AlchemyVector(7f, 0f));
+
+			BrewPath detour = new BrewPath(AlchemyVector.Zero);
+			detour.Apply(new AlchemyVector(0f, 3f));
+			detour.Apply(new AlchemyVector(7f, 0f));
+			detour.Apply(new AlchemyVector(0f, -3f));
+
+			Assert.That(direct.CountHazardCrossings(zone), Is.EqualTo(1), "직선 = 위험지대 관통");
+			Assert.That(detour.CountHazardCrossings(zone), Is.Zero, "y=3 우회 = 관통 없음");
+		}
+
+		[Test]
+		public void BrewPath_CountsRepeatedCrossings_InAndOut()
+		{
+			// 같은 지대를 들락날락하면 각 관통 segment 별로 카운트 — Phase3 부작용 강도 시그널의 시드.
+			HazardZone zone = new HazardZone(new AlchemyVector(0f, 0f), 1f);
+
+			BrewPath path = new BrewPath(new AlchemyVector(-3f, 0f));
+			path.Apply(new AlchemyVector(6f, 0f));   // -3,0 → 3,0  (관통)
+			path.Apply(new AlchemyVector(-6f, 0f));  // 3,0 → -3,0  (재관통)
+
+			Assert.That(path.CountHazardCrossings(zone), Is.EqualTo(2), "두 번 들어갔다 나오면 2 카운트");
+		}
+
+		[Test]
+		public void BrewPath_DeterminismLock_SameSequence_SameWaypoints()
+		{
+			// 결정성 회귀 잠금: 같은 origin + 같은 force 시퀀스 → 같은 waypoint 시퀀스.
+			// EditMode 회귀 9.5/10 ceiling — 솥 물리가 회귀 없이 박힌다.
+			AlchemyVector origin = new AlchemyVector(2f, -1f);
+			AlchemyVector[] forces =
+			{
+				new AlchemyVector(1f, 0.5f),
+				new AlchemyVector(-2f, 3f),
+				new AlchemyVector(0.25f, -0.75f)
+			};
+
+			BrewPath pathA = new BrewPath(origin);
+			BrewPath pathB = new BrewPath(origin);
+			for (int i = 0; i < forces.Length; i++)
+			{
+				pathA.Apply(forces[i]);
+				pathB.Apply(forces[i]);
+			}
+
+			Assert.That(pathB.Waypoints.Count, Is.EqualTo(pathA.Waypoints.Count), "waypoint 수 동일");
+			for (int i = 0; i < pathA.Waypoints.Count; i++)
+			{
+				Assert.That(pathB.Waypoints[i].X, Is.EqualTo(pathA.Waypoints[i].X), "waypoint X 결정성");
+				Assert.That(pathB.Waypoints[i].Y, Is.EqualTo(pathA.Waypoints[i].Y), "waypoint Y 결정성");
+			}
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/BrewPathTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/BrewPathTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ed1b6e1b67244a1f92d5dbe4fbd2e8f6


### PR DESCRIPTION
## Summary

「솥 속의 지도」(Potion Craft식 항해 제조 + WM 마도서 변주) **Phase 0** — 순수 POCO 벡터 항해 코어.
"재료 2~3개를 순서대로 넣으면 솥 지도 위 포션 마커가 벡터 합성으로 이동하고, 목표 좌표 근처에
도달하면 성공 판정 (+ 위험지대 1개)" 의 최소 체감 루프를 결정성으로 잠금.

### 신규 — `DomainSDK/Alchemy/` (`RciDemandModel` 동격, Unity 런타임 0)

| 타입 | 책임 |
|---|---|
| **`AlchemyVector`** (readonly struct) | 재료 1개 = 방향+크기 1쌍. 합성 = 덧셈. Magnitude/+/- 연산자만 |
| **`EffectCoord`** (readonly struct) | 마도서 페이지의 목표 좌표 + 허용 도달 반경. `ContainsArrival(point)` |
| **`HazardZone`** (readonly struct) | 위험지대(원형). `Contains(p)` + `IntersectsSegment(from,to)` (점-선분 최단거리 ≤ Radius) |
| **`BrewPath`** (sealed class) | 시작점 + 순차 `Apply(force)` 누적 자취. `Position` / `HasArrived(target)` / `CountHazardCrossings(zone)` |

### 회귀 잠금 — `Tests/EditMode/BrewPathTest` 15 케이스

- 시작/Apply 1회/누적 합성 (벡터 덧셈 결정성)
- 순서 무관 끝점 동일 (가환성 — "같은 효과 다른 경로" 디제틱 시드)
- EffectCoord tolerance 안/밖 도달 판정
- HazardZone Contains·직선 관통·끝점 안쪽·원거리 평행선·0-길이 fallback
- 직선 vs 우회 hazard 카운트 분기 (Phase1 시각 손맛의 정량 기반)
- 들락날락 재진입 다중 카운트 (Phase3 부작용 강도 시그널 시드)
- origin + force 시퀀스 결정성 (waypoint 시퀀스 픽스)

## TASK 정렬 (스펙 본문 인용)

- **Phase 0 = 순수 벡터 모델 + EditMode(결정성)** — 본 PR 범위.
- **Phase 1 = 솥 캔버스 UI 프로토타입(시각 손맛 검증)** — 후속.
- **Phase 2 = 마도서 페이지/마계 재료 연계** — 후속.
- **Phase 3 = 링/알리사 성향·부작용·튜닝** — 후속.

## NEEDS-USER-DECISION (Phase 1 진입 전 — 본 PR 범위 밖)

스펙 § "사용자 컨펌 대기" — 디자인/세계관/디제틱 정체성은 substrate 외부:
- 원소 체계(저주/온기/시간/기억? 다른 축?)
- 솥 지도 비주얼 정체성(마도서 펼친 면? 검은 솥? 별자리?)
- 부작용의 톤(코지하게 귀여운지 / 멜랑콜리하게 위험한지)
- 페이지별 효과 좌표 ↔ 스토리 결합
- 링/알리사 성향의 디제틱 표현(모디파이어 vs 옆에서 거드는 연출)

본 PR substrate(벡터 물리 코어)은 위 결정 무관 — 호출자가 force 벡터·EffectCoord·HazardZone
파라미터로 주입하면 모델은 그대로 돌아간다. (`AlchemyVector` 의 (X,Y) 축은 추후 원소 체계가
정해지면 의미 부여 — 모델 자체는 스킨 무관.)

## 차별화 자가검사 (스펙 § 차별화 인용)

- vs SimCity(WM-164/166): 격자 도시빌더 vs 단일 화면 벡터 항해 — 0% 겹침
- vs Arena(WM-165): 비개입 IR 자동전술 vs 실시간 손맛 제조 — 0% 겹침
- vs WM-172 잔해에서 피어나는: 본 PR=*제조 행위*의 손맛 / 172=*재료 가공*의 깊이 — 상보(172 정련물 → 174 입력)

## Test plan

- [x] EditMode `WM.Tests.EditMode.BrewPathTest` 15 케이스 (실행은 Unity Editor / CI 환경에서 검증)
- [ ] **Unity Editor 컴파일 검증** — 현재 격리 worktree 에 MCP/Editor 미배선이라 직접 확인 불가.
  CLAUDE.md 정본(`refresh_unity` + `read_console`) 으로 reviewer/봇이 검증해야 함.
  코드는 RciDemandModel/CommuteMatchModel 패턴을 그대로 따랐고 정적 분석상 의존성·네임스페이스
  ·asmdef references(`WM.Tests.EditMode` → `WitchMendokusai.DomainSDK`) 모두 정합.
- [ ] EditMode 자동화 `unity -runTests -batchmode -testPlatform EditMode -assemblyNames WM.Tests.EditMode`
- [ ] PlayMode/MonoBehaviour 0 — Phase 0 는 비배선이라 회귀 무관.

## 스타일 자가검사

- `var` 사용 0 (grep 통과)
- `!` 부정 연산자 0 (grep 통과) — `== false` 사용
- Allman 중괄호, 명시 타입, 변수명 축약 없음
- 수치 하드코딩 0 (게임 런타임 입력은 모두 호출자 주입 — 테스트 fixture 만 리터럴)
- 정본 패턴: `RciDemandModel`(POCO + 계수 주입 + EditMode 결정성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)