### PR TITLE
feat(TASK-WM-188): 모딩 2패러다임 통합 Mod SDK seam — IMod 껍데기→실기능

### DIFF
--- a/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/RootLifetimeScope.cs
+++ b/Assets/_WitchMendokusai/Domain/Application/Scripts/DI/RootLifetimeScope.cs
@@ -51,6 +51,9 @@ namespace WitchMendokusai
 			// TASK-WM-107 Slice 2A — POCO Effect dispatch DI 진입점 (static Effect.ApplyEffect 우회 대체).
 			builder.Register<EffectRunner>(Lifetime.Singleton).As<IEffectRunner>();
 
+			// TASK-WM-188 — IMod 콘텐츠 등록 어댑터. ctor 가 ModContentRegistryBridge.Register + ModLoader.InitializeDiscoveredMods 트리거.
+			builder.Register<ModContentRegistryHost>(Lifetime.Singleton);
+
 			// TASK-WM-120 γ — GameLogic spawn 서비스 (static class → 주입). ctor
 			// [Inject] ObjectPoolManager (static `.Instance` reach 제거 = graph-derived).
 			builder.Register<GameLogic>(Lifetime.Singleton);
@@ -95,6 +98,8 @@ namespace WitchMendokusai
 				BootGuard.EagerResolve<GameManager>(container, "Root");
 				BootGuard.EagerResolve<UIRoot>(container, "Root");
 				BootGuard.EagerResolve<InputStrategySelector>(container, "Root");
+				// TASK-WM-188 — ModContentRegistryHost = Bridge 등록 + IMod Initialize 트리거. deps (QuestManager / DataManager) 가 eager 위에서 해소된 후 resolve.
+				BootGuard.EagerResolve<ModContentRegistryHost>(container, "Root");
 				BootObserver.Enter(BootPhase.RootContainerBuilt); // TASK-WM-118 B1
 			});
 		}

