### PR TITLE
feat(TASK-WM-186): 마도서 레시피 UGC schema POCO DomainSDK 격상 (시드)

### DIFF
--- a/Assets/_WitchMendokusai/Domain/Data/UGC/UGCJsonLoader.cs
+++ b/Assets/_WitchMendokusai/Domain/Data/UGC/UGCJsonLoader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
+using WitchMendokusai.DomainSDK.UGC;
 
 namespace WitchMendokusai
 {
@@ -74,6 +75,36 @@ namespace WitchMendokusai
 			}
 
 			if (UGCJsonValidator.TryValidateManifest(manifest, out error) == false)
+			{
+				error = $"{Path.GetFileName(path)} {error}";
+				return false;
+			}
+
+			error = null;
+			return true;
+		}
+
+		public static bool TryLoadRecipeManifestFromSample(string fileName, out UGCRecipeManifestData manifest, out string error)
+		{
+			string path = UGCPathResolver.GetSamplePath(fileName);
+			if (TryReadJsonFile(path, out string json, out error) == false)
+			{
+				manifest = null;
+				return false;
+			}
+
+			try
+			{
+				manifest = JsonConvert.DeserializeObject<UGCRecipeManifestData>(json, JsonSettings);
+			}
+			catch (Exception ex)
+			{
+				manifest = null;
+				error = $"Failed to deserialize recipe manifest JSON: {ex.Message}";
+				return false;
+			}
+
+			if (UGCJsonValidator.TryValidateRecipeManifest(manifest, out error) == false)
 			{
 				error = $"{Path.GetFileName(path)} {error}";
 				return false;

--- a/Assets/_WitchMendokusai/Domain/Data/UGC/UGCJsonValidator.cs
+++ b/Assets/_WitchMendokusai/Domain/Data/UGC/UGCJsonValidator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using WitchMendokusai.DomainSDK.UGC;
 
 namespace WitchMendokusai
 {
@@ -268,6 +269,122 @@ namespace WitchMendokusai
 					error = $"action[{index}] has unsupported type: {action.type}";
 					return false;
 			}
+		}
+
+		public static bool TryValidateRecipeManifest(UGCRecipeManifestData manifest, out string error)
+		{
+			if (manifest == null)
+			{
+				error = "Recipe manifest is null.";
+				return false;
+			}
+
+			if (manifest.schemaVersion != CURRENT_SCHEMA_VERSION)
+			{
+				error = $"Unsupported recipe schemaVersion: {manifest.schemaVersion}";
+				return false;
+			}
+
+			if (string.IsNullOrWhiteSpace(manifest.manifestId))
+			{
+				error = "Recipe manifestId is required.";
+				return false;
+			}
+
+			if (manifest.recipe == null)
+			{
+				error = $"Recipe manifest '{manifest.manifestId}' has no recipe page.";
+				return false;
+			}
+
+			UGCRecipePageData recipe = manifest.recipe;
+
+			if (recipe.recipeId < 0)
+			{
+				error = $"Recipe '{manifest.manifestId}' has invalid recipeId: {recipe.recipeId}";
+				return false;
+			}
+
+			if (string.IsNullOrWhiteSpace(recipe.title))
+			{
+				error = $"Recipe '{manifest.manifestId}' title is required.";
+				return false;
+			}
+
+			if (string.IsNullOrWhiteSpace(recipe.effectName))
+			{
+				error = $"Recipe '{manifest.manifestId}' effectName is required.";
+				return false;
+			}
+
+			if (recipe.target == null)
+			{
+				error = $"Recipe '{manifest.manifestId}' target is required.";
+				return false;
+			}
+
+			if (recipe.target.radius <= 0f)
+			{
+				error = $"Recipe '{manifest.manifestId}' target.radius must be > 0 (got {recipe.target.radius}).";
+				return false;
+			}
+
+			if (recipe.ingredients != null)
+			{
+				for (int i = 0; i < recipe.ingredients.Count; i++)
+				{
+					UGCRecipeIngredientRefData ingredient = recipe.ingredients[i];
+					if (ingredient == null)
+					{
+						error = $"Recipe '{manifest.manifestId}' ingredient[{i}] is null.";
+						return false;
+					}
+
+					if (ingredient.ingredientId < 0)
+					{
+						error = $"Recipe '{manifest.manifestId}' ingredient[{i}] ingredientId must be >= 0.";
+						return false;
+					}
+
+					if (ingredient.grind < 0f)
+					{
+						error = $"Recipe '{manifest.manifestId}' ingredient[{i}] grind must be >= 0 (got {ingredient.grind}).";
+						return false;
+					}
+				}
+			}
+
+			if (recipe.gradeThresholds != null)
+			{
+				UGCRecipeGradeThresholdsData thresholds = recipe.gradeThresholds;
+
+				if (thresholds.crudeMaxDistance < 0f || thresholds.fineMaxDistance < 0f || thresholds.masterworkMaxDistance < 0f)
+				{
+					error = $"Recipe '{manifest.manifestId}' gradeThresholds distance fields must be >= 0.";
+					return false;
+				}
+
+				if (thresholds.fineMaxDistance > thresholds.crudeMaxDistance)
+				{
+					error = $"Recipe '{manifest.manifestId}' gradeThresholds.fineMaxDistance must be <= crudeMaxDistance.";
+					return false;
+				}
+
+				if (thresholds.masterworkMaxDistance > thresholds.fineMaxDistance)
+				{
+					error = $"Recipe '{manifest.manifestId}' gradeThresholds.masterworkMaxDistance must be <= fineMaxDistance.";
+					return false;
+				}
+
+				if (thresholds.masterworkMaxSideEffect < 0f)
+				{
+					error = $"Recipe '{manifest.manifestId}' gradeThresholds.masterworkMaxSideEffect must be >= 0.";
+					return false;
+				}
+			}
+
+			error = null;
+			return true;
 		}
 
 		public static bool TryValidateSeed(UGCSeedManifestData manifest, out string error)

--- a/Assets/_WitchMendokusai/DomainSDK/UGC.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/UGC.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d0dbc224e6b642f69766480e0034bfb7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeGradeThresholdsData.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeGradeThresholdsData.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace WitchMendokusai.DomainSDK.UGC
+{
+	/// <summary>
+	/// 레시피 페이지가 정의하는 등급 경계 = BrewOutcomeRules 정합의 UGC 표면.
+	/// 거리·부작용 = 목표점에서 멀어질수록 / 부작용 누적이 많을수록 등급 강등.
+	/// Default 수치는 placeholder — 본격 진입 시 게임 BrewOutcomeRules 와 매핑.
+	/// </summary>
+	[Serializable]
+	public class UGCRecipeGradeThresholdsData
+	{
+		public float crudeMaxDistance;
+		public float fineMaxDistance;
+		public float masterworkMaxDistance;
+		public float masterworkMaxSideEffect;
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeGradeThresholdsData.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeGradeThresholdsData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dc4ff5f57ca44c4282b8f9afc350aa11

--- a/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeIngredientRefData.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeIngredientRefData.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace WitchMendokusai.DomainSDK.UGC
+{
+	/// <summary>
+	/// 레시피 페이지가 권장하는 재료 1개 참조 = BrewIngredient.Id + 기본 갈기량 표면.
+	/// 본격 진입 시 IngredientSO 가 등록한 ID 와 매칭(미등록 ID = sandbox reject).
+	/// 팬이 자기 레시피에 "이 재료 이만큼 갈아라" 라고 적는 표면.
+	/// </summary>
+	[Serializable]
+	public class UGCRecipeIngredientRefData
+	{
+		public int ingredientId;
+		public float grind;
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeIngredientRefData.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeIngredientRefData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 52df30b8a96a434f918574ac4a7bf5f9

--- a/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeManifestData.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeManifestData.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace WitchMendokusai.DomainSDK.UGC
+{
+	/// <summary>
+	/// 팬이 공유하는 마도서 레시피 1개 매니페스트 = JSON 직렬화 정본 표면.
+	/// Map/Seed 매니페스트와 같은 schemaVersion/version/author/tags/meta 컨벤션 — 기존 UGC 인프라(loader/validator) 정합.
+	/// meta = free-form 문자열(JObject 동적 dict 대신) — sandbox 표면 closed 유지.
+	/// </summary>
+	[Serializable]
+	public class UGCRecipeManifestData
+	{
+		public int schemaVersion;
+		public string manifestId;
+		public int version;
+		public string author;
+		public UGCRecipePageData recipe;
+		public List<string> tags = new();
+		public string note;
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeManifestData.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeManifestData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d9db1351a596467b855fab1813d9c5ac

--- a/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipePageData.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipePageData.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace WitchMendokusai.DomainSDK.UGC
+{
+	/// <summary>
+	/// 팬이 마도서 한 페이지에 적는 레시피 정의 = 데이터 주도 UGC 표면.
+	/// BrewRecipe(Id/EffectName/Target) 정합 + 팬 작성 메타(표제/설명/태그) + 권장 재료·등급 임계.
+	/// UnityEngine·Newtonsoft 의존 0 — DomainSDK references=[UniTask, MessagePipe] 정합. Domain 측 loader/validator 가 직렬화 담당.
+	/// 본격 진입 시 RecipeSO 가 감싸 디자이너 노출 + 마도서 페이지 UI/G6 모드 등록 표면.
+	/// </summary>
+	[Serializable]
+	public class UGCRecipePageData
+	{
+		public int recipeId;
+		public string effectName;
+		public string title;
+		public string description;
+		public UGCRecipeTargetData target;
+		public List<UGCRecipeIngredientRefData> ingredients = new();
+		public UGCRecipeGradeThresholdsData gradeThresholds;
+		public List<string> tags = new();
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipePageData.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipePageData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2eb77a8eda71482dbcb8e03035d97735

--- a/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeTargetData.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeTargetData.cs
@@ -1,0 +1,27 @@
+using System;
+using WitchMendokusai.DomainSDK.Alchemy;
+
+namespace WitchMendokusai.DomainSDK.UGC
+{
+	/// <summary>
+	/// 마도서 페이지가 요구하는 효과 공간 목표 좌표 + 허용 반경 = EffectTarget 의 JSON 직렬화 표면.
+	/// BrewVector 가 nested object(positionX/Y)를 갖는 대신 평탄 float 필드로 풀어, 팬 JSON 손수 작성 진입장벽 0.
+	/// ToEffectTarget() = Domain 측 변환 책임 — DomainSDK 안에서 정합 유지.
+	/// </summary>
+	[Serializable]
+	public class UGCRecipeTargetData
+	{
+		public float positionX;
+		public float positionY;
+		public float radius;
+
+		public EffectTarget ToEffectTarget()
+		{
+			return new EffectTarget
+			{
+				Position = new BrewVector(positionX, positionY),
+				Radius = radius,
+			};
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeTargetData.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/UGC/UGCRecipeTargetData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8198f00e16304a7da7185c48f88c68e3

--- a/Assets/_WitchMendokusai/Tests/EditMode/UGCRecipeLoaderTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/UGCRecipeLoaderTest.cs
@@ -1,0 +1,196 @@
+using Newtonsoft.Json;
+using NUnit.Framework;
+using WitchMendokusai.DomainSDK.Alchemy;
+using WitchMendokusai.DomainSDK.UGC;
+
+namespace WitchMendokusai.Tests
+{
+	public sealed class UGCRecipeLoaderTest
+	{
+		private const string SAMPLE_FILE = "recipe_001_starlight_salve.json";
+
+		[Test]
+		public void TryLoadRecipeManifestFromSample_StarlightSalve_ReturnsExpectedFields()
+		{
+			bool ok = UGCJsonLoader.TryLoadRecipeManifestFromSample(SAMPLE_FILE, out UGCRecipeManifestData manifest, out string error);
+
+			Assert.That(ok, Is.True, $"sample 로딩 실패: {error}");
+			Assert.That(manifest, Is.Not.Null);
+			Assert.That(manifest.schemaVersion, Is.EqualTo(1));
+			Assert.That(manifest.manifestId, Is.EqualTo("recipe_001_starlight_salve"));
+			Assert.That(manifest.author, Is.EqualTo("WM_System"));
+			Assert.That(manifest.recipe, Is.Not.Null);
+			Assert.That(manifest.recipe.title, Is.EqualTo("별빛 연고"));
+			Assert.That(manifest.recipe.effectName, Is.EqualTo("Restore"));
+			Assert.That(manifest.recipe.target.radius, Is.EqualTo(0.4f).Within(0.0001f));
+			Assert.That(manifest.recipe.ingredients, Is.Not.Null);
+			Assert.That(manifest.recipe.ingredients.Count, Is.EqualTo(2));
+			Assert.That(manifest.recipe.ingredients[0].ingredientId, Is.EqualTo(101));
+		}
+
+		[Test]
+		public void ToEffectTarget_TransfersPositionAndRadius()
+		{
+			UGCRecipeTargetData target = new()
+			{
+				positionX = 1.2f,
+				positionY = -0.5f,
+				radius = 0.3f,
+			};
+
+			EffectTarget effect = target.ToEffectTarget();
+
+			Assert.That(effect.Position.X, Is.EqualTo(1.2f).Within(0.0001f));
+			Assert.That(effect.Position.Y, Is.EqualTo(-0.5f).Within(0.0001f));
+			Assert.That(effect.Radius, Is.EqualTo(0.3f).Within(0.0001f));
+		}
+
+		[Test]
+		public void TryValidateRecipeManifest_RejectsWrongSchemaVersion()
+		{
+			UGCRecipeManifestData manifest = MakeValidManifest();
+			manifest.schemaVersion = 99;
+
+			bool ok = UGCJsonValidator.TryValidateRecipeManifest(manifest, out string error);
+
+			Assert.That(ok, Is.False);
+			Assert.That(error, Does.Contain("schemaVersion"));
+		}
+
+		[Test]
+		public void TryValidateRecipeManifest_RejectsEmptyManifestId()
+		{
+			UGCRecipeManifestData manifest = MakeValidManifest();
+			manifest.manifestId = "";
+
+			bool ok = UGCJsonValidator.TryValidateRecipeManifest(manifest, out string error);
+
+			Assert.That(ok, Is.False);
+			Assert.That(error, Does.Contain("manifestId"));
+		}
+
+		[Test]
+		public void TryValidateRecipeManifest_RejectsNullRecipe()
+		{
+			UGCRecipeManifestData manifest = MakeValidManifest();
+			manifest.recipe = null;
+
+			bool ok = UGCJsonValidator.TryValidateRecipeManifest(manifest, out string error);
+
+			Assert.That(ok, Is.False);
+			Assert.That(error, Does.Contain("recipe page"));
+		}
+
+		[Test]
+		public void TryValidateRecipeManifest_RejectsZeroRadius()
+		{
+			UGCRecipeManifestData manifest = MakeValidManifest();
+			manifest.recipe.target.radius = 0f;
+
+			bool ok = UGCJsonValidator.TryValidateRecipeManifest(manifest, out string error);
+
+			Assert.That(ok, Is.False);
+			Assert.That(error, Does.Contain("radius"));
+		}
+
+		[Test]
+		public void TryValidateRecipeManifest_RejectsNegativeGrind()
+		{
+			UGCRecipeManifestData manifest = MakeValidManifest();
+			manifest.recipe.ingredients.Add(new UGCRecipeIngredientRefData
+			{
+				ingredientId = 101,
+				grind = -0.1f,
+			});
+
+			bool ok = UGCJsonValidator.TryValidateRecipeManifest(manifest, out string error);
+
+			Assert.That(ok, Is.False);
+			Assert.That(error, Does.Contain("grind"));
+		}
+
+		[Test]
+		public void TryValidateRecipeManifest_RejectsInvertedThresholds()
+		{
+			UGCRecipeManifestData manifest = MakeValidManifest();
+			manifest.recipe.gradeThresholds = new UGCRecipeGradeThresholdsData
+			{
+				crudeMaxDistance = 1.0f,
+				fineMaxDistance = 1.5f,
+				masterworkMaxDistance = 0.3f,
+				masterworkMaxSideEffect = 0.1f,
+			};
+
+			bool ok = UGCJsonValidator.TryValidateRecipeManifest(manifest, out string error);
+
+			Assert.That(ok, Is.False);
+			Assert.That(error, Does.Contain("fineMaxDistance"));
+		}
+
+		[Test]
+		public void Deserialize_DropsOutOfSchemaFields()
+		{
+			string maliciousJson = @"{
+				""schemaVersion"": 1,
+				""manifestId"": ""recipe_sandbox_probe"",
+				""version"": 1,
+				""author"": ""tester"",
+				""recipe"": {
+					""recipeId"": 9,
+					""effectName"": ""Probe"",
+					""title"": ""Sandbox Probe"",
+					""target"": { ""positionX"": 0, ""positionY"": 0, ""radius"": 0.5 },
+					""ingredients"": [],
+					""arbitraryEvilField"": ""attempt-to-escape""
+				},
+				""tags"": [],
+				""__exec"": ""os.system('rm -rf /')""
+			}";
+
+			JsonSerializerSettings settings = new()
+			{
+				MissingMemberHandling = MissingMemberHandling.Ignore,
+				NullValueHandling = NullValueHandling.Include,
+			};
+
+			UGCRecipeManifestData parsed = JsonConvert.DeserializeObject<UGCRecipeManifestData>(maliciousJson, settings);
+
+			Assert.That(parsed, Is.Not.Null);
+			Assert.That(parsed.manifestId, Is.EqualTo("recipe_sandbox_probe"));
+			Assert.That(parsed.recipe.title, Is.EqualTo("Sandbox Probe"));
+
+			System.Reflection.FieldInfo evilField = typeof(UGCRecipePageData).GetField("arbitraryEvilField");
+			Assert.That(evilField, Is.Null, "UGCRecipePageData 에 arbitraryEvilField 가 생기면 sandbox 표면 확장 — 의도적 결정 필요");
+
+			System.Reflection.FieldInfo execField = typeof(UGCRecipeManifestData).GetField("__exec");
+			Assert.That(execField, Is.Null, "UGCRecipeManifestData 에 __exec 가 생기면 sandbox 우회 표면 — 절대 추가 X");
+		}
+
+		private static UGCRecipeManifestData MakeValidManifest()
+		{
+			return new UGCRecipeManifestData
+			{
+				schemaVersion = 1,
+				manifestId = "recipe_test",
+				version = 1,
+				author = "tester",
+				recipe = new UGCRecipePageData
+				{
+					recipeId = 1,
+					effectName = "Restore",
+					title = "Test Recipe",
+					description = "for test",
+					target = new UGCRecipeTargetData
+					{
+						positionX = 1f,
+						positionY = 1f,
+						radius = 0.5f,
+					},
+					ingredients = new(),
+					gradeThresholds = null,
+					tags = new(),
+				},
+			};
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/UGCRecipeLoaderTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/UGCRecipeLoaderTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 83d965097cbf48ac9dffadad6f16364a

--- a/ServerData/UGC/Samples/recipe_001_starlight_salve.json
+++ b/ServerData/UGC/Samples/recipe_001_starlight_salve.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "manifestId": "recipe_001_starlight_salve",
+  "version": 1,
+  "author": "WM_System",
+  "recipe": {
+    "recipeId": 1,
+    "effectName": "Restore",
+    "title": "별빛 연고",
+    "description": "달빛 이끼와 별가루를 갈아, 부드러운 회복 좌표로 항해한다. 첫 페이지 — 가장 안전한 회복 레시피.",
+    "target": {
+      "positionX": 1.0,
+      "positionY": 0.5,
+      "radius": 0.4
+    },
+    "ingredients": [
+      { "ingredientId": 101, "grind": 0.6 },
+      { "ingredientId": 102, "grind": 0.4 }
+    ],
+    "gradeThresholds": {
+      "crudeMaxDistance": 0.4,
+      "fineMaxDistance": 0.2,
+      "masterworkMaxDistance": 0.1,
+      "masterworkMaxSideEffect": 0.05
+    },
+    "tags": ["restore", "starter", "fan-page"]
+  },
+  "tags": ["fan-grimoire", "starter"],
+  "note": "First-use UGC 마도서 레시피 — 팬이 작성하는 한 페이지의 형태 박기. 본격 격상 시 IngredientSO 등록 ID 와 매핑."
+}


### PR DESCRIPTION
## Summary

UGC 콘텐츠 비전핏 0(플랫포머 점프맵) → **마도서 레시피 페이지**로 재조준 (G4 contents pivot). `BrewRecipe`/`EffectTarget` 정합 schema POCO 5종을 `DomainSDK/UGC/` 에 신설 = "외부 표면만 채움" 격상 입도 (SaveData-only, validator/loader 는 Domain 잔존). 본격 격상(플랫포머 deprecate / 마도서 UI / G6 모드 등록 표면) = **후속**.

### TASK 스펙 정렬 (cwd 밖 wm/tasks/TASK-WM-186-마도서-레시피-UGC-재조준-격상.md)

- current_phase = "시드 — 비전 방향 확정, 본격 격상·first-use 후속"
- 사용자 발화 (2026-06-07): "전부다 할건데 일단 임시로 1번 하고 나머지는 나중에. 그 외에것을 더 우선적으로" → 본 PR = "임시 1번" = 마도서 레시피 옵션 채택의 *시드형 first-use* 박기.
- 본 PR 범위 = 스펙 § 범위 1~3 의 *최소 단위* (schema 설계 + DomainSDK 격상 + first-use JSON+test). 4(플랫포머 deprecate) / 5(architecture.md canon 재정합) / 본격 UI = 후속 별도 PR.

### 변경

**DomainSDK/UGC/ (신설, references=[UniTask, MessagePipe] 정합 — UnityEngine·Newtonsoft 의존 0)**
- `UGCRecipePageData.cs` — 페이지 정의(recipeId/effectName/title/description/target/ingredients/gradeThresholds/tags)
- `UGCRecipeTargetData.cs` — 평탄 float positionX/Y/radius + `ToEffectTarget()` (BrewVector/EffectTarget 변환)
- `UGCRecipeIngredientRefData.cs` — ingredientId + grind (BrewIngredient.Id 정합)
- `UGCRecipeGradeThresholdsData.cs` — crude/fine/masterwork 거리 + sideEffect 임계 (BrewOutcomeRules 정합)
- `UGCRecipeManifestData.cs` — 팬 공유 정본 표면 (schemaVersion/manifestId/version/author/recipe/tags/note). meta = free-form string (JObject 동적 dict 대신 — sandbox closed 유지).

**Domain/Data/UGC/ (확장, 격상 입도 정책 따라 Domain 잔존)**
- `UGCJsonValidator.TryValidateRecipeManifest` — schemaVersion=1 / manifestId/effectName/title required / target.radius>0 / grind>=0 / 등급 임계 단조감소(masterwork ≤ fine ≤ crude)
- `UGCJsonLoader.TryLoadRecipeManifestFromSample` — Newtonsoft 직렬화 + validator 통과 강제

**Tests/EditMode/**
- `UGCRecipeLoaderTest` 9 케이스 — 샘플 round-trip + ToEffectTarget 변환 + 7 validator fail 케이스 + sandbox probe(악의 JSON에 \`__exec\`/\`arbitraryEvilField\` 추가해도 schema 밖 = 드랍 검증)

**ServerData/UGC/Samples/**
- `recipe_001_starlight_salve.json` — 별빛 연고 first-use 샘플 (마도서 페이지 1장의 형태 박기)

### 후속(이 PR 범위 X)

- 플랫포머 schema(Door/Platform/Checkpoint/Hazard executor + UGCActionData JObject @params) deprecate 또는 sandbox 데모 격하
- 마도서 페이지 UI / 인게임 레시피 에디터
- IModContentRegistry(G6) 등록 표면 → BrewRecipe 변환 어댑터
- WM-185 ledger retrofit-cost 자동 기록 확인
- architecture.md UGC 행 「방향 확정」 → 「마도서 레시피 first-use 박힘」 canon 재정합 (memo 봇 별도 반영)

### 환경 노트 (정직 보고)

- **Unity-MCP read_console 미가용** (cwd 격리 worktree + MCP HTTP 브릿지 미연결). DomainSDK.asmdef references / namespace 정합은 self-check 완료(POCO 가 Newtonsoft·UnityEngine 의존 0, BrewVector/EffectTarget 만 인용). 후속 Editor open 세션에서 MCP \`read_console(types=["error","warning"])\` = 0 entries 검증 필요.
- \`dotnet build\` wrapper (\`dotnet-build-wm.ps1\`) cwd 밖 → 사용 불가.
- 본 PR 의 EditMode 9 케이스 = Unity Test Runner 또는 \`run_tests(EditMode)\` 후속 실행으로 first-use 확정.

## Test plan

- [ ] Unity Editor open + \`read_console(types=["error","warning"])\` = 0 entries
- [ ] \`run_tests(EditMode)\` UGCRecipeLoaderTest 9 케이스 전부 pass
- [ ] (선택) 본격 격상 후속 PR 분할 — 플랫포머 deprecate / UI / G6 어댑터

🤖 Generated with [Claude Code](https://claude.com/claude-code)