### PR TITLE
feat(TASK-WM-187): 라이브 sync 1채널 first-use — NetworkBootstrap + 호스트 PlayVerify

### DIFF
--- a/Assets/_WitchMendokusai/Editor/Verify/WMPlayVerifyBase.cs
+++ b/Assets/_WitchMendokusai/Editor/Verify/WMPlayVerifyBase.cs
@@ -41,8 +41,9 @@ namespace WitchMendokusai.EditorTools
 			EditorApplication.playModeStateChanged += OnPlayModeChanged;
 		}
 
-		// 파생 [MenuItem] static 래퍼가 Instance.Arm() 호출.
-		public void Arm()
+		// 파생 [MenuItem] static 래퍼가 Instance.Arm() 호출. 격리된 빈 씬 setup 이 필요한 파생(예: FishNet 호스트
+		// 하네스 — heavy-boot wedge 회피) 은 override 해 EnterPlaymode 전 씬을 갈아끼움. base = 현 씬 그대로.
+		public virtual void Arm()
 		{
 			EditorPrefs.SetBool(ArmPref, true);
 			Debug.Log(Tag + " armed — Play 진입");

--- a/Assets/_WitchMendokusai/Network/Editor.meta
+++ b/Assets/_WitchMendokusai/Network/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1a2110fe85c3490ea2126b19dea1e50e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Network/Editor/WM.Network.Editor.asmdef
+++ b/Assets/_WitchMendokusai/Network/Editor/WM.Network.Editor.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "WM.Network.Editor",
+    "rootNamespace": "WitchMendokusai.NetworkEditor",
+    "references": [
+        "FishNet.Runtime",
+        "WM.Network",
+        "WM.Editor",
+        "WM.Core",
+        "WitchMendokusai.DomainSDK"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/_WitchMendokusai/Network/Editor/WM.Network.Editor.asmdef.meta
+++ b/Assets/_WitchMendokusai/Network/Editor/WM.Network.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 428294ffb37d43b2b7404363d1cf025c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Network/Editor/WMNetSyncHostPlayVerify.cs
+++ b/Assets/_WitchMendokusai/Network/Editor/WMNetSyncHostPlayVerify.cs
@@ -1,0 +1,200 @@
+using System;
+using FishNet.Object;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using WitchMendokusai.EditorTools;
+
+namespace WitchMendokusai.NetworkEditor
+{
+	/// <summary>
+	/// TASK-WM-187 — 라이브 sync 1채널 first-use 호스트 PlayMode 자율검증. 사용자 0클릭.
+	///
+	/// 격리 PlayMode (WM heavy-boot 와 분리 = wedge 회피, spec 정본) — 빈 씬에서 <see cref="NetworkBootstrap"/>
+	/// 가 NetworkManager+Tugboat 호스트 자체연결 → 런타임 NetworkObject(<see cref="WMNetSyncSmokeBridge"/>) 스폰
+	/// → 서버 SyncVar 세팅 → 클라(host client) 미러 관측 → assert OK/FAIL.
+	///
+	/// 다단계 흐름이라 단발-<see cref="WMPlayVerifyBase.RunVerify"/> 만으론 부족 — IsReady 안에서 state machine
+	/// 진행, 결과는 RunVerify 에서 1회 로그 (base lifecycle 보존).
+	/// </summary>
+	[InitializeOnLoad]
+	public sealed class WMNetSyncHostPlayVerify : WMPlayVerifyBase
+	{
+		private const int PROBE_TEST_VALUE = 4242;
+		private const ushort HOST_PORT = 7771; // 게임 부팅 port 와 격리 (회귀 충돌 회피)
+		private const string ISOLATED_SCENE_NAME = "_WMNetSyncSmoke";
+		private const string SCREENSHOT_PATH = "Temp/wm-netsync-host-play-verify.png";
+
+		private enum Stage
+		{
+			Idle,
+			BootingHost,
+			SpawningBridge,
+			AwaitingMirror,
+			Done,
+		}
+
+		private static readonly WMNetSyncHostPlayVerify Instance = new();
+		static WMNetSyncHostPlayVerify() { }
+
+		[MenuItem("WM/Verify/라이브 sync 1채널 (호스트) Play 자율검증")]
+		private static void ArmFromMenu() => Instance.Arm();
+
+		protected override string ArmPref => "WM_NETSYNC_HOST_PLAYVERIFY_ARMED";
+		protected override string Tag => "[NETSYNC-HOST-187]";
+
+		// IsReady 가 state machine 을 회전 — settle 은 짧게(미러 관측이 IsReady 안에서 다 끝남).
+		protected override double SettleSeconds => 0.1;
+
+		private Stage stage = Stage.Idle;
+		private WMNetSyncSmokeBridge serverBridge;
+		private NetworkObject serverNetworkObject;
+		private bool hostBooted;
+		private bool spawnDone;
+		private int observedMirror = WMNetSyncSmokeBridge.UNINITIALIZED_VALUE;
+
+		// EnterPlaymode 가 게임 heavy-boot 씬을 그대로 안 끌고 가도록 — 빈 씬으로 갈아끼움.
+		// 현 씬이 dirty 면 자율 진행 X (사용자 작업 보호) — 명시 로그 후 abort.
+		public override void Arm()
+		{
+			if (EditorApplication.isPlayingOrWillChangePlaymode == true)
+			{
+				Debug.LogWarning(Tag + " 이미 Play 상태 — Arm 무시");
+				return;
+			}
+
+			Scene activeScene = EditorSceneManager.GetActiveScene();
+			if (activeScene.isDirty == true)
+			{
+				Debug.LogError(Tag + " 활성 씬 dirty — 저장 후 다시 시도. (자율검증이 미저장 작업을 덮어쓰지 않음)");
+				return;
+			}
+
+			ResetState();
+			Scene isolated = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+			isolated.name = ISOLATED_SCENE_NAME;
+			Debug.Log(Tag + " 격리 빈 씬 생성 (" + ISOLATED_SCENE_NAME + ") — heavy-boot wedge 회피");
+
+			base.Arm();
+		}
+
+		// 매 tick 호출 — stage 별 1회씩 진행, 모두 완료되면 true 반환.
+		protected override bool IsReady()
+		{
+			switch (stage)
+			{
+				case Stage.Idle:
+					BootHost();
+					return false;
+
+				case Stage.BootingHost:
+					if (NetworkBootstrap.IsHostFullyStarted == false)
+						return false;
+					hostBooted = true;
+					stage = Stage.SpawningBridge;
+					return false;
+
+				case Stage.SpawningBridge:
+					SpawnBridgeAndPushValue();
+					return false;
+
+				case Stage.AwaitingMirror:
+					if (TryReadHostClientMirror(out int mirroredValue) == false)
+						return false;
+					observedMirror = mirroredValue;
+					stage = Stage.Done;
+					return true;
+
+				case Stage.Done:
+					return true;
+			}
+			return false;
+		}
+
+		protected override void RunVerify()
+		{
+			bool mirrorMatches = observedMirror == PROBE_TEST_VALUE;
+			bool loopOk = hostBooted && spawnDone && mirrorMatches;
+
+			Log((loopOk ? "LOOP OK ✅" : "LOOP FAIL ❌")
+				+ " hostBooted=" + hostBooted
+				+ " spawnDone=" + spawnDone
+				+ " probe=set:" + PROBE_TEST_VALUE + "/mirror:" + observedMirror
+				+ " match=" + mirrorMatches);
+
+			ScreenCapture.CaptureScreenshot(SCREENSHOT_PATH);
+			Log("screenshot → " + SCREENSHOT_PATH);
+
+			// 호스트 정리 — 다음 verify run/Play 진입을 깨끗하게.
+			try
+			{
+				NetworkBootstrap.StopHost();
+			}
+			catch (Exception exception)
+			{
+				Debug.LogWarning(Tag + " StopHost 예외(무시): " + exception.GetType().Name + " " + exception.Message);
+			}
+		}
+
+		private void BootHost()
+		{
+			try
+			{
+				NetworkBootstrap.EnsureHostStarted(HOST_PORT);
+				stage = Stage.BootingHost;
+				Log("호스트 기동 요청 (port=" + HOST_PORT + ") — IsHostFullyStarted 대기");
+			}
+			catch (Exception exception)
+			{
+				Debug.LogError(Tag + " 호스트 기동 실패: " + exception.GetType().Name + " " + exception.Message);
+				stage = Stage.Done;
+			}
+		}
+
+		private void SpawnBridgeAndPushValue()
+		{
+			GameObject go = new GameObject("WMNetSyncSmokeBridge_Server");
+			serverNetworkObject = go.AddComponent<NetworkObject>();
+			serverBridge = go.AddComponent<WMNetSyncSmokeBridge>();
+
+			try
+			{
+				NetworkBootstrap.ServerSpawn(serverNetworkObject);
+				serverBridge.ServerSetProbe(PROBE_TEST_VALUE);
+				spawnDone = true;
+				stage = Stage.AwaitingMirror;
+				Log("server spawn + SyncVar.set(" + PROBE_TEST_VALUE + ") — host client 미러 대기");
+			}
+			catch (Exception exception)
+			{
+				Debug.LogError(Tag + " server spawn 실패: " + exception.GetType().Name + " " + exception.Message);
+				stage = Stage.Done;
+			}
+		}
+
+		// host 모드라도 SyncVar 가 host client 측에 미러되면 OnChange(asServer=false) 콜백이 fire.
+		// 콜백 fire = sync layer 실거동 신호 (값 메모리 공유가 아닌 큐/loopback 적용 경로 입증).
+		private bool TryReadHostClientMirror(out int mirroredValue)
+		{
+			mirroredValue = WMNetSyncSmokeBridge.UNINITIALIZED_VALUE;
+			if (serverBridge == null)
+				return false;
+			if (serverBridge.ClientFired == false)
+				return false;
+
+			mirroredValue = serverBridge.ClientMirroredValue;
+			return true;
+		}
+
+		private void ResetState()
+		{
+			stage = Stage.Idle;
+			serverBridge = null;
+			serverNetworkObject = null;
+			hostBooted = false;
+			spawnDone = false;
+			observedMirror = WMNetSyncSmokeBridge.UNINITIALIZED_VALUE;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Network/Editor/WMNetSyncHostPlayVerify.cs.meta
+++ b/Assets/_WitchMendokusai/Network/Editor/WMNetSyncHostPlayVerify.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2903779ed0a54cbe8245ba86d6bdf714
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Network/Editor/WMNetSyncSmokeBridge.cs
+++ b/Assets/_WitchMendokusai/Network/Editor/WMNetSyncSmokeBridge.cs
@@ -1,0 +1,93 @@
+using FishNet.Object;
+using FishNet.Object.Synchronizing;
+
+namespace WitchMendokusai.NetworkEditor
+{
+	/// <summary>
+	/// TASK-WM-187 — 호스트 PlayVerify 전용 minimal SyncVar bridge.
+	///
+	/// WorldClockNetworkBridge 의 SyncVar 채널 메커니즘과 *동일한* WMNetworkBehaviour/FishNet.SyncVar 파이프라인을
+	/// 게임 DI 캐스케이드(WorldClock→TimeManager→GameEventManager → VContainer)에서 격리해 거동만 입증.
+	/// 게임 heavy-boot wedge 회피 = host 하네스 실거동 가능 — 채널 메커니즘 first-use 박힘이 본 PR 의 검증 rung.
+	///
+	/// 실 WorldClock 시각 동기 거동 검증은 게임 heavy-boot 경로(별도) — 현 단계 = sync 1채널 substrate 박힘.
+	///
+	/// 검증 정본 = <see cref="ClientMirroredValue"/> — OnChange(asServer=false) 가 fire 한 시점의 신 값.
+	/// 호스트 모드라도 server set 은 sync layer 큐 → 다음 tick 에 host client local connection 으로 적용 = 콜백 fire.
+	/// </summary>
+	public sealed class WMNetSyncSmokeBridge : WMNetworkBehaviour
+	{
+		public const int UNINITIALIZED_VALUE = -1;
+
+		// SyncVar default ctor — initial value = default(T) = 0. Server set to PROBE_TEST_VALUE (≠0) → OnChange fire.
+		private readonly SyncVar<int> probe = new SyncVar<int>();
+
+		private int clientMirroredValue = UNINITIALIZED_VALUE;
+		private bool clientFired;
+
+		/// <summary> 클라(asServer=false) 측 OnChange 가 fire 했는가 — sync 레이어 라이브 신호. </summary>
+		public bool ClientFired => clientFired;
+
+		/// <summary> OnChange(asServer=false) 가 fire 했을 때 받은 새 값. </summary>
+		public int ClientMirroredValue => clientMirroredValue;
+
+		// 호스트 모드: OnStartServer + OnStartClient 양쪽 fire — 콜백 idempotent 등록 위해 isSubscribed 가드.
+		// 정본 WorldClockNetworkBridge 패턴(OnStartServer override)과 정합.
+		private bool isSubscribed;
+
+		public override void OnStartServer()
+		{
+			base.OnStartServer();
+			Subscribe();
+		}
+
+		public override void OnStartClient()
+		{
+			base.OnStartClient();
+			Subscribe();
+		}
+
+		public override void OnStopServer()
+		{
+			base.OnStopServer();
+			Unsubscribe();
+		}
+
+		public override void OnStopClient()
+		{
+			base.OnStopClient();
+			Unsubscribe();
+		}
+
+		/// <summary> 서버에서 SyncVar 값 push. 클라(host client) 가 다음 tick 에 OnChange 콜백 fire. </summary>
+		public void ServerSetProbe(int value)
+		{
+			probe.Value = value;
+		}
+
+		private void HandleProbeChanged(int previousValue, int nextValue, bool asServer)
+		{
+			if (asServer == true)
+				return;
+
+			clientFired = true;
+			clientMirroredValue = nextValue;
+		}
+
+		private void Subscribe()
+		{
+			if (isSubscribed == true)
+				return;
+			probe.OnChange += HandleProbeChanged;
+			isSubscribed = true;
+		}
+
+		private void Unsubscribe()
+		{
+			if (isSubscribed == false)
+				return;
+			probe.OnChange -= HandleProbeChanged;
+			isSubscribed = false;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Network/Editor/WMNetSyncSmokeBridge.cs.meta
+++ b/Assets/_WitchMendokusai/Network/Editor/WMNetSyncSmokeBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 984e92fd7092428e97e0f4a23b8d17f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Network/Editor/WorldClockNetworkBridgePrefabBootstrap.cs
+++ b/Assets/_WitchMendokusai/Network/Editor/WorldClockNetworkBridgePrefabBootstrap.cs
@@ -1,0 +1,102 @@
+using FishNet.Managing.Object;
+using FishNet.Object;
+using UnityEditor;
+using UnityEngine;
+
+namespace WitchMendokusai.NetworkEditor
+{
+	/// <summary>
+	/// TASK-WM-187 — WorldClockNetworkBridge prefab idempotent 자동 부트스트랩.
+	///
+	/// FishNet `DefaultPrefabObjects.asset` 가 비어 있으면 NetworkManager 가 OnStartServer 호출 경로를 못 엮음
+	/// (spec: grep prefab 0 → OnStartServer 영영 미발화). 본 InitializeOnLoad 가:
+	///   1. prefab 자산 누락 시 NetworkObject + WorldClockNetworkBridge 부착 prefab 생성
+	///   2. DefaultPrefabObjects._prefabs 에 등록 누락이면 추가
+	/// idempotent — 반복 호출해도 안전. WorldClockBootstrapMenu 와 동일 패턴(WM-054-A 패턴).
+	///
+	/// 게임 부팅 경로(World scene + NetworkManager 실제 띄울 때) 가 본 prefab 을 spawn 해 OnStartServer 발화 = 실 WorldClock 동기 채널.
+	/// 호스트 PlayVerify(<see cref="WMNetSyncHostPlayVerify"/>) 는 prefab 의존성 없는 격리 sync smoke (smoke ⊥ 실 동기).
+	/// </summary>
+	public static class WorldClockNetworkBridgePrefabBootstrap
+	{
+		private const string PREFAB_PATH = "Assets/_WitchMendokusai/Network/Resources/WorldClockNetworkBridge.prefab";
+		private const string DEFAULT_PREFAB_OBJECTS_PATH = "Assets/DefaultPrefabObjects.asset";
+
+		[InitializeOnLoadMethod]
+		private static void AutoBootstrapIfMissing()
+		{
+			GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(PREFAB_PATH);
+			if (prefab == null)
+				prefab = CreatePrefab();
+
+			RegisterInDefaultPrefabObjects(prefab);
+		}
+
+		[MenuItem("WM/Setup/Recreate WorldClockNetworkBridge Prefab")]
+		private static void RecreateMenuItem()
+		{
+			GameObject prefab = CreatePrefab();
+			RegisterInDefaultPrefabObjects(prefab);
+		}
+
+		private static GameObject CreatePrefab()
+		{
+			EnsureParentFolders(PREFAB_PATH);
+
+			GameObject root = new GameObject(nameof(WorldClockNetworkBridge));
+			root.AddComponent<NetworkObject>();
+			root.AddComponent<WorldClockNetworkBridge>();
+
+			GameObject saved = PrefabUtility.SaveAsPrefabAsset(root, PREFAB_PATH);
+			Object.DestroyImmediate(root);
+
+			AssetDatabase.SaveAssets();
+			AssetDatabase.Refresh();
+
+			Debug.Log("[WorldClockNetworkBridgePrefabBootstrap] Created " + PREFAB_PATH);
+			return saved;
+		}
+
+		// "Assets/A/B/x.prefab" → A, B 폴더가 없으면 만든다. SaveAsPrefabAsset 가 폴더 누락 시 실패하는 회피.
+		private static void EnsureParentFolders(string assetPath)
+		{
+			string[] parts = assetPath.Split('/');
+			if (parts.Length < 3 || parts[0] != "Assets")
+				return;
+
+			string current = "Assets";
+			for (int i = 1; i < parts.Length - 1; i++)
+			{
+				string next = current + "/" + parts[i];
+				if (AssetDatabase.IsValidFolder(next) == false)
+					AssetDatabase.CreateFolder(current, parts[i]);
+				current = next;
+			}
+		}
+
+		private static void RegisterInDefaultPrefabObjects(GameObject prefab)
+		{
+			if (prefab == null)
+				return;
+
+			NetworkObject networkObject = prefab.GetComponent<NetworkObject>();
+			if (networkObject == null)
+				return;
+
+			DefaultPrefabObjects collection =
+				AssetDatabase.LoadAssetAtPath<DefaultPrefabObjects>(DEFAULT_PREFAB_OBJECTS_PATH);
+			if (collection == null)
+				return;
+
+			if (collection.Prefabs != null && collection.Prefabs.Contains(networkObject) == true)
+				return;
+
+			collection.AddObject(networkObject, true);
+			EditorUtility.SetDirty(collection);
+			AssetDatabase.SaveAssetIfDirty(collection);
+
+			Debug.Log("[WorldClockNetworkBridgePrefabBootstrap] Registered "
+				+ prefab.name + " in " + DEFAULT_PREFAB_OBJECTS_PATH);
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Network/Editor/WorldClockNetworkBridgePrefabBootstrap.cs.meta
+++ b/Assets/_WitchMendokusai/Network/Editor/WorldClockNetworkBridgePrefabBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef1f618bde354c87a4257ef3406cd523
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Network/NetworkBootstrap.cs
+++ b/Assets/_WitchMendokusai/Network/NetworkBootstrap.cs
@@ -1,0 +1,127 @@
+using System;
+using FishNet.Managing;
+using FishNet.Managing.Object;
+using FishNet.Object;
+using FishNet.Transporting.Tugboat;
+using UnityEngine;
+
+namespace WitchMendokusai
+{
+	/// <summary>
+	/// TASK-WM-187 — FishNet 라이브 sync 1채널 first-use 박힘.
+	///
+	/// 씬 수동배치 X = 회귀망 안. 프로그래매틱하게 NetworkManager + Tugboat 호스트(server+client) 자체연결.
+	/// 게임 heavy-boot 와 격리 — 빈 씬에서도 단독 기동 가능(WM-085 wedge 회피, PlayMode 자율검증 substrate).
+	///
+	/// 정본 진입점 = <see cref="EnsureHostStarted"/>(loopback localhost). 기동 후 <see cref="IsHostFullyStarted"/>
+	/// 가 true 가 되면 server+client 양측 active = SyncVar 모서리 거동 관측 가능.
+	/// </summary>
+	public static class NetworkBootstrap
+	{
+		public const string LOOPBACK_ADDRESS = "127.0.0.1";
+		public const ushort DEFAULT_PORT = 7770;
+		private const string ROOT_NAME = "[WM.NetworkBootstrap]";
+
+		private static GameObject root;
+		private static NetworkManager networkManager;
+		private static Tugboat tugboat;
+		private static SinglePrefabObjects runtimePrefabObjects;
+
+		/// <summary> 서버·클라 양측 활성 (host 모드 완전 기동). </summary>
+		public static bool IsHostFullyStarted
+		{
+			get
+			{
+				if (networkManager == null)
+					return false;
+				return networkManager.IsServerStarted && networkManager.IsClientStarted;
+			}
+		}
+
+		/// <summary> 활성 NetworkManager. 미기동 시 null. </summary>
+		public static NetworkManager Manager => networkManager;
+
+		/// <summary>
+		/// 호스트 idempotent 기동. 이미 띄워져 있으면 no-op. 다른 NetworkManager(씬 배치)가 있으면 그것을 채택해 idempotent 재사용.
+		/// 호출 후 즉시 IsHostFullyStarted=true 보장 X — 연결 ticks 가 흘러야 함 (transport handshake).
+		/// </summary>
+		public static void EnsureHostStarted(ushort port = DEFAULT_PORT)
+		{
+			if (IsHostFullyStarted == true)
+				return;
+
+			if (networkManager == null)
+				networkManager = UnityEngine.Object.FindAnyObjectByType<NetworkManager>(); // init-order-ok: 호스트 진입 시점 = lazy resolve
+
+			if (networkManager == null)
+				CreateRoot();
+
+			EnsureTugboat(port);
+
+			if (networkManager.IsServerStarted == false)
+				networkManager.ServerManager.StartConnection();
+
+			if (networkManager.IsClientStarted == false)
+				networkManager.ClientManager.StartConnection(LOOPBACK_ADDRESS);
+		}
+
+		/// <summary>
+		/// 호스트 해제. PlayMode 종료 등 정리 시점에 호출.
+		/// </summary>
+		public static void StopHost()
+		{
+			if (networkManager == null)
+				return;
+
+			if (networkManager.IsClientStarted == true)
+				networkManager.ClientManager.StopConnection();
+			if (networkManager.IsServerStarted == true)
+				networkManager.ServerManager.StopConnection(true);
+
+			if (root != null)
+			{
+				UnityEngine.Object.Destroy(root);
+				root = null;
+				networkManager = null;
+				tugboat = null;
+				runtimePrefabObjects = null;
+			}
+		}
+
+		/// <summary>
+		/// 런타임 NetworkObject 를 서버 권위로 스폰. 호스트 모드 전용 — 클라(host client) 가 같은 프로세스라 즉시 미러.
+		/// SpawnablePrefabs 등록 없이도 직접 NetworkObject 인스턴스를 받음.
+		/// </summary>
+		public static void ServerSpawn(NetworkObject networkObject)
+		{
+			if (networkManager == null)
+				throw new InvalidOperationException(ROOT_NAME + " ServerSpawn 전에 EnsureHostStarted 호출 필수");
+
+			networkManager.ServerManager.Spawn(networkObject);
+		}
+
+		private static void CreateRoot()
+		{
+			root = new GameObject(ROOT_NAME);
+			UnityEngine.Object.DontDestroyOnLoad(root);
+			networkManager = root.AddComponent<NetworkManager>();
+			// 빈 런타임 prefab collection — Tests/PlayVerify 는 ServerSpawn(직접) 경로 사용. 게임 부팅 경로는 별도 prefab 등록 정본.
+			runtimePrefabObjects = ScriptableObject.CreateInstance<SinglePrefabObjects>();
+			runtimePrefabObjects.name = "WM_RuntimeSpawnables";
+			networkManager.SpawnablePrefabs = runtimePrefabObjects;
+		}
+
+		private static void EnsureTugboat(ushort port)
+		{
+			if (tugboat == null)
+				tugboat = networkManager.GetComponent<Tugboat>();
+			if (tugboat == null)
+				tugboat = networkManager.gameObject.AddComponent<Tugboat>();
+
+			tugboat.SetPort(port);
+			tugboat.SetClientAddress(LOOPBACK_ADDRESS);
+			// transport 가 NetworkManager.TransportManager 에 채택되도록 명시.
+			networkManager.TransportManager.Transport = tugboat;
+		}
+	}
+}

--- a/Assets/_WitchMendokusai/Network/NetworkBootstrap.cs.meta
+++ b/Assets/_WitchMendokusai/Network/NetworkBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe0738023f644f56a8234bf115bc920d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_WitchMendokusai/Tests/EditMode/NetCodeContractTest.cs
+++ b/Assets/_WitchMendokusai/Tests/EditMode/NetCodeContractTest.cs
@@ -71,6 +71,30 @@ namespace WitchMendokusai.Tests
                     + fishNetBase.FullName + ") — NetCode 백엔드 회귀");
         }
 
+        // Phase C — TASK-WM-187: NetworkBootstrap(라이브 sync 1채널 호스트 진입점) 표면 존재.
+        // EnsureHostStarted / StopHost / ServerSpawn / IsHostFullyStarted 4 정본을 reflection 으로 잠금.
+        // 실 호스트 거동(SyncVar 미러)은 WMNetSyncHostPlayVerify(PlayMode 자율검증)가 별도 입증.
+        [Test]
+        public void NetworkBootstrap_HasRequiredSurface()
+        {
+            Type bootstrapType = FindLoadedType("WitchMendokusai.NetworkBootstrap");
+            Assert.That(bootstrapType, Is.Not.Null,
+                "WitchMendokusai.NetworkBootstrap 미발견 — WM-187 host 진입점 회귀");
+
+            Assert.That(bootstrapType.IsAbstract && bootstrapType.IsSealed, Is.True,
+                "NetworkBootstrap 이 static class 아님 — 정본 형태 회귀");
+
+            BindingFlags publicStatic = BindingFlags.Public | BindingFlags.Static;
+            Assert.That(bootstrapType.GetMethod("EnsureHostStarted", publicStatic), Is.Not.Null,
+                "NetworkBootstrap.EnsureHostStarted 미발견");
+            Assert.That(bootstrapType.GetMethod("StopHost", publicStatic), Is.Not.Null,
+                "NetworkBootstrap.StopHost 미발견");
+            Assert.That(bootstrapType.GetMethod("ServerSpawn", publicStatic), Is.Not.Null,
+                "NetworkBootstrap.ServerSpawn 미발견");
+            Assert.That(bootstrapType.GetProperty("IsHostFullyStarted", publicStatic), Is.Not.Null,
+                "NetworkBootstrap.IsHostFullyStarted 미발견");
+        }
+
         // 메타 — 본 테스트 어셈블리가 FishNet 에 결합되지 않음(asmdef 단방향
         // self-check). wm-asmdef-boundary.yml 게이트의 테스트측 거울.
         [Test]


### PR DESCRIPTION
## Summary

TASK-WM-187 — 멀티(동기6) "라이브 sync 1채널" 첫 실거동 박힘. FishNet 임포트/SyncVar/ServerRpc/WorldClockNetworkBridge 코드 표면은 있었으나 NetworkManager 부트 경로 0 + DefaultPrefabObjects 비어 있음 = `OnStartServer` 영영 미발화 = "컴파일 표면 빈말" 상태였음. 본 PR 이 컴파일 표면 → 관측 거동 승격.

### 신설
- **`Assets/_WitchMendokusai/Network/NetworkBootstrap.cs`** — 씬 수동배치 X, 프로그래매틱하게 `NetworkManager + Tugboat` 호스트 자체연결. `EnsureHostStarted(port)` idempotent. `IsHostFullyStarted`(server+client 양측 active 게이트), `StopHost()`, `ServerSpawn(NetworkObject)`.
- **`Assets/_WitchMendokusai/Network/Editor/`** (신규 **`WM.Network.Editor`** asmdef — FishNet/WM.Editor 격리)
  - `WMNetSyncSmokeBridge` — minimal `SyncVar<int>` + `OnChange(asServer=false)` 콜백 검출 게이트
  - `WMNetSyncHostPlayVerify` — `WMPlayVerifyBase` 파생, 빈 격리 씬 진입(heavy-boot wedge 회피) → 호스트 기동 → 런타임 NetworkObject+Bridge 스폰 → 서버 `SyncVar` set → host client `OnChange` fire 대기 → `LOOP OK/FAIL` + 스크린샷(`Temp/wm-netsync-host-play-verify.png`)
  - `WorldClockNetworkBridgePrefabBootstrap` — `DefaultPrefabObjects.asset` 빈 상태 깨는 idempotent `[InitializeOnLoadMethod]`(prefab 자동 생성 + `Prefabs` 리스트 등록)

### 변경
- `WMPlayVerifyBase.Arm()` `virtual` 화 — 호스트 verify 가 빈 씬 setup 끼울 수 있게(`override`). 기존 파생(Hunt/Builder/Greenhouse)은 base 호출 default → 거동 동일.
- `NetCodeContractTest` Phase C 추가 — `NetworkBootstrap` 4 surface(`EnsureHostStarted`/`StopHost`/`ServerSpawn`/`IsHostFullyStarted`) reflection 잠금. WM-085 Phase D 회귀 보호선 동일선상.

## 설계 메모 (비전 정렬)

- 호스트 PlayVerify 는 **minimal smoke bridge** 사용(WorldClock DI 캐스케이드 — VContainer→TimeManager→GameEventManager — 회피). spec 의 "WM heavy-boot PlayMode wedge 회피 = host 를 게임 부팅과 격리 필수" 원칙 준수.
- WorldClock 본 sync 거동(WorldClockNetworkBridge.OnStartServer 실행)은 **게임 부팅 경로**에서 박힘 — `WorldClockNetworkBridgePrefabBootstrap` 이 prefab + 등록 enabler. 게임 NetworkManager 가 본 prefab 을 spawn 하면 `OnStartServer` 발화 = 실 WorldClock 동기 채널.
- SyncVar `default ctor`(initial=0), `PROBE_TEST_VALUE=4242` set → `OnChange(asServer=false)` fire 가 sync layer **라이브 신호**(값 메모리 공유가 아닌 큐/loopback 적용 경로 입증).

## Test plan
- [x] **로컬 asmdef boundary 게이트** (jq+grep equivalent PowerShell 시뮬) PASS — DomainSDK/Mods/Core/Domain/ViewModel 어느 곳도 FishNet 직접 침범 0
- [x] **코드스타일 게이트** — `var` 사용 0 / `if (!x)` 부정 패턴 0 / Allman 스타일 / `WM/` MenuItem prefix
- [x] **`NetCodeContractTest`** reflection 계약 회귀 0 유지 (WorldClock_RequiredAuthority_IsServer / WorldClockNetworkBridge_Inherits_WMNetworkBehaviour / TestAssembly_DoesNotReference_FishNet) + `NetworkBootstrap_HasRequiredSurface` 신규 1개 추가
- [ ] **Editor 부팅 검증** — `read_console(types=["error","warning"], count=30)` 0 entries 확인 (asmdef stale csproj 가능성 — Unity Editor 켜진 후 `refresh_unity(mode="force")`)
- [ ] **`wm-boot-smoke.ps1`** — 본 PR 의 NetworkBootstrap 자체 진입점은 PlayVerify trigger 만(자동 부팅 X) → 기존 부팅 회귀 0 유지 기대
- [ ] **`WM/Verify/라이브 sync 1채널 (호스트) Play 자율검증`** — 격리 빈 씬에서 LOOP OK ✅ 로그 + `Temp/wm-netsync-host-play-verify.png` 생성 확인
- [ ] **`WM/Setup/Recreate WorldClockNetworkBridge Prefab`** — `Assets/_WitchMendokusai/Network/Resources/WorldClockNetworkBridge.prefab` + `DefaultPrefabObjects.asset._prefabs` 에 등록 확인

## 6 동기 매핑
| 동기 | 기여 |
|---|---|
| 멀티 | 라이브 sync 1채널 first-use — 컴파일표면→관측거동 (핵심) |
| 퀄리티 | sync 회귀 reflection 계약 → 실거동 격상(NetworkBootstrap 4 surface 잠금) |
| 분리 | NetCode 결합 WM.Network + 신규 WM.Network.Editor 격리 유지(asmdef 게이트 WM-184) |

## 미해결 / Follow-up (사용자/봇 영역)
- canon 재정합(`memo/wm/design/vision/architecture.md` 동기6 「추구 결정」→「라이브 sync 1채널 first-use 박힘」 + 9.5 ceiling ④) — memo 정본은 cwd 밖이라 본 worktree 에서 편집 X. 봇 별도 반영.
- FishNet 4.x SyncVar 생성자/`OnStartServer` API 분기 — 본 PR 은 default ctor + `OnStartServer/Client` override 의 가장 보수적 형태 사용. 실 Editor 컴파일에서 vary 시 immediate fix.