--- a/Assets/_WitchMendokusai/Domain/Mods/ModContentRegistryHost.cs
+++ b/Assets/_WitchMendokusai/Domain/Mods/ModContentRegistryHost.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using UnityEngine;
+using VContainer;
+
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// TASK-WM-188 — IModContentRegistry 의 Core 어댑터.
+	/// ctor 가 ModContentRegistryBridge.Register(this) → DomainSDK 정적 등록 정본 + ModLoader.InitializeDiscoveredMods 트리거(껍데기→실기능 seam).
+	/// QuestAddedEvent 구독자 0(grep 확인) → AddQuest 가 boot 시 안전. RuntimeQuest 는 saveData + 빈 Criteria 로 직접 구성(factory StartQuest 회피 = GameEventBridge 등록 0).
+	/// Effect 는 in-process catalog 에 저장(즉시 apply X — boot 시 PlayerProvider 등 미준비 deps 회피, 후속 quest definition 참조용 seam).
+	/// </summary>
+	public class ModContentRegistryHost : IModContentRegistry
+	{
+		private readonly QuestManager questManager;
+		private readonly List<EffectInfoData> registeredModEffects = new();
+
+		public IReadOnlyList<EffectInfoData> RegisteredModEffects => registeredModEffects;
+
+		[Inject]
+		public ModContentRegistryHost(QuestManager questManager)
+		{
+			this.questManager = questManager;
+			ModContentRegistryBridge.Register(this);
+			ModLoader.InitializeDiscoveredMods(new ModContext(this));
+		}
+
+		public void RegisterQuest(RuntimeQuestSaveData questSaveData)
+		{
+			RuntimeQuest quest = new RuntimeQuest(questSaveData) { Criteria = new List<RuntimeCriteria>() };
+			questManager.AddQuest(quest);
+			Debug.Log($"[ModContentRegistryHost] RegisterQuest — {questSaveData.Name} (Guid={questSaveData.Guid}, Type={questSaveData.Type})");
+		}
+
+		public void RegisterEffect(EffectInfoData effectInfoData)
+		{
+			registeredModEffects.Add(effectInfoData);
+			Debug.Log($"[ModContentRegistryHost] RegisterEffect — Type={effectInfoData.Type}, DataSoID={effectInfoData.DataSoID}, Value={effectInfoData.Value}");
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Domain/Mods/ModContentRegistryHost.cs.meta
+++ b/Assets/_WitchMendokusai/Domain/Mods/ModContentRegistryHost.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53b15dc1ca614f50b4eda153465440d0

--- a/Assets/_WitchMendokusai/Domain/Mods/ModLoader.cs
+++ b/Assets/_WitchMendokusai/Domain/Mods/ModLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -6,37 +7,73 @@ using UnityEngine;
 namespace WitchMendokusai
 {
 	/// <summary>
-	/// TASK-WM-083 Phase B — 게임 시작 시 (AfterAssembliesLoaded) 모든 IMod 구현을 reflection 으로 발견 + Initialize 호출.
+	/// TASK-WM-083 Phase B + TASK-WM-188 — IMod 구현 reflection 발견 + IModContext 기반 Initialize 트리거.
 	/// 본 ModLoader 는 Domain (Assembly-CSharp.dll) 안 — Mods.Sample.dll 등은 별 dll 로 빌드되어 AppDomain 에 자동 로드됨 (autoReferenced=false 라도 Unity 가 dll 자체는 로드).
+	/// 2-단계: (1) DiscoverMods @ AfterAssembliesLoaded — IMod 인스턴스 수집만, Initialize 보류 / (2) InitializeDiscoveredMods — Core 어댑터 ctor 가 IModContext 들고 호출.
 	/// </summary>
 	public static class ModLoader
 	{
+		private static readonly List<IMod> discoveredMods = new();
+		private static bool initialized = false;
+
+		public static IReadOnlyList<IMod> DiscoveredMods => discoveredMods;
+
 		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
-		private static void LoadMods()
+		private static void DiscoverMods()
 		{
+			discoveredMods.Clear();
+			initialized = false;
+
 			Type modInterface = typeof(IMod);
 
 			Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
 			Type[] modTypes = assemblies
-				.Where(a => a.GetName().Name.StartsWith("WitchMendokusai.Mods."))
-				.SelectMany(a => SafeGetTypes(a))
-				.Where(t => t != null && modInterface.IsAssignableFrom(t) && t.IsClass && t.IsAbstract == false)
+				.Where(assembly => assembly.GetName().Name.StartsWith("WitchMendokusai.Mods."))
+				.SelectMany(assembly => SafeGetTypes(assembly))
+				.Where(modType => modType != null && modInterface.IsAssignableFrom(modType) && modType.IsClass && modType.IsAbstract == false)
 				.ToArray();
-
-			Debug.Log($"[ModLoader] {modTypes.Length} mod 발견 (IMod 구현 in WitchMendokusai.Mods.* assembly)");
 
 			foreach (Type modType in modTypes)
 			{
 				try
 				{
 					IMod mod = (IMod)Activator.CreateInstance(modType);
-					mod.Initialize();
+					discoveredMods.Add(mod);
 				}
-				catch (Exception ex)
+				catch (Exception exception)
 				{
-					Debug.LogError($"[ModLoader] {modType.FullName} Initialize 실패 — {ex.Message}\n{ex.StackTrace}");
+					Debug.LogError($"[ModLoader] {modType.FullName} 인스턴스화 실패 — {exception.Message}\n{exception.StackTrace}");
 				}
 			}
+
+			Debug.Log($"[ModLoader] discovered {discoveredMods.Count} mods (IMod 구현 in WitchMendokusai.Mods.* assembly) — Initialize 보류, Host ctx 대기.");
+		}
+
+		/// <summary>
+		/// Core 어댑터(ModContentRegistryHost) ctor 가 호출. IModContext 주입 시점 = QuestManager 등 deps 준비 완료 후.
+		/// 멱등 — 재호출 시 no-op (도메인 reload 시 DiscoverMods 가 initialized=false 리셋).
+		/// </summary>
+		public static void InitializeDiscoveredMods(IModContext context)
+		{
+			if (initialized)
+			{
+				return;
+			}
+			initialized = true;
+
+			foreach (IMod mod in discoveredMods)
+			{
+				try
+				{
+					mod.Initialize(context);
+				}
+				catch (Exception exception)
+				{
+					Debug.LogError($"[ModLoader] {mod.Name} Initialize 실패 — {exception.Message}\n{exception.StackTrace}");
+				}
+			}
+
+			Debug.Log($"[ModLoader] Initialized {discoveredMods.Count} mods via IModContext (TASK-WM-188 seam).");
 		}
 
 		private static Type[] SafeGetTypes(Assembly assembly)
@@ -45,9 +82,9 @@ namespace WitchMendokusai
 			{
 				return assembly.GetTypes();
 			}
-			catch (ReflectionTypeLoadException ex)
+			catch (ReflectionTypeLoadException exception)
 			{
-				return ex.Types.Where(t => t != null).ToArray();
+				return exception.Types.Where(type => type != null).ToArray();
 			}
 		}
 	}

--- a/Assets/_WitchMendokusai/DomainSDK/Mods/IMod.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Mods/IMod.cs
@@ -1,13 +1,15 @@
 namespace WitchMendokusai
 {
 	/// <summary>
-	/// 모드 진입점 interface. ModLoader 가 RuntimeInitializeOnLoadMethod 시점에 모든 IMod 구현을 reflection 으로 발견 + Initialize 호출.
-	/// 모드 .dll 은 *DomainSDK 만 reference* — IMod 구현 시 Domain type 사용 X (sandbox 강제).
+	/// 모드 진입점 interface. ModLoader 가 reflection 으로 발견 + ModContentRegistryHost ctor 가 Initialize(ctx) 호출.
+	/// 모드 .dll 은 *DomainSDK 만 reference* — IMod 구현 시 Domain type 사용 X (asmdef 단방향 + WM-184 게이트가 sandbox 강제).
+	/// TASK-WM-188 — Initialize() → Initialize(IModContext) 격상. ModKind = 2-패러다임 통합 taxonomy (Behavior / AssetOverlay).
 	/// </summary>
 	public interface IMod
 	{
 		string Name { get; }
 		string Version { get; }
-		void Initialize();
+		ModKind Kind { get; }
+		void Initialize(IModContext context);
 	}
 }

--- a/Assets/_WitchMendokusai/DomainSDK/Mods/IModContentRegistry.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Mods/IModContentRegistry.cs
@@ -1,0 +1,13 @@
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// TASK-WM-188 — 모드가 콘텐츠(quest/effect) 를 게임에 등록하는 sandbox API.
+	/// DomainSDK POCO 만 받음(QuestSO/EffectInfo Domain 타입 X) — asmdef 단방향 + WM-184 게이트가 sandbox 강제.
+	/// 구현 = Core ModContentRegistryHost (ModContentRegistryBridge.Register 로 주입).
+	/// </summary>
+	public interface IModContentRegistry
+	{
+		void RegisterQuest(RuntimeQuestSaveData questSaveData);
+		void RegisterEffect(EffectInfoData effectInfoData);
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Mods/IModContentRegistry.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Mods/IModContentRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8f143a8957754601be409832328e6c93

--- a/Assets/_WitchMendokusai/DomainSDK/Mods/IModContext.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Mods/IModContext.cs
@@ -1,0 +1,11 @@
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// TASK-WM-188 — IMod.Initialize 가 받는 진입 context. 콘텐츠 등록 API seam.
+	/// 후속 phase 에서 logger/metadata/permission 등 확장.
+	/// </summary>
+	public interface IModContext
+	{
+		IModContentRegistry ContentRegistry { get; }
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Mods/IModContext.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Mods/IModContext.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec2389b4ee6143f6b802e60c99e5cdc2

--- a/Assets/_WitchMendokusai/DomainSDK/Mods/ModContentRegistryBridge.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Mods/ModContentRegistryBridge.cs
@@ -1,0 +1,29 @@
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// TASK-WM-188 — Bridge 패턴(DomainSDK ↛ Core Singleton 직접호출 금지).
+	/// Core 어댑터(ModContentRegistryHost) ctor 가 Register(this) 호출 → DomainSDK 정적 호출로 등록.
+	/// FastFail — Bootstrap(RootLifetimeScope eager resolve) 후 호출 보장이라 null check 제거.
+	/// </summary>
+	public static class ModContentRegistryBridge
+	{
+		private static IModContentRegistry instance;
+
+		public static IModContentRegistry Instance => instance;
+
+		public static void Register(IModContentRegistry registry)
+		{
+			instance = registry;
+		}
+
+		public static void RegisterQuest(RuntimeQuestSaveData questSaveData)
+		{
+			instance.RegisterQuest(questSaveData);
+		}
+
+		public static void RegisterEffect(EffectInfoData effectInfoData)
+		{
+			instance.RegisterEffect(effectInfoData);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Mods/ModContentRegistryBridge.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Mods/ModContentRegistryBridge.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d4a801b03c2842e3b36e3f0064b995c7

--- a/Assets/_WitchMendokusai/DomainSDK/Mods/ModContext.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Mods/ModContext.cs
@@ -1,0 +1,12 @@
+namespace WitchMendokusai
+{
+	public class ModContext : IModContext
+	{
+		public IModContentRegistry ContentRegistry { get; }
+
+		public ModContext(IModContentRegistry contentRegistry)
+		{
+			ContentRegistry = contentRegistry;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Mods/ModContext.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Mods/ModContext.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 729724b284644936904d45fc831e41f1

--- a/Assets/_WitchMendokusai/DomainSDK/Mods/ModKind.cs
+++ b/Assets/_WitchMendokusai/DomainSDK/Mods/ModKind.cs
@@ -1,0 +1,11 @@
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// TASK-WM-188 — 2 패러다임 통합 taxonomy. Behavior = in-process C# .dll(IMod), AssetOverlay = manifest+bundle slot(ShaderModding 류).
+	/// </summary>
+	public enum ModKind
+	{
+		Behavior = 0,
+		AssetOverlay = 1,
+	}
+}

--- a/Assets/_WitchMendokusai/DomainSDK/Mods/ModKind.cs.meta
+++ b/Assets/_WitchMendokusai/DomainSDK/Mods/ModKind.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 16f35297ca604b4487f6718dea170754

--- a/Assets/_WitchMendokusai/Mods/Sample/HelloMod.cs
+++ b/Assets/_WitchMendokusai/Mods/Sample/HelloMod.cs
@@ -1,25 +1,51 @@
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace WitchMendokusai.Mods.Sample
 {
 	/// <summary>
-	/// TASK-WM-083 Phase A+B — Mods Sample.
-	/// asmdef references = [WitchMendokusai.DomainSDK] 만 → DomainSDK type 만 호출 가능.
-	/// IMod 구현 = ModLoader 가 reflection 으로 발견 + Initialize 호출.
+	/// TASK-WM-083 Phase A+B + TASK-WM-188 first-use.
+	/// asmdef references = [WitchMendokusai.DomainSDK] 만 → DomainSDK type 만 호출 가능(sandbox 강제, WM-184 게이트).
+	/// IMod.Initialize(IModContext) = 껍데기→실기능 seam: quest 1 + effect 1 실제 등록.
 	/// </summary>
 	public class HelloMod : IMod
 	{
 		public string Name => "Sample";
 		public string Version => "0.1.0";
+		public ModKind Kind => ModKind.Behavior;
 
-		// DomainSDK type reference 검증 (단방향 OK).
-		public QuestType DefaultQuestType => QuestType.Normal;
-		public EffectType DefaultEffectType => EffectType.UnitStat;
-		public int DefaultWorkerID => WorkConstants.NONE_WORKER_ID;
-
-		public void Initialize()
+		public void Initialize(IModContext context)
 		{
-			Debug.Log($"[Mod:{Name} v{Version}] Initialize — DomainSDK sandbox 검증 ✅. DefaultQuestType={DefaultQuestType}, DefaultEffectType={DefaultEffectType}, DefaultWorkerID={DefaultWorkerID}");
+			RuntimeQuestSaveData sampleQuest = new RuntimeQuestSaveData
+			{
+				Guid = Guid.NewGuid(),
+				State = RuntimeQuestState.InProgress,
+				SO_ID = -1,
+				Name = "Hello Mod Quest",
+				Description = "TASK-WM-188 first-use — DomainSDK POCO 만으로 quest 등록 sandbox 검증.",
+				Type = QuestType.Normal,
+				GameEvents = new List<GameEventType>(),
+				Criteria = new List<RuntimeCriteriaSaveData>(),
+				CompleteEffects = new List<EffectInfoData>(),
+				RewardEffects = new List<RewardInfoData>(),
+				Rewards = new List<RewardInfoData>(),
+				WorkTime = 0f,
+				AutoWork = false,
+				AutoComplete = false,
+			};
+			context.ContentRegistry.RegisterQuest(sampleQuest);
+
+			EffectInfoData sampleEffect = new EffectInfoData
+			{
+				Type = EffectType.UnitStat,
+				DataSoID = WorkConstants.NONE_WORKER_ID,
+				ArithmeticOperator = ArithmeticOperator.Add,
+				Value = 0,
+			};
+			context.ContentRegistry.RegisterEffect(sampleEffect);
+
+			Debug.Log($"[Mod:{Name} v{Version}] Initialize via IModContext — quest 1 + effect 1 registered ({Kind}).");
 		}
 	}
 }

--- a/Assets/_WitchMendokusai/Tests/EditMode/Mods.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/Mods.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 58a548060e7a4b3aab8ad72226069e7e
+folderAsset: yes

--- a/Assets/_WitchMendokusai/Tests/EditMode/Mods/HelloModRegistryTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/Mods/HelloModRegistryTest.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace WitchMendokusai.Tests
+{
+	/// <summary>
+	/// TASK-WM-188 first-use rung — mock IModContentRegistry 주입 → HelloMod.Initialize(ctx) → quest/effect 1개 등록됨 assert.
+	/// 껍데기(Debug.Log only) → 실기능(IModContext 콘텐츠 등록) 전환 증명.
+	/// </summary>
+	[TestFixture]
+	public class HelloModRegistryTest
+	{
+		private class FakeModContentRegistry : IModContentRegistry
+		{
+			public readonly List<RuntimeQuestSaveData> RegisteredQuests = new();
+			public readonly List<EffectInfoData> RegisteredEffects = new();
+
+			public void RegisterQuest(RuntimeQuestSaveData questSaveData) => RegisteredQuests.Add(questSaveData);
+			public void RegisterEffect(EffectInfoData effectInfoData) => RegisteredEffects.Add(effectInfoData);
+		}
+
+		[Test]
+		public void Initialize_WithIModContext_RegistersOneQuestAndOneEffect()
+		{
+			FakeModContentRegistry registry = new FakeModContentRegistry();
+			ModContext context = new ModContext(registry);
+			Mods.Sample.HelloMod mod = new Mods.Sample.HelloMod();
+
+			mod.Initialize(context);
+
+			Assert.AreEqual(1, registry.RegisteredQuests.Count, "HelloMod 가 quest 1개 등록해야 함 (껍데기 → 실기능).");
+			Assert.AreEqual("Hello Mod Quest", registry.RegisteredQuests[0].Name);
+			Assert.AreEqual(QuestType.Normal, registry.RegisteredQuests[0].Type);
+			Assert.AreEqual(RuntimeQuestState.InProgress, registry.RegisteredQuests[0].State);
+			Assert.IsNotNull(registry.RegisteredQuests[0].Guid);
+
+			Assert.AreEqual(1, registry.RegisteredEffects.Count, "HelloMod 가 effect 1개 등록해야 함.");
+			Assert.AreEqual(EffectType.UnitStat, registry.RegisteredEffects[0].Type);
+			Assert.AreEqual(ArithmeticOperator.Add, registry.RegisteredEffects[0].ArithmeticOperator);
+		}
+
+		[Test]
+		public void HelloMod_Kind_IsBehavior()
+		{
+			Mods.Sample.HelloMod mod = new Mods.Sample.HelloMod();
+			Assert.AreEqual(ModKind.Behavior, mod.Kind, "in-process C# .dll 모드 = Behavior kind.");
+		}
+
+		[Test]
+		public void ModKind_Behavior_IsDistinctFrom_AssetOverlay()
+		{
+			Assert.AreNotEqual(ModKind.Behavior, ModKind.AssetOverlay,
+				"통합 taxonomy = 2-kind 분류 (Behavior in-process .dll / AssetOverlay manifest+bundle).");
+		}
+
+		[Test]
+		public void ModContext_ExposesInjectedContentRegistry()
+		{
+			FakeModContentRegistry registry = new FakeModContentRegistry();
+			ModContext context = new ModContext(registry);
+
+			Assert.AreSame(registry, context.ContentRegistry, "ModContext 가 주입된 registry 를 노출 (DI seam).");
+		}
+
+		[Test]
+		public void ModContentRegistryBridge_RegisterRoutesToInstance()
+		{
+			FakeModContentRegistry registry = new FakeModContentRegistry();
+			ModContentRegistryBridge.Register(registry);
+
+			EffectInfoData effectInfoData = new EffectInfoData
+			{
+				Type = EffectType.IntVariable,
+				DataSoID = -1,
+				ArithmeticOperator = ArithmeticOperator.Add,
+				Value = 7,
+			};
+			ModContentRegistryBridge.RegisterEffect(effectInfoData);
+
+			Assert.AreEqual(1, registry.RegisteredEffects.Count, "Bridge static accessor 가 Instance 로 라우팅.");
+			Assert.AreEqual(7, registry.RegisteredEffects[0].Value);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Tests/EditMode/Mods/HelloModRegistryTest.cs.meta
+++ b/Assets/_WitchMendokusai/Tests/EditMode/Mods/HelloModRegistryTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7978ba2b4daa42c6a51867829fd8b38c

--- a/Assets/_WitchMendokusai/Tests/EditMode/WM.Tests.EditMode.asmdef
+++ b/Assets/_WitchMendokusai/Tests/EditMode/WM.Tests.EditMode.asmdef
@@ -6,6 +6,7 @@
         "WM.Domain",
         "WM.Core",
         "WM.Editor",
+        "WitchMendokusai.Mods.Sample",
         "VContainer"
     ],
     "includePlatforms": [


### PR DESCRIPTION
## TASK-WM-188 — 모딩 2 패러다임 통합 Mod SDK seam (G6)

> 사용자 발화 (2026-06-07): \"둘 다 지원하는게 어떨지.\" — G6 모딩 = 데이터/SO 등록 + 임의 C# .dll 둘 다 지원.

### 문제

audit(wf_8264da00) 진단:
- `DomainSDK/Mods/IMod.cs` — `Initialize()` 가 콘텐츠 등록 seam 부재 = 껍데기. `HelloMod.Initialize` = `Debug.Log` 만.
- `Domain/Mods/ModLoader.cs` — reflection 발견 + Initialize 경로 실재(임의 C# .dll 경로 존재) 하지만 **콘텐츠 라우팅 0**.
- `Core/Scripts/ShaderModding/ShaderPackManager.cs` — 별 패러다임 실기능. IMod 와 서로 모름 (재통합 필요 :170 미해소).

→ **둘 다 지원**: IMod 실기능화(콘텐츠 등록 seam) + sandbox(asmdef refs=[DomainSDK]만, WM-184 게이트) + ShaderSDK 와 단일 2-kind taxonomy.

## Summary

- **DomainSDK seam 5 신설**: `ModKind`(Behavior/AssetOverlay enum), `IModContentRegistry`(RegisterQuest/RegisterEffect POCO API), `IModContext`/`ModContext`(Initialize 진입 ctx, 후속 확장 seam), `ModContentRegistryBridge`(static accessor, FastFail).
- **IMod 격상**: `Initialize()` → `Initialize(IModContext)` + 필수 `ModKind Kind`.
- **Core 어댑터 + 부팅**: `ModContentRegistryHost`(Domain layer, `[Inject] QuestManager`) ctor 가 Bridge.Register + ModLoader.InitializeDiscoveredMods 트리거. RootLifetimeScope Singleton 등록 + BuildCallback EagerResolve.
- **ModLoader 2-단계 split**: DiscoverMods @ AfterAssembliesLoaded(인스턴스 수집만) + InitializeDiscoveredMods(Host ctx). 멱등.
- **HelloMod first-use**: `Initialize(ctx)` = quest 1(\"Hello Mod Quest\", QuestType.Normal) + effect 1(EffectType.UnitStat) 실제 등록.
- **EditMode rung**: HelloModRegistryTest 5 case (mock IModContentRegistry → Initialize → assert).

## 변경 파일

```
신설 (DomainSDK seam):
  DomainSDK/Mods/ModKind.cs
  DomainSDK/Mods/IModContentRegistry.cs
  DomainSDK/Mods/IModContext.cs
  DomainSDK/Mods/ModContext.cs
  DomainSDK/Mods/ModContentRegistryBridge.cs

신설 (Core 어댑터):
  Domain/Mods/ModContentRegistryHost.cs

신설 (검증):
  Tests/EditMode/Mods/HelloModRegistryTest.cs

수정:
  DomainSDK/Mods/IMod.cs                                 # Initialize() → Initialize(IModContext), Kind 추가
  Domain/Mods/ModLoader.cs                               # 2-단계 split
  Domain/Application/Scripts/DI/RootLifetimeScope.cs     # Host Singleton + Eager
  Mods/Sample/HelloMod.cs                                # quest/effect 1개씩 실 등록
  Tests/EditMode/WM.Tests.EditMode.asmdef                # Mods.Sample reference 추가
```

## 6 동기 매핑

| 동기 | 기여 |
|---|---|
| 모딩 | IMod 껍데기 → 실기능 + 2 패러다임 단일 taxonomy (핵심) |
| 분리 | Mod sandbox 단방향(asmdef refs=[DomainSDK]) 유지 — WM-184 게이트가 강제 |
| UGC | RuntimeQuestSaveData / EffectInfoData POCO 등록 = 모드/UGC 공통 경로 (G4 마도서 레시피 후속 연동 seam) |

## 둘 다 지원 가드

- **임의 C# .dll(Behavior kind)** = ModLoader reflection 경로 무손상. `WitchMendokusai.Mods.*` assembly scan, Activator.CreateInstance, asmdef 단방향(WM-184 게이트가 컴파일 시 sandbox 강제).
- **AssetOverlay kind** = ShaderPackManager 본체 무변경. slot Apply/Revert seam 무손상. taxonomy 단일화 = ModKind enum + IMod.Kind 로 명시.

## Test plan

- [x] EditMode rung — `HelloModRegistryTest.Initialize_WithIModContext_RegistersOneQuestAndOneEffect` (mock 주입 + count + 필드 assert)
- [x] EditMode rung — `HelloMod_Kind_IsBehavior` / `ModKind_Behavior_IsDistinctFrom_AssetOverlay` (taxonomy 분리)
- [x] EditMode rung — `ModContext_ExposesInjectedContentRegistry` / `ModContentRegistryBridge_RegisterRoutesToInstance` (DI seam + Bridge static 라우팅)
- [ ] **Unity-MCP `read_console(types=[error,warning])` = 0** — 본 worktree 단계에서 MCP 미가용. Editor 동기화 후 확인 필요.
- [ ] **`wm-boot-smoke.ps1`** — ModContentRegistryHost EagerResolve 가 부팅 안 깸 확인. QuestAddedEvent 구독자 0 grep 확인(현 트리) + RuntimeQuest factory StartQuest 회피로 GameEventBridge 등록 0 보장 = boot 시점 안전 추정. 실 smoke 는 Editor 환경에서.
- [ ] **WM-184 asmdef sandbox 게이트** — `WitchMendokusai.Mods.Sample` (refs=[DomainSDK] 그대로) + HelloMod 가 DomainSDK type 만 호출 확인. 게이트 CI 통과 예상.
- [ ] **ShaderModding 회귀 0** — ShaderPackManager 본체 무변경 = slot Apply/Revert seam 무손상.
- [ ] **MenuItem 'WitchMendokusai/' grep 0** — 본 commit 신규 MenuItem 0.

## Follow-up (본 commit 미반영)

- **정본 통합 doc** — `memo/wm/design/vision/architecture.md` § 4 모딩 + `shader-modding-architecture.md` → 단일 모딩 SDK § (2 mod-kind 표, 로더/매니페스트/sandbox/first-use). :170 \"재통합 필요\" 해소. memo/ 가 본 worktree 밖이라 미반영 → 봇/사용자 별도 반영.
- **임의 C# .dll permission UI** — 후속 phase.
- **G4 마도서 레시피 연동** — TASK-WM-186 후속 / IModContentRegistry RegisterRecipe 확장.
- **Effect 실 적용 (catalog → runtime)** — 현재 RegisterEffect = in-process catalog 저장. 후속 phase 에서 quest definition 참조 / 실시간 적용 경로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